### PR TITLE
Removed platform flag from build script. Left the command in the comm…

### DIFF
--- a/generators/app/templates/deploy/build_and_push.sh
+++ b/generators/app/templates/deploy/build_and_push.sh
@@ -13,7 +13,8 @@ ECR_REPOSITORY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${IMAGE_NA
 echo "Building Docker image..."
 
 #docker build -t ${IMAGE_NAME}:latest .
-docker buildx build --platform linux/amd64 --output type=docker --provenance=false -t ${IMAGE_NAME}:latest .
+#docker buildx build --platform linux/amd64 --output type=docker --provenance=false -t ${IMAGE_NAME}:latest .
+docker buildx build --output type=docker --provenance=false -t ${IMAGE_NAME}:latest .
 
 echo "Image pushed to: ${ECR_REPOSITORY}:latest"
 


### PR DESCRIPTION
…ents for users augment at their discretion.

*Issue #, if available:* #4

*Description of changes:*
Removed the `--platform` flag from `build_and_push.sh` to address the exec issue in logs. Users may have to augment this to build for a specific platform

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
