### PR TITLE
NVIDIA Triton Inference Server Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,13 @@ jobs:
           echo "Testing generator help command..."
           yo @aws/ml-container-creator help
 
-      - name: Test generator with CLI options (legacy format)
+      - name: Test generator with CLI options (new format)
         run: |
           mkdir -p test-output-legacy
           cd test-output-legacy
           yo @aws/ml-container-creator test-project-legacy \
-            --framework=sklearn \
-            --model-server=flask \
+            --deployment-config=http-flask \
+            --engine=sklearn \
             --model-format=pkl \
             --skip-prompts
           
@@ -107,14 +107,15 @@ jobs:
           test -f test-project-legacy/deploy/deploy.sh
           grep -q "DEPRECATED" test-project-legacy/deploy/build_and_push.sh
           
-          echo "✅ Generator CLI test (legacy format) passed"
+          echo "✅ Generator CLI test (new format) passed"
       
       - name: Test generator with deployment config option
         run: |
           mkdir -p test-output-new
           cd test-output-new
           yo @aws/ml-container-creator test-project-new \
-            --deployment-config=sklearn-flask \
+            --deployment-config=http-flask \
+            --engine=sklearn \
             --model-format=pkl \
             --skip-prompts
           
@@ -132,8 +133,8 @@ jobs:
           test -f test-project-new/do/README.md
           
           # Verify do/config contains correct deployment config
-          grep -q "DEPLOYMENT_CONFIG=\"sklearn-flask\"" test-project-new/do/config
-          grep -q "FRAMEWORK=\"sklearn\"" test-project-new/do/config
+          grep -q "DEPLOYMENT_CONFIG=\"http-flask\"" test-project-new/do/config
+          grep -q "FRAMEWORK=\"http\"" test-project-new/do/config
           grep -q "MODEL_SERVER=\"flask\"" test-project-new/do/config
           
           echo "✅ Generator CLI test (deployment config) passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,13 +77,13 @@ jobs:
           npm install -g yo@latest
           npm link
           echo "Testing generator help command..."
-          yo ml-container-creator help
+          yo @aws/ml-container-creator help
 
       - name: Test generator with CLI options (legacy format)
         run: |
           mkdir -p test-output-legacy
           cd test-output-legacy
-          yo ml-container-creator test-project-legacy \
+          yo @aws/ml-container-creator test-project-legacy \
             --framework=sklearn \
             --model-server=flask \
             --model-format=pkl \
@@ -113,7 +113,7 @@ jobs:
         run: |
           mkdir -p test-output-new
           cd test-output-new
-          yo ml-container-creator test-project-new \
+          yo @aws/ml-container-creator test-project-new \
             --deployment-config=sklearn-flask \
             --model-format=pkl \
             --skip-prompts
@@ -137,6 +137,9 @@ jobs:
           grep -q "MODEL_SERVER=\"flask\"" test-project-new/do/config
           
           echo "✅ Generator CLI test (deployment config) passed"
+
+      - name: Validate package namespaces
+        run: node scripts/validate-namespaces.js
 
   security:
     name: Security Scan

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,7 @@ test_your_new_feature() {
     mkdir -p "your-feature-test"
     cd "your-feature-test"
     
-    if yo ml-container-creator --your-new-option --skip-prompts > ../test.log 2>&1; then
+    if yo @aws/ml-container-creator --your-new-option --skip-prompts > ../test.log 2>&1; then
         validate_files ["expected-file.txt"] "your feature test"
         cd ..
         record_test_result "Your Feature" "PASS"

--- a/README.md
+++ b/README.md
@@ -1,1004 +1,311 @@
-#
-<div align="center">
-  <img src="logo.png" alt="ML Container Creator" width="200"/>
-  <h1>ML Container Creator</h1>
-  <p><em>Simplify your machine learning deployments on AWS SageMaker</em></p>
-</div>
-[![CI](https://github.com/awslabs/ml-container-creator/actions/workflows/ci.yml/badge.svg)](https://github.com/awslabs/ml-container-creator/actions/workflows/ci.yml)
-[![Deploy MkDocs to GitHub Pages](https://github.com/awslabs/ml-container-creator/actions/workflows/docs.yml/badge.svg)](https://github.com/awslabs/ml-container-creator/actions/workflows/docs.yml)
+# quick-inference-container
 
-## Why ML Container Creator?
+SageMaker-compatible ML container for deploying triton models using fil.
 
-GitHub Pages site -- [ML Container Creator](https://awslabs.github.io/ml-container-creator/)
+Generated on 2026-03-20T01-32-30 using [ML Container Creator](https://github.com/yourusername/ml-container-creator).
 
-Deploying machine learning models to production shouldn't be complicated. ML Container Creator eliminates the complexity of creating SageMaker Bring Your Own Container (BYOC) deployments, letting you focus on what matters most - your models.
+## Quick Start
 
-**Perfect for:**
-- Data scientists who want to deploy models without DevOps overhead
-- ML engineers building production model serving pipelines
-- Teams standardizing their ML deployment process
-- Organizations moving from prototype to production
-
-## What is SageMaker BYOC?
-
-Amazon SageMaker Bring Your Own Container (BYOC) lets you deploy custom machine learning models using your own Docker containers. This gives you full control over your model's runtime environment while leveraging SageMaker's managed infrastructure for hosting and scaling.
-
-## 📋 What You Get with ml-container-creator
-
-Every generated project includes:
-- **SageMaker-compatible container** with health checks and invocation endpoints
-- **do-framework scripts** for standardized container lifecycle management (`build`, `push`, `deploy`, `run`, `test`, `clean`)
-- **Multiple deployment options** - Direct SageMaker deployment or AWS CodeBuild for CI/CD
-- **Local testing suite** to validate before deployment
-- **Sample model and training code** to illustrate the deployment
-- **Centralized configuration** in `do/config` for easy customization
-- **Multi-framework support** (sklearn, XGBoost, TensorFlow, vLLM, SGLang, TensorRT-LLM)
-- **🆕 Intelligent configuration system** with community-validated settings
-  - Framework Registry: Pre-configured settings for framework versions (vLLM, SGLang, TensorRT-LLM, LMI, DJL)
-  - Model Registry: Model-specific optimizations and overrides
-  - HuggingFace Hub integration: Automatic model metadata fetching
-- **🆕 Accelerator compatibility validation** (CUDA, Neuron SDK, CPU, ROCm)
-  - Automatic instance type validation against framework requirements
-  - Version compatibility checking for accelerator drivers
-  - Clear error messages with recommended alternatives
-- **🆕 Configuration profiles** for different optimization strategies
-  - Low-latency vs high-throughput profiles
-  - Single-GPU vs multi-GPU configurations
-  - Framework and model-specific optimizations
-- **🆕 Environment variable validation** to catch configuration errors early
-  - Known flags validation against framework specifications
-  - Type and range constraint checking
-  - Deprecated flag warnings with suggested replacements
-
-> **Note**: This tool generates starter code. Review and customize for your production requirements.
-
-## Prerequisites
-
-Before you begin, ensure you have:
-- **Node.js v24+** (required for development and testing)
-  - Check version: `node --version`
-  - Use nvm: `nvm use node` to switch to latest version
-- An AWS account with SageMaker access
-- Basic familiarity with Docker and command line
-- A trained machine learning model ready for deployment
-
-## 🚀 Deployment Options
-
-ML Container Creator supports two deployment approaches to fit different workflows:
-
-### 🏗️ **CodeBuild CI/CD Pipeline (Recommended)**
-Enterprise-ready CI/CD with AWS CodeBuild:
-- Automated Docker image building in AWS with correct architecture
-- Shared ECR repository with project-specific tagging
-- No local architecture compatibility issues
-- Integrated with AWS infrastructure
-- Perfect for production and team environments
+### 1. Build the Container
 
 ```bash
-# Generate project with CodeBuild deployment
-yo ml-container-creator my-model --deploy-target=codebuild --skip-prompts
-
-# Submit build job and deploy using do-framework
-cd my-model
-./do/submit  # Builds and pushes image via CodeBuild
-./do/deploy your-sagemaker-role-arn  # Deploys to SageMaker
-./do/test my-model-endpoint  # Test the endpoint
+./do/build
 ```
 
-### 🎯 **Direct SageMaker Deployment**
-Quick local builds for development:
-- Build and push Docker image locally
-- Deploy directly to SageMaker endpoint
-- Ideal for prototyping and development environments
-- ⚠️ **Note**: May encounter architecture compatibility issues (e.g., ARM64 Mac → x86_64 SageMaker)
+Builds a Docker image tagged as `quick-inference-container:latest`.
+
+### 2. Test Locally
 
 ```bash
-# Generate project with SageMaker deployment
-yo ml-container-creator my-model --deploy-target=sagemaker --skip-prompts
+# Start the container
+./do/run
 
-# Build, deploy, and test using do-framework
-cd my-model
-./do/build  # Build Docker image
-./do/push   # Push to ECR
-./do/deploy your-sagemaker-role-arn  # Deploy to SageMaker
-./do/test my-model-endpoint  # Test the endpoint
+# In another terminal, test the endpoints
+./do/test
 ```
 
-### 🔄 **CodeBuild Features**
-- **Shared ECR Repository**: All projects use `ml-container-creator` repository with project-specific tags
-- **Automatic Infrastructure**: Creates CodeBuild projects, IAM roles, and S3 buckets automatically
-- **Build Monitoring**: Real-time build status and progress tracking
-- **Compute Options**: Small, Medium, or Large compute types for different project sizes
-- **Comprehensive Logging**: CloudWatch integration for build logs and debugging
+### 3. Push to ECR
 
-## 🛠️ do-framework Integration
+```bash
+./do/push
+```
 
-All generated projects use the [do-framework](https://github.com/iankoulski/do-framework) for standardized container lifecycle management. This provides a consistent interface across all ML Container Creator projects.
+Pushes the image to Amazon ECR in the `us-east-1` region.
+
+### 4. Deploy to SageMaker
+
+```bash
+./do/deploy <your-sagemaker-execution-role-arn>
+```
+
+Creates a SageMaker endpoint named `quick-inference-container-endpoint`.
+
+### 5. Test the Endpoint
+
+```bash
+./do/test quick-inference-container-endpoint
+```
+
+## Project Structure
+
+```
+quick-inference-container/
+├── do/                      # do-framework lifecycle scripts
+│   ├── build                # Build Docker image
+│   ├── push                 # Push to Amazon ECR
+│   ├── deploy               # Deploy to SageMaker
+│   ├── run                  # Run container locally
+│   ├── test                 # Test container or endpoint
+│   ├── clean                # Clean up resources
+│   ├── submit               # Submit build to CodeBuild
+│   ├── config               # Configuration variables
+│   └── README.md            # Detailed do-framework documentation
+├── code/                    # Model serving code
+│   ├── model_handler.py   # Model loading and inference
+│   └── serve.py            # fil server
+├── deploy/                 # Legacy scripts (deprecated)
+│   ├── build_and_push.sh   # Use ./do/build && ./do/push instead
+│   └── deploy.sh           # Use ./do/deploy instead
+├── sample_model/          # Sample training code
+│   ├── train_abalone.py    # Train sample model
+│   └── test_inference.py   # Test inference
+
+├── test/                  # Test suite
+│   ├── test_endpoint.sh    # Test SageMaker endpoint
+│   └── test_local_image.sh # Test local container
+
+├── Dockerfile              # Container definition
+├── requirements.txt        # Python dependencies
+└── README.md               # This file
+```
+
+## Configuration
+
+All deployment configuration is centralized in `do/config`:
+
+```bash
+# Project identification
+PROJECT_NAME="quick-inference-container"
+DEPLOYMENT_CONFIG="triton-fil"
+
+# AWS configuration
+AWS_REGION="us-east-1"
+INSTANCE_TYPE="ml.g5.12xlarge"
+
+# Framework configuration
+FRAMEWORK="triton"
+MODEL_SERVER="fil"
+
+```
+
+You can override these values by setting environment variables before running do scripts.
+
+## Deployment Workflows
+
+### Local Development Workflow
+
+```bash
+# Build and test locally
+./do/build
+./do/run &
+./do/test
+
+# When satisfied, push to ECR
+./do/push
+```
+
+### CodeBuild Workflow
+
+```bash
+# Submit build to CodeBuild (builds and pushes to ECR)
+./do/submit
+
+# Deploy to SageMaker
+./do/deploy <role-arn>
+
+# Test the endpoint
+./do/test quick-inference-container-endpoint
+```
+
+### Cleanup
+
+```bash
+# Remove local images
+./do/clean local
+
+# Remove ECR images
+./do/clean ecr
+
+# Delete SageMaker endpoint
+./do/clean endpoint
+
+# Clean everything
+./do/clean all
+```
+
+## do-framework Commands
+
+This project uses the [do-framework](https://github.com/iankoulski/do-framework) for standardized container lifecycle management.
 
 ### Available Commands
-
-Every generated project includes these standardized scripts in the `do/` directory:
 
 | Command | Description |
 |---------|-------------|
 | `./do/build` | Build Docker image locally |
 | `./do/push` | Push image to Amazon ECR |
-| `./do/deploy` | Deploy to SageMaker endpoint |
-| `./do/run` | Run container locally for testing |
-| `./do/test` | Test local container or SageMaker endpoint |
-| `./do/clean` | Clean up resources (local, ECR, endpoint) |
-| `./do/submit` | Submit build to CodeBuild (CodeBuild deployment only) |
+| `./do/deploy <role-arn>` | Deploy to SageMaker endpoint |
+| `./do/run` | Run container locally on port 8080 |
+| `./do/test [endpoint]` | Test local container or SageMaker endpoint |
+| `./do/clean <target>` | Clean up resources (local/ecr/endpoint/all) |
+| `./do/submit` | Submit build to AWS CodeBuild |
 
-### Quick Workflow Examples
+For detailed documentation on each command, see `do/README.md`.
 
-**Local Development:**
-```bash
-./do/build          # Build image
-./do/run &          # Run locally
-./do/test           # Test local container
-./do/push           # Push to ECR
-./do/deploy $ROLE   # Deploy to SageMaker
-```
+## Framework-Specific Information
 
-**CodeBuild CI/CD:**
-```bash
-./do/submit         # Build and push via CodeBuild
-./do/deploy $ROLE   # Deploy to SageMaker
-./do/test my-endpoint  # Test the endpoint
-```
 
-### Configuration
 
-All scripts use centralized configuration in `do/config`:
+## SageMaker Endpoints
+
+### Health Check
+
+SageMaker calls the `/ping` endpoint to verify container health:
 
 ```bash
-# Edit do/config to customize
-export PROJECT_NAME="my-model"
-export AWS_REGION="us-east-1"
-export INSTANCE_TYPE="ml.m5.xlarge"
-export DEPLOYMENT_CONFIG="sklearn-flask"
+curl http://localhost:8080/ping
 ```
 
-Override any setting with environment variables:
-```bash
-AWS_REGION=us-west-2 ./do/deploy
-```
+Expected response: `200 OK`
 
-### Migration from Legacy Scripts
+### Inference
 
-Legacy `deploy/` scripts are still available for backward compatibility but are deprecated:
-
-| Legacy | do-framework | Status |
-|--------|--------------|--------|
-| `./deploy/build_and_push.sh` | `./do/build && ./do/push` | Deprecated |
-| `./deploy/deploy.sh` | `./do/deploy` | Deprecated |
-| `./deploy/submit_build.sh` | `./do/submit` | Deprecated |
-
-See the generated `MIGRATION.md` file in your project for detailed migration instructions.
-
-## 🎯 Intelligent Configuration System
-
-ML Container Creator includes a powerful multi-registry configuration system that provides:
-
-### Framework Registry
-Pre-configured, tested settings for transformer serving frameworks:
-- **Base images** and environment variables for each framework version
-- **Accelerator requirements** (CUDA versions, Neuron SDK versions)
-- **SageMaker AMI versions** matched to accelerator requirements
-- **Recommended instance types** for optimal performance
-- **Validation levels** indicating how well-tested each configuration is
-
-### Model Registry
-Model-specific optimizations and overrides:
-- **Chat templates** for conversational models
-- **Framework compatibility** information
-- **Known issues** and workarounds
-- **Pattern matching** for model families (e.g., `mistral*` matches all Mistral variants)
-
-### HuggingFace Hub Integration
-Automatic fetching of model metadata:
-- **Tokenizer configurations** including chat templates
-- **Model architectures** and requirements
-- **Graceful fallback** when API is unavailable
-- **Offline mode** for air-gapped environments
-
-### Configuration Profiles
-Choose optimization strategies for your use case:
-- **Low-latency profiles**: Optimized for single-request response time
-- **High-throughput profiles**: Optimized for batch processing
-- **Single-GPU vs multi-GPU**: Different tensor parallelism settings
-- **Framework-specific profiles**: vLLM, TensorRT-LLM, SGLang optimizations
-
-### Accelerator Compatibility Validation
-Automatic validation of hardware compatibility:
-- **Type matching**: Ensures framework accelerator type (CUDA/Neuron/CPU/ROCm) matches instance
-- **Version checking**: Validates accelerator driver versions
-- **AMI compatibility**: Verifies SageMaker AMI provides required drivers
-- **Clear recommendations**: Suggests compatible instance types when mismatches detected
-
-### Environment Variable Validation
-Catch configuration errors before deployment:
-- **Known flags validation**: Checks against framework specifications
-- **Type constraints**: Validates integer, float, string, boolean values
-- **Range constraints**: Enforces min/max values
-- **Deprecation warnings**: Alerts about deprecated flags with suggested replacements
-- **Opt-in validation**: Enable with `--validate-env-vars` flag (enabled by default)
-
-### Community Contributions
-Share your tested configurations:
-- **Export working configurations**: After successful deployment
-- **Validation levels**: Experimental → Community-validated → Tested
-- **Test reports**: Document successful deployments on specific instance types
-- **Registry contributions**: Submit configurations via pull requests
-
-### How It Works
-
-```
-User Input → Framework Registry Lookup → Profile Selection (optional)
-                    ↓
-         Model Registry Lookup (optional)
-                    ↓
-         HuggingFace API Fetch (optional)
-                    ↓
-         Configuration Merge (priority order)
-                    ↓
-         Accelerator Validation
-                    ↓
-         Environment Variable Validation
-                    ↓
-         Template Generation
-```
-
-**Configuration Priority Order:**
-1. Base framework configuration (Framework Registry)
-2. Framework profile (if selected)
-3. HuggingFace API data (if available)
-4. Model registry overrides (if available)
-5. Model profile (if selected)
-
-**Graceful Degradation:**
-When registry data is unavailable, the generator falls back to current default behavior - ensuring backward compatibility and reliability.
-
-## 🚀 Get Started in Minutes
+Send prediction requests to the `/invocations` endpoint:
 
 ```bash
-# Install Yeoman and the generator
-cd ml-container-creator
-npm install -g yo
-npm link
-
-# Generate your project
-yo ml-container-creator
+curl -X POST http://localhost:8080/invocations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "instances": [[1.0, 2.0, 3.0, 4.0]]
+  }'
 ```
 
-Answer a few questions about your model, and get a complete container with:
-- **do-framework scripts** for standardized container lifecycle management
-- **Optimized model serving** (Flask, FastAPI, vLLM, SGLang, TensorRT-LLM)
-- **Built-in testing and deployment scripts** with consistent interface
-- **Support for SageMaker AI** managed endpoint hosting
-- **Local testing capabilities** before cloud deployment
 
-## ⚙️ Configuration Options
+## AWS Requirements
 
-ML Container Creator supports multiple ways to configure your project, from interactive prompts to fully automated CLI usage. Choose the method that best fits your workflow.
+### IAM Permissions
 
-### Configuration Methods (by precedence)
+The SageMaker execution role needs these permissions:
 
-1. **CLI Options** (highest precedence)
-2. **CLI Arguments** 
-3. **Environment Variables**
-4. **CLI Config File** (`--config=file.json`)
-5. **Custom Config File** (`config/mcp.json`)
-6. **Package.json Section** (`"ml-container-creator": {...}`)
-7. **Generator Defaults**
-8. **Interactive Prompts** (lowest precedence)
+- `ecr:GetAuthorizationToken`
+- `ecr:BatchCheckLayerAvailability`
+- `ecr:GetDownloadUrlForLayer`
+- `ecr:BatchGetImage`
+- `s3:GetObject` (if using S3 for model artifacts)
+- `logs:CreateLogGroup`
+- `logs:CreateLogStream`
+- `logs:PutLogEvents`
 
-### Quick Start Examples
+See `IAM_PERMISSIONS.md` for detailed permission requirements.
 
-#### Interactive Mode (Default)
-```bash
-yo ml-container-creator
-# Follow the prompts to configure your project
-```
+### AWS CLI Configuration
 
-#### CLI Mode (Skip Prompts)
-```bash
-# Basic sklearn project with SageMaker deployment
-yo ml-container-creator my-sklearn-project \
-  --deployment-config=sklearn-flask \
-  --model-format=pkl \
-  --deploy-target=sagemaker \
-  --skip-prompts
-
-# Transformers project with vLLM and CodeBuild CI/CD
-yo ml-container-creator my-llm-project \
-  --deployment-config=transformers-vllm \
-  --instance-type=gpu-enabled \
-  --deploy-target=codebuild \
-  --codebuild-compute-type=BUILD_GENERAL1_MEDIUM \
-  --skip-prompts
-
-# XGBoost with FastAPI and testing
-yo ml-container-creator my-xgb-project \
-  --deployment-config=xgboost-fastapi \
-  --model-format=json \
-  --include-testing \
-  --deploy-target=sagemaker \
-  --skip-prompts
-```
-
-#### Environment Variables
-```bash
-# Set configuration via environment (only supported parameters)
-export ML_INSTANCE_TYPE="cpu-optimized"
-export AWS_REGION="us-east-1"
-export AWS_ROLE="arn:aws:iam::123456789012:role/SageMakerRole"
-
-# Generate with environment config + CLI options for core parameters
-yo ml-container-creator --deployment-config=sklearn-flask --model-format=pkl --skip-prompts
-```
-
-#### Configuration File
-```bash
-# Create configuration file
-yo ml-container-creator configure
-
-# Or generate empty config
-yo ml-container-creator generate-empty-config
-
-# Use configuration file
-yo ml-container-creator --config=production.json --skip-prompts
-```
-
-### CLI Options Reference
-
-| Option | Description | Values |
-|--------|-------------|---------|
-| `--skip-prompts` | Skip interactive prompts | `true/false` |
-| `--config=<file>` | Load configuration from file | File path |
-| `--project-name=<name>` | Project name | String |
-| `--deployment-config=<config>` | Deployment configuration (framework-server) | `sklearn-flask`, `sklearn-fastapi`, `xgboost-flask`, `xgboost-fastapi`, `tensorflow-flask`, `tensorflow-fastapi`, `transformers-vllm`, `transformers-sglang`, `transformers-tensorrt-llm`, `transformers-lmi`, `transformers-djl` |
-| `--framework=<framework>` | ML framework (deprecated, use --deployment-config) | `sklearn`, `xgboost`, `tensorflow`, `transformers` |
-| `--model-server=<server>` | Model server (deprecated, use --deployment-config) | `flask`, `fastapi`, `vllm`, `sglang`, `tensorrt-llm` |
-| `--model-format=<format>` | Model format | Depends on framework |
-| `--include-sample` | Include sample model code | `true/false` |
-| `--include-testing` | Include test suite | `true/false` |
-| `--test-types=<types>` | Test types (comma-separated) | `local-model-cli`, `local-model-server`, `hosted-model-endpoint` |
-| `--deploy-target=<target>` | Deployment target | `sagemaker`, `codebuild` |
-| `--codebuild-compute-type=<type>` | CodeBuild compute type | `BUILD_GENERAL1_SMALL`, `BUILD_GENERAL1_MEDIUM`, `BUILD_GENERAL1_LARGE` |
-| `--instance-type=<type>` | Instance type | `cpu-optimized`, `gpu-enabled` |
-| `--region=<region>` | AWS region | `us-east-1`, etc. |
-| `--role-arn=<arn>` | AWS IAM role ARN | `arn:aws:iam::123456789012:role/SageMakerRole` |
-| `--project-dir=<dir>` | Output directory path | `./my-project` |
-| `--hf-token=<token>` | HuggingFace authentication token | `hf_abc123...` or `$HF_TOKEN` |
-| `--validate-env-vars` | Enable environment variable validation | `true/false` (default: `true`) |
-| `--validate-with-docker` | Enable Docker introspection validation | `true/false` (default: `false`) |
-| `--offline` | Skip HuggingFace API lookups | `true/false` (default: `false`) |
-
-### Environment Variables Reference
-
-**Note:** According to the parameter matrix specification, only the following environment variables are supported. Core parameters (framework, model-server, etc.) must be configured via CLI options or configuration files.
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `ML_INSTANCE_TYPE` | Instance type | `cpu-optimized` |
-| `AWS_REGION` | AWS region | `us-east-1` |
-| `AWS_ROLE` | AWS IAM role ARN | `arn:aws:iam::123456789012:role/SageMakerRole` |
-| `ML_CONTAINER_CREATOR_CONFIG` | Config file path | `./my-config.json` |
-
-### Configuration File Examples
-
-#### Custom Config File (`config/mcp.json`)
-```json
-{
-  "projectName": "my-ml-project",
-  "deploymentConfig": "sklearn-flask",
-  "modelFormat": "pkl",
-  "includeSampleModel": false,
-  "includeTesting": true,
-  "testTypes": ["local-model-cli", "hosted-model-endpoint"],
-  "deployTarget": "sagemaker",
-  "instanceType": "cpu-optimized",
-  "awsRegion": "us-east-1"
-}
-```
-
-#### Package.json Section
-```json
-{
-  "name": "my-project",
-  "ml-container-creator": {
-    "projectName": "my-ml-project",
-    "deploymentConfig": "transformers-vllm",
-    "instanceType": "gpu-enabled",
-    "includeTesting": true
-  }
-}
-```
-
-### CLI Commands
-
-| Command | Description |
-|---------|-------------|
-| `yo ml-container-creator` | Interactive generation |
-| `yo ml-container-creator configure` | Interactive configuration setup |
-| `yo ml-container-creator generate-empty-config` | Generate empty config file |
-| `yo ml-container-creator help` | Show help information |
-
-### Framework-Specific Options
-
-#### Traditional ML (sklearn, xgboost, tensorflow)
-- **Deployment Configurations**: `sklearn-flask`, `sklearn-fastapi`, `xgboost-flask`, `xgboost-fastapi`, `tensorflow-flask`, `tensorflow-fastapi`
-- **Model Formats**: Varies by framework
-- **Sample Model**: Available (Abalone classifier)
-- **Instance Types**: `cpu-optimized`, `gpu-enabled`
-
-#### Transformers (LLMs)
-- **Deployment Configurations**: `transformers-vllm`, `transformers-sglang`, `transformers-tensorrt-llm`, `transformers-lmi`, `transformers-djl`
-- **Model Formats**: Not applicable (loaded from Hugging Face Hub)
-- **Sample Model**: Not available
-- **Instance Types**: `gpu-enabled` (defaults to `ml.g6.12xlarge`)
-- **Note**: TensorRT-LLM requires [NVIDIA NGC authentication](#tensorrt-llm-authentication) to pull the base image
-
-### Example: Deploy a scikit-learn Model
-
-1. **Prepare your model**: Save as `model.pkl`
-2. **Generate container**: Run `yo ml-container-creator` and select `sklearn-flask` deployment configuration
-3. **Build and test locally**:
-   ```bash
-   cd my-sklearn-project
-   ./do/build
-   ./do/run &
-   ./do/test
-   ```
-4. **Deploy to SageMaker**:
-   ```bash
-   ./do/push
-   ./do/deploy your-sagemaker-role-arn
-   ./do/test my-sklearn-project-endpoint
-   ```
-
-Or use CodeBuild for CI/CD:
-```bash
-./do/submit  # Build and push via CodeBuild
-./do/deploy your-sagemaker-role-arn
-```
-
-## 🔐 HuggingFace Authentication
-
-### When is Authentication Needed?
-
-HuggingFace authentication is required for:
-- **Private models**: Models in private repositories
-- **Gated models**: Models requiring user agreement (e.g., Llama 2, Llama 3)
-- **Rate-limited access**: Avoiding rate limits on public models
-
-Public models like `openai/gpt-oss-20b` do not require authentication.
-
-### Providing Your HF_TOKEN
-
-When you manually enter a transformer model ID (not selecting from examples), you'll be prompted for authentication:
-
-#### Option 1: Interactive Prompt (Recommended for Local Development)
-
-```
-🔐 HuggingFace Authentication
-⚠️  Security Note: The token will be baked into the Docker image.
-   For CI/CD, consider using "$HF_TOKEN" to reference an environment variable.
-
-? HuggingFace token (enter token, "$HF_TOKEN" for env var, or leave empty):
-```
-
-You can:
-- **Enter your token directly**: `hf_abc123...`
-- **Reference an environment variable**: `$HF_TOKEN`
-- **Leave empty for public models**: (press Enter)
-
-#### Option 2: CLI Option
+Ensure AWS CLI is configured with appropriate credentials:
 
 ```bash
-# Direct token
-yo ml-container-creator my-llm-project \
-  --deployment-config=transformers-vllm \
-  --model-name=meta-llama/Llama-2-7b-hf \
-  --hf-token=hf_abc123... \
-  --skip-prompts
-
-# Environment variable reference
-yo ml-container-creator my-llm-project \
-  --deployment-config=transformers-vllm \
-  --model-name=meta-llama/Llama-2-7b-hf \
-  --hf-token='$HF_TOKEN' \
-  --skip-prompts
+aws configure
 ```
 
-#### Option 3: Configuration File
-
-```json
-{
-  "deploymentConfig": "transformers-vllm",
-  "modelName": "meta-llama/Llama-2-7b-hf",
-  "hfToken": "$HF_TOKEN"
-}
-```
-
-### Security Best Practices
-
-⚠️ **Important Security Considerations:**
-
-1. **Tokens are baked into the image**: Anyone with access to your Docker image can extract the token using `docker inspect`.
-
-2. **Use environment variable references for CI/CD**:
-   ```bash
-   export HF_TOKEN=hf_your_token_here
-   yo ml-container-creator --framework=transformers --hf-token='$HF_TOKEN' --skip-prompts
-   ```
-
-3. **Never commit tokens to version control**: Use `$HF_TOKEN` in config files, not actual tokens.
-
-4. **Rotate tokens regularly**: Generate new tokens periodically from your HuggingFace account.
-
-### TensorRT-LLM Authentication
-
-TensorRT-LLM uses NVIDIA's NGC (NVIDIA GPU Cloud) registry, which requires authentication:
-
-**Before building a TensorRT-LLM container:**
-
-1. **Create an NGC account**: Visit [https://ngc.nvidia.com/signup](https://ngc.nvidia.com/signup)
-
-2. **Generate an API key**:
-   - Go to [https://ngc.nvidia.com/setup/api-key](https://ngc.nvidia.com/setup/api-key)
-   - Click "Generate API Key"
-   - Save your API key securely
-
-3. **Set NGC_API_KEY environment variable**:
-   ```bash
-   export NGC_API_KEY='your-api-key-here'
-   ```
-
-4. **Build and deploy**:
-
-   **For SageMaker deployment (local build):**
-   ```bash
-   cd my-tensorrt-project
-   ./do/build  # Automatically authenticates with NGC using NGC_API_KEY
-   ./do/push
-   ./do/deploy your-sagemaker-role-arn
-   ```
-
-   **For CodeBuild deployment (CI/CD):**
-   ```bash
-   cd my-tensorrt-project
-   ./do/submit  # Passes NGC_API_KEY to CodeBuild
-   ./do/deploy your-sagemaker-role-arn
-   ```
-
-**How it works:**
-- The do-framework scripts automatically authenticate with NGC using your `NGC_API_KEY` environment variable
-- For local builds (`./do/build`), Docker login happens on your machine
-- For CodeBuild (`./do/submit`), the NGC_API_KEY is passed as a CodeBuild environment variable
-- No manual `docker login` required!
-
-**Security Note for CodeBuild:**
-- NGC_API_KEY is passed as a plaintext environment variable to CodeBuild
-- For production, consider using AWS Secrets Manager:
-  ```bash
-  # Store in Secrets Manager
-  aws secretsmanager create-secret --name ngc-api-key --secret-string "$NGC_API_KEY"
-  
-  # Update buildspec to retrieve from Secrets Manager
-  # See AWS CodeBuild documentation for details
-  ```
-
-**Note**: NGC authentication is only required for TensorRT-LLM. vLLM and SGLang use publicly available images.
-
-### Getting Your HF_TOKEN
-
-1. Go to https://huggingface.co/settings/tokens
-2. Click "New token"
-3. Give it a descriptive name (e.g., "sagemaker-deployment")
-4. Select "Read" access
-5. Copy the token (starts with `hf_`)
-
-### Troubleshooting Authentication
-
-**Error: "Repository not found" or "Access denied"**
-- Verify your token is valid and not expired
-- Ensure you've accepted the model's license agreement on HuggingFace
-- Check that your token has access to the model's organization
-
-**Error: "HF_TOKEN environment variable not set"**
-- You specified `$HF_TOKEN` but the environment variable is not set
-- Set it: `export HF_TOKEN=hf_your_token_here`
-- Or provide the token directly instead of using `$HF_TOKEN`
-
-**Container builds but fails at runtime**
-- The model requires authentication but no token was provided
-- Rebuild with `--hf-token` option
-
-For more authentication troubleshooting, see the [Troubleshooting Guide](./TROUBLESHOOTING.md#huggingface-authentication-issues).
-
-## 🛠️ Requirements
-
-### For Users
-- Node.js 24+
-- Python 3.8+
-- Docker 20+
-- AWS CLI 2+
-
-### For Contributors
-- Node.js 24+ and npm
-- All other tools managed via npm scripts
-
-## 🌟 Open Source & Community Driven
-
-ML Container Creator is **open source** under the Apache 2.0 license.
-
-### 🗺️ Live Roadmap
-
-Our development is driven by user needs. Check out our [live roadmap](https://github.com/ml-container-creator/projects) to:
-- See what's coming next
-- Vote on features you need
-- Contribute ideas and feedback
-- Track progress on requested features
-
-**Current priorities:**
-- Enhanced transformer model support
-- Multi-model endpoints
-- Auto-scaling configurations
-- Cost optimization features
-
-## 🧪 Testing
-
-ML Container Creator has a comprehensive test suite ensuring reliability and correctness across all supported configurations.
-
-### Test Architecture
-
-Our testing approach combines multiple testing strategies for comprehensive coverage:
-
-#### 📋 **Unit Tests** (87 tests)
-Focused tests for specific functionality organized by capability:
-
-- **CLI Options** - Command-line option parsing and validation
-- **Environment Variables** - Environment variable handling and precedence
-- **Configuration Files** - JSON config files and package.json sections
-- **Configuration Precedence** - Multi-source configuration merging
-- **File Generation** - Template processing and conditional file creation
-- **Error Handling** - Validation errors and edge cases
-
-#### 🔬 **Property-Based Tests** (10 universal properties)
-Automated testing of universal correctness properties using [fast-check](https://github.com/dubzzz/fast-check):
-
-- **Parameter Source Enforcement** - Unsupported sources are ignored
-- **Environment Variable Mapping** - Correct variable-to-parameter mapping
-- **CLI Option Consistency** - CLI options accepted and mapped correctly
-- **Package.json Filtering** - Only supported parameters loaded from package.json
-- **Default Value Application** - Correct defaults applied when values missing
-- **Configuration Isolation** - .yo-rc.json files completely ignored
-- **Non-Promptable Handling** - Non-interactive parameters handled correctly
-- **Required Parameter Validation** - Missing required parameters produce errors
-- **Config File Resolution** - Environment variable config paths work correctly
-- **Parameter Precedence** - Highest precedence source values used
-
-#### 🔒 **Security Testing**
-- **Dependency Scanning** - npm audit for known vulnerabilities
-- **Code Quality** - ESLint for security best practices
-- **Input Validation** - Malformed configuration handling
-
-### Running Tests
+Or use environment variables:
 
 ```bash
-# Complete validation (recommended before PR)
-npm run validate                # ESLint + Security + All Tests
-
-# Individual test categories
-npm test                        # Unit tests only
-npm run test:property          # Property-based tests only
-npm run test:all               # Unit + Property tests
-npm run test:coverage          # Tests with coverage report
-
-# Development workflows
-npm run test:watch             # Unit tests in watch mode
-npm run test:property:watch    # Property tests in watch mode
-
-# Specific test targeting
-npm test -- --grep "CLI Options"     # CLI-related tests
-npm test -- --grep "sklearn"         # Framework-specific tests
-npm test -- --grep "precedence"      # Configuration precedence tests
+export AWS_ACCESS_KEY_ID=your-access-key
+export AWS_SECRET_ACCESS_KEY=your-secret-key
+export AWS_DEFAULT_REGION=us-east-1
 ```
 
-### Test Features
+## Troubleshooting
 
-#### 🎯 **Comprehensive Coverage**
-- **1000+ test iterations** across all parameter combinations
-- **All configuration sources** tested (CLI, env vars, config files, package.json)
-- **All frameworks** tested (sklearn, xgboost, tensorflow, transformers)
-- **All precedence scenarios** validated
+### Build Issues
 
-#### 📊 **Detailed Reporting**
-```
-🧪 Test #1: should parse sklearn CLI options correctly
-📍 Test Suite: CLI Options Parsing
-🔍 Checking 6 expected files for sklearn CLI parsing...
-✅ Found: Dockerfile
-✅ Found: requirements.txt
-📊 Summary: All 6 expected files found
-```
+**Docker Not Found**
 
-#### 🔍 **Debug Information**
-When tests fail, detailed context is provided:
-```
-🔍 DEBUG: Current state for test #5 failure:
-📁 Working directory: /tmp/test-dir
-📄 Files in current directory (3 total): [Dockerfile, requirements.txt, ...]
-```
+Install Docker: https://docs.docker.com/get-docker/
 
-#### ⚡ **Performance Optimized**
-- **Smart test generation** - Only valid parameter combinations tested
-- **Configurable timeouts** - Prevent hanging tests
-- **Efficient validation** - Early returns for known invalid states
-- **Minimal logging** during property execution
+**Permission Denied**
 
-### Test Results
-
-Current test status:
-- ✅ **87 unit tests passing** - All functionality validated
-- ✅ **10 property tests passing** - Universal correctness verified
-- ✅ **100% success rate** - Zero failing tests
-- ✅ **~6 second execution** - Fast feedback cycle
-- ✅ **1000+ iterations** - Comprehensive coverage
-
-### For Contributors
-
-When adding new features, include appropriate tests:
-
-1. **Choose the right test module** based on functionality
-2. **Follow existing patterns** for consistency
-3. **Test both success and failure cases**
-4. **Add property tests** for universal behavior
-5. **Run `npm run validate`** before submitting PR
-
-See [CONTRIBUTING.md](./CONTRIBUTING.md#testing-requirements) for detailed testing guidelines.
-
-### Test Philosophy
-
-Our testing approach ensures reliability through multiple complementary strategies:
-
-#### 🎯 **Focused Unit Tests**
-Each test module focuses on a specific capability (CLI options, environment variables, configuration files, etc.), making it easy to understand what's being tested and debug failures.
-
-#### 🔬 **Property-Based Testing**
-Using [fast-check](https://github.com/dubzzz/fast-check), we test universal correctness properties across thousands of parameter combinations, ensuring the system behaves correctly for all valid inputs.
-
-#### 🔒 **Security & Quality**
-Automated security auditing and code quality checks ensure the generated containers and deployment scripts follow best practices.
-
-#### 📊 **Comprehensive Coverage**
-- **87 unit tests** covering specific functionality
-- **10 property tests** validating universal behavior
-- **1000+ test iterations** across all parameter combinations
-- **Multi-Node.js version testing** ensuring compatibility
-
-#### ⚡ **Fast Feedback**
-Tests complete in ~6 seconds, providing rapid feedback during development while maintaining comprehensive coverage.
-
-## 🤝 Contributing
-
-We welcome contributions of all sizes! Whether you're:
-- Reporting bugs or requesting features
-- Improving documentation
-- Adding support for new frameworks
-- Optimizing performance
-
-Your input shapes the future of this tool.
-
-### Development Setup
-
-Quick contribution setup:
-
+Add your user to the docker group:
 ```bash
-# Clone and setup
-git clone https://github.com/awslabs/ml-container-creator
-cd ml-container-creator
-
-# Ensure you're using Node.js 24+
-nvm use node  # or: nvm install 24
-
-# Install dependencies and link for local development
-npm install
-npm link
-
-# Run tests
-npm test
-
-# Run linting
-npm run lint
-
-# Make your changes and submit a PR!
+sudo usermod -aG docker $USER
 ```
 
-### Continuous Integration
+### Deployment Issues
 
-All pull requests are automatically tested with our comprehensive CI pipeline:
+**ECR Push Failed**
 
-#### 🔄 **Automated Testing**
-- **Multi-Node Testing**: Tests run on Node.js 24.x and 22.x
-- **Complete Test Suite**: Unit tests + property-based tests + security audit
-- **Code Quality**: ESLint checks for code standards
-- **Security Scanning**: npm audit for known vulnerabilities
-- **Coverage Reporting**: Test coverage analysis and reporting
-
-#### 📋 **CI Pipeline Stages**
-
-1. **Test Suite** - Runs on multiple Node.js versions
-   - ESLint code quality checks
-   - Security audit (npm audit)
-   - Unit tests (87 tests)
-   - Property-based tests (10 universal properties)
-   - Test coverage generation
-
-2. **Full Validation** - Complete end-to-end testing
-   - Full validation suite (`npm run validate`)
-   - Generator installation testing
-   - CLI functionality verification
-   - File generation validation
-
-3. **Security Scan** - Security vulnerability assessment
-   - Dependency vulnerability scanning
-   - High/critical vulnerability blocking
-   - Security best practices validation
-
-#### ✅ **PR Requirements**
-
-Before your PR can be merged, it must:
-- ✅ Pass all tests on supported Node.js versions
-- ✅ Pass ESLint code quality checks
-- ✅ Pass security audit (no high/critical vulnerabilities)
-- ✅ Maintain or improve test coverage
-- ✅ Successfully generate containers with CLI options
-
-#### 🚀 **Local Validation**
-
-Run the same checks locally before submitting:
-
+Check AWS credentials and IAM permissions:
 ```bash
-# Run the complete validation suite (same as CI)
-npm run validate
-
-# Test generator functionality
-npm link
-yo ml-container-creator test-project --framework=sklearn --model-server=flask --model-format=pkl --skip-prompts
+aws sts get-caller-identity
 ```
 
-### Running Tests
+**Endpoint Creation Failed**
 
-The project has a comprehensive test suite with multiple types of tests:
+- Verify the execution role ARN is correct
+- Check IAM permissions
+- Ensure the instance type is available in your region
 
+**Endpoint Stuck in Creating**
+
+Check CloudWatch logs:
 ```bash
-# Run all tests (unit + property-based + security audit)
-npm run validate
-
-# Run unit tests only
-npm test
-
-# Run property-based tests only
-npm run test:property
-
-# Run all tests without security audit
-npm run test:all
-
-# Development workflows
-npm run test:watch          # Watch mode for unit tests
-npm run test:property:watch # Watch mode for property tests
-npm run test:coverage       # Run with coverage report
+aws logs tail /aws/sagemaker/Endpoints/quick-inference-container-endpoint --follow
 ```
 
-#### Test Organization
+### Runtime Issues
 
-Our test suite is organized into focused modules:
+**Container Exits Immediately**
 
-**📋 Unit Tests** (`test/input-parsing-and-generation/`)
-- **CLI Options**: `cli-options.test.js` - CLI option parsing and validation
-- **Environment Variables**: `environment-variables.test.js` - Environment variable handling
-- **Configuration Files**: `configuration-files.test.js` - Config file parsing (JSON, package.json)
-- **Configuration Precedence**: `configuration-precedence.test.js` - Multi-source precedence testing
-- **File Generation**: `file-generation.test.js` - Template processing and file creation
-- **Error Handling**: `error-handling.test.js` - Validation and error scenarios
-
-**🔬 Property-Based Tests** (`test/input-parsing-and-generation/parameter-matrix-compliance.property.test.js`)
-- **Parameter Matrix Compliance**: 10 universal correctness properties
-- **Comprehensive Coverage**: 1000+ test iterations across all parameter combinations
-- **Automated Validation**: Tests all configuration sources and precedence rules
-
-#### Test Features
-
-- **87 passing tests** with comprehensive coverage
-- **Property-based testing** using fast-check for universal correctness validation
-- **Detailed progress reporting** with numbered tests and clear output
-- **Debug information** when tests fail
-- **Modular structure** for easy maintenance and contribution
-
-#### Running Specific Tests
-
+Check container logs:
 ```bash
-# Run specific test categories
-npm test -- --grep "CLI Options"        # CLI option tests
-npm test -- --grep "Environment"        # Environment variable tests
-npm test -- --grep "precedence"         # Configuration precedence tests
-npm test -- --grep "sklearn"            # Framework-specific tests
-
-# Run property tests for specific properties
-npm run test:property -- --grep "Property 1"  # Parameter source enforcement
-npm run test:property -- --grep "Property 10" # Parameter precedence order
+docker logs $(docker ps -a | grep quick-inference-container | awk '{print $1}')
 ```
 
-## Security
+**Out of Memory**
 
-See [CONTRIBUTING](./CONTRIBUTING.md#security-issue-notifications) for more information.
+Increase instance size or optimize model:
+```bash
+# Edit do/config
+INSTANCE_TYPE="ml.m5.2xlarge"  # Larger instance
+```
+
+## Migration from Legacy Scripts
+
+If you're familiar with the old `deploy/` scripts, see `MIGRATION.md` for a command mapping guide.
+
+**Quick Reference**:
+
+| Legacy Command | do-framework Command |
+|----------------|---------------------|
+| `./deploy/build_and_push.sh` | `./do/build && ./do/push` |
+| `./deploy/deploy.sh <role>` | `./do/deploy <role>` |
+| `./deploy/submit_build.sh` | `./do/submit` |
+
+The legacy scripts are still available but deprecated. They will display warnings and forward to do-framework commands.
+
+## Additional Resources
+
+- [do-framework Documentation](https://github.com/iankoulski/do-framework)
+- [AWS SageMaker Documentation](https://docs.aws.amazon.com/sagemaker/)
+- [SageMaker BYOC Guide](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms.html)
+
+## Support
+
+For issues or questions:
+
+1. Check `do/README.md` for detailed command documentation
+2. Review CloudWatch logs for deployment issues
+3. See `MIGRATION.md` if migrating from legacy scripts
+4. Open an issue on the [ML Container Creator repository](https://github.com/yourusername/ml-container-creator)
 
 ## License
 
-This project is licensed under the Apache-2.0 License.
-
-## 📚 Documentation
-
-**📖 [Full Documentation Site](https://awslabs.github.io/ml-container-creator/)** - Complete guides, examples, and API reference
-
-### Quick Links
-- 📖 **[Getting Started](./docs/getting-started.md)** - Installation and first project tutorial
-- 📖 **[Examples Guide](./docs/EXAMPLES.md)** - Step-by-step examples for common use cases including CodeBuild CI/CD
-- 🔧 **[Troubleshooting Guide](./docs/TROUBLESHOOTING.md)** - Solutions to common issues
-- 🎯 **[Template System](./docs/template-system.md)** - How the template system works
-- 🏗️ **[Architecture](./docs/architecture.md)** - Complete architecture guide
-
-### Release Documentation
-- 📋 **[v1.0.0 Release Notes](./.kiro/v1.0.0-Release/RELEASE_NOTES.md)** - Complete feature descriptions and testing commands
-- 📊 **[v1.0.0 Release Summary](./.kiro/v1.0.0-Release/RELEASE_SUMMARY.md)** - High-level overview and statistics
-- ⚡ **[Quick Test Guide](./.kiro/v1.0.0-Release/REVIEWER_QUICK_TEST.md)** - Fast validation for reviewers
-
-### For Contributors
-- 🚀 **[Contributing Guide](./docs/CONTRIBUTING.md)** - Get started contributing in 5 minutes
-- 🛠️ **[Adding Features](./docs/ADDING_FEATURES.md)** - Guide for adding new frameworks
-- 📝 **[Coding Standards](./docs/coding-standards.md)** - Code style and conventions
-- ☁️ **[AWS/SageMaker Guide](./docs/aws-sagemaker.md)** - Domain knowledge and best practices
-
-### Examples
-- [Deploy a scikit-learn Model](./docs/EXAMPLES.md#example-1-deploy-a-scikit-learn-model)
-- [Deploy an XGBoost Model](./docs/EXAMPLES.md#example-2-deploy-an-xgboost-model)
-- [Deploy a TensorFlow Model](./docs/EXAMPLES.md#example-3-deploy-a-tensorflow-model)
-- [Deploy a Transformer Model (LLM)](./docs/EXAMPLES.md#example-4-deploy-a-transformer-model-llm)
-
-## 🆘 Support & Troubleshooting
-
-### Get Help
-- 📖 [Examples Guide](./docs/EXAMPLES.md) - Detailed walkthroughs
-- 🔧 [Troubleshooting Guide](./TROUBLESHOOTING.md) - Common issues and solutions
-- 🔧 [Advanced Troubleshooting](./docs/TROUBLESHOOTING.md) - Development and CI issues
-- 🐛 [Report Issues](https://github.com/awslabs/ml-container-creator/issues)
-- 💬 [Community Discussions](https://github.com/awslabs/ml-container-creator/discussions)
-- 🗺️ [Roadmap & Feature Requests](https://github.com/awslabs/ml-container-creator/projects)
-- 📖 [SageMaker Documentation](https://docs.aws.amazon.com/sagemaker/)
-
-### Quick Troubleshooting
-
-**Container fails to start**
-```bash
-# Check logs
-docker logs your-container-name
-
-# See detailed solutions in troubleshooting guide
-```
-
-**SageMaker deployment fails**
-```bash
-# Check CloudWatch logs
-aws logs tail /aws/sagemaker/Endpoints/your-endpoint --follow
-
-# See detailed solutions in troubleshooting guide
-```
-
-**Need more help?** Check the [troubleshooting guide](./TROUBLESHOOTING.md) for common issues and solutions.
-
-<div align="center">
-  <p>Made with ❤️ by the ML community, for the ML community</p>
-</div>
+This generated project is provided as starter code. Modify as needed for your use case.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -21,7 +21,7 @@ Common issues and solutions when using ML Container Creator.
 
 **Problem:**
 ```bash
-$ yo ml-container-creator
+$ yo @aws/ml-container-creator
 Error: ml-container-creator generator not found
 ```
 
@@ -465,7 +465,7 @@ Error: Failed to download model from HuggingFace Hub
    
    Rebuild with token:
    ```bash
-   yo ml-container-creator my-llm-project \
+   yo @aws/ml-container-creator my-llm-project \
      --framework=transformers \
      --model-name=meta-llama/Llama-2-7b-hf \
      --model-server=vllm \
@@ -496,7 +496,7 @@ Concerned about token security in Docker image
 1. **Use environment variable reference** (recommended for CI/CD):
    ```bash
    # During generation, use $HF_TOKEN reference
-   yo ml-container-creator --hf-token='$HF_TOKEN' --skip-prompts
+   yo @aws/ml-container-creator --hf-token='$HF_TOKEN' --skip-prompts
    
    # Set environment variable before building
    export HF_TOKEN=hf_your_token_here
@@ -556,7 +556,7 @@ Error: Rate limit exceeded
 1. **Use authentication**:
    Authenticated requests have higher rate limits:
    ```bash
-   yo ml-container-creator --hf-token=hf_your_token_here --skip-prompts
+   yo @aws/ml-container-creator --hf-token=hf_your_token_here --skip-prompts
    ```
 
 2. **Wait and retry**:

--- a/docs/ADDING_FEATURES.md
+++ b/docs/ADDING_FEATURES.md
@@ -115,7 +115,7 @@ const helpers = require('yeoman-test');
 const assert = require('yeoman-assert');
 const path = require('path');
 
-describe('generator-ml-container-creator:pytorch', () => {
+describe('@aws/generator-ml-container-creator:pytorch', () => {
     it('creates pytorch project with pt format', async () => {
         await helpers.run(path.join(__dirname, '../generators/app'))
             .withPrompts({
@@ -160,7 +160,7 @@ scripted_model.save('model.torchscript')
 ### Step 2: Generate Project
 
 \`\`\`bash
-yo ml-container-creator
+yo @aws/ml-container-creator
 # Select pytorch, pt format, flask server
 \`\`\`
 ```
@@ -519,7 +519,7 @@ npm test -- --coverage
 npm link
 
 # Test generation
-yo ml-container-creator
+yo @aws/ml-container-creator
 
 # Test all combinations
 # - New framework + flask
@@ -532,7 +532,7 @@ yo ml-container-creator
 
 ```bash
 # Generate project
-yo ml-container-creator
+yo @aws/ml-container-creator
 
 # Build container
 cd generated-project

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,7 +21,7 @@ npm link
 npm test
 
 # 3. Try the generator
-yo ml-container-creator
+yo @aws/ml-container-creator
 ```
 
 That's it! You're ready to contribute.
@@ -286,7 +286,7 @@ npm link
 
 # 3. Test in a temporary directory
 cd /tmp
-yo ml-container-creator
+yo @aws/ml-container-creator
 
 # 4. Verify generated project structure
 cd your-generated-project
@@ -308,10 +308,10 @@ docker images | grep your-project  # Verify image was created
 
 ```bash
 # See detailed Yeoman output
-DEBUG=yeoman:* yo ml-container-creator
+DEBUG=yeoman:* yo @aws/ml-container-creator
 
 # See generator-specific output
-DEBUG=generator-ml-container-creator:* yo ml-container-creator
+DEBUG=@aws/generator-ml-container-creator:* yo @aws/ml-container-creator
 ```
 
 ### Common Issues

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -22,7 +22,7 @@ You have a trained scikit-learn model saved as `model.pkl` and want to deploy it
 ### Step 1: Generate Project
 
 ```bash
-yo ml-container-creator
+yo @aws/ml-container-creator
 ```
 
 **Prompts and Answers:**
@@ -96,7 +96,7 @@ You have an XGBoost model saved in JSON format for a regression task.
 ### Step 1: Generate Project
 
 ```bash
-yo ml-container-creator
+yo @aws/ml-container-creator
 ```
 
 **Configuration:**
@@ -257,7 +257,7 @@ When generating a transformer project, you'll be prompted to select a model. The
 **Example: Using a Custom Model with Authentication**
 
 ```bash
-yo ml-container-creator
+yo @aws/ml-container-creator
 
 # When prompted:
 ? Which model do you want to use? Custom (enter manually)
@@ -353,7 +353,7 @@ TensorRT-LLM is NVIDIA's high-performance inference engine specifically designed
 ### Step 1: Generate Project
 
 ```bash
-yo ml-container-creator
+yo @aws/ml-container-creator
 ```
 
 **Configuration:**
@@ -635,7 +635,7 @@ For automated deployments:
 
 ```bash
 # Generate TensorRT-LLM project with CLI
-yo ml-container-creator tensorrt-llm-project \
+yo @aws/ml-container-creator tensorrt-llm-project \
   --framework=transformers \
   --model-server=tensorrt-llm \
   --model-name=meta-llama/Llama-3.2-3B-Instruct \
@@ -751,7 +751,7 @@ You want to set up an enterprise-ready CI/CD pipeline using AWS CodeBuild for au
 
 ```bash
 # Using CLI for automation
-yo ml-container-creator sklearn-codebuild-project \
+yo @aws/ml-container-creator sklearn-codebuild-project \
   --framework=sklearn \
   --model-server=flask \
   --model-format=pkl \
@@ -895,7 +895,7 @@ You want to optimize costs and performance by using specific AWS instance types 
 
 ```bash
 # Generate project with small instance for development
-yo ml-container-creator dev-sklearn-model \
+yo @aws/ml-container-creator dev-sklearn-model \
   --framework=sklearn \
   --model-server=flask \
   --model-format=pkl \
@@ -914,7 +914,7 @@ yo ml-container-creator dev-sklearn-model \
 
 ```bash
 # Generate project optimized for AWS Inferentia chips
-yo ml-container-creator inferentia-model \
+yo @aws/ml-container-creator inferentia-model \
   --framework=tensorflow \
   --model-server=flask \
   --model-format=SavedModel \
@@ -932,7 +932,7 @@ yo ml-container-creator inferentia-model \
 
 ```bash
 # Generate project for memory-intensive models
-yo ml-container-creator memory-intensive-model \
+yo @aws/ml-container-creator memory-intensive-model \
   --framework=sklearn \
   --model-server=fastapi \
   --model-format=pkl \
@@ -950,7 +950,7 @@ yo ml-container-creator memory-intensive-model \
 
 ```bash
 # Generate project for high-throughput inference
-yo ml-container-creator high-throughput-model \
+yo @aws/ml-container-creator high-throughput-model \
   --framework=xgboost \
   --model-server=fastapi \
   --model-format=json \
@@ -968,7 +968,7 @@ yo ml-container-creator high-throughput-model \
 
 ```bash
 # Generate project with single GPU for cost-effective deep learning
-yo ml-container-creator single-gpu-model \
+yo @aws/ml-container-creator single-gpu-model \
   --framework=tensorflow \
   --model-server=flask \
   --model-format=SavedModel \
@@ -1009,10 +1009,10 @@ Create reusable configurations for different environments:
 #### Usage
 ```bash
 # Development deployment
-yo ml-container-creator --config=dev-config.json --framework=sklearn --skip-prompts
+yo @aws/ml-container-creator --config=dev-config.json --framework=sklearn --skip-prompts
 
 # Production deployment  
-yo ml-container-creator --config=prod-config.json --framework=sklearn --skip-prompts
+yo @aws/ml-container-creator --config=prod-config.json --framework=sklearn --skip-prompts
 ```
 
 ### Environment Variable Approach
@@ -1031,7 +1031,7 @@ export ML_CUSTOM_INSTANCE_TYPE=ml.inf1.xlarge
 export AWS_REGION=us-west-2
 
 # Generate project (inherits environment config)
-yo ml-container-creator --framework=sklearn --model-server=flask --skip-prompts
+yo @aws/ml-container-creator --framework=sklearn --model-server=flask --skip-prompts
 ```
 
 ### Cost Comparison
@@ -1078,10 +1078,10 @@ The generator validates custom instance types:
 
 ```bash
 # Valid format
-yo ml-container-creator --instance-type=custom --custom-instance-type=ml.g4dn.xlarge ✅
+yo @aws/ml-container-creator --instance-type=custom --custom-instance-type=ml.g4dn.xlarge ✅
 
 # Invalid format
-yo ml-container-creator --instance-type=custom --custom-instance-type=invalid-type ❌
+yo @aws/ml-container-creator --instance-type=custom --custom-instance-type=invalid-type ❌
 # Error: Invalid custom instance type format: invalid-type
 ```
 
@@ -1225,7 +1225,7 @@ Use the custom instance type option for specialized hardware:
 
 ```bash
 # Generate project with custom instance type
-yo ml-container-creator my-optimized-model \
+yo @aws/ml-container-creator my-optimized-model \
   --framework=sklearn \
   --model-server=flask \
   --model-format=pkl \

--- a/docs/REGISTRY_CONTRIBUTION_GUIDE.md
+++ b/docs/REGISTRY_CONTRIBUTION_GUIDE.md
@@ -444,7 +444,7 @@ Before contributing, test your configuration:
 
 ```bash
 # Generate project with your configuration
-yo ml-container-creator test-project \
+yo @aws/ml-container-creator test-project \
   --framework=your-framework \
   --version=your-version \
   --skip-prompts
@@ -520,7 +520,7 @@ Test your configuration manually:
 npm link
 
 # 2. Generate project with your configuration
-yo ml-container-creator test-project \
+yo @aws/ml-container-creator test-project \
   --framework=your-framework \
   --version=your-version \
   --skip-prompts

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -44,8 +44,8 @@ Common issues and solutions for ML Container Creator.
 
 **Symptom:**
 ```bash
-$ yo ml-container-creator
-Error: ml-container-creator generator not found
+$ yo @aws/ml-container-creator
+Error: @aws/ml-container-creator generator not found
 ```
 
 **Solution:**
@@ -55,7 +55,7 @@ cd ml-container-creator
 npm link
 
 # Verify it's linked
-npm list -g generator-ml-container-creator
+npm list -g @aws/generator-ml-container-creator
 
 # If still not working, reinstall Yeoman
 npm install -g yo
@@ -105,7 +105,7 @@ Generated files contain `<%= projectName %>` instead of actual values.
 ```bash
 yo: command not found
 # OR
-generator-ml-container-creator not found
+@aws/generator-ml-container-creator not found
 ```
 
 **Solution:**
@@ -300,7 +300,7 @@ yo: command not found in CI
   run: npm link
 
 - name: Test generator
-  run: yo ml-container-creator --help
+  run: yo @aws/ml-container-creator --help
 ```
 
 ### ESLint Failing in CI
@@ -964,7 +964,7 @@ cat generators/app/config/registries/frameworks.js | grep -A 20 "vllm"
 # Priority: Framework base → Framework profile → HF API → Model registry → Model profile
 
 # 3. Enable debug logging
-DEBUG=* yo ml-container-creator
+DEBUG=* yo @aws/ml-container-creator
 
 # 4. Check if graceful degradation is occurring
 # If registry is empty, generator uses defaults
@@ -1002,7 +1002,7 @@ Warning: Profile 'low-latency' not found for vllm 0.5.0
 }
 
 // Or skip profile selection
-yo ml-container-creator --skip-profile-selection
+yo @aws/ml-container-creator --skip-profile-selection
 ```
 
 ---
@@ -1020,13 +1020,13 @@ Consider using ml.g5.xlarge, ml.g5.2xlarge, ml.g5.4xlarge
 **Solution:**
 ```bash
 # Option 1: Use recommended instance type
-yo ml-container-creator \
+yo @aws/ml-container-creator \
   --framework=vllm \
   --instance-type=ml.g5.xlarge
 
 # Option 2: Choose framework compatible with your instance
 # For ml.inf2 (Neuron SDK), use transformers-neuron
-yo ml-container-creator \
+yo @aws/ml-container-creator \
   --framework=transformers-neuron \
   --instance-type=ml.inf2.xlarge
 
@@ -1049,13 +1049,13 @@ Consider using ml.g5 or ml.g6 instances for CUDA 12.x support
 # ml.g4dn family: CUDA 11.x
 # ml.p3 family: CUDA 11.x
 
-yo ml-container-creator \
+yo @aws/ml-container-creator \
   --framework=vllm \
   --version=0.5.0 \
   --instance-type=ml.g5.xlarge  # CUDA 12.x
 
 # Option 2: Use older framework version
-yo ml-container-creator \
+yo @aws/ml-container-creator \
   --framework=vllm \
   --version=0.3.0 \  # Requires CUDA 11.x
   --instance-type=ml.g4dn.xlarge
@@ -1167,7 +1167,7 @@ Warning: HuggingFace API timeout, checking local registry
 this.timeout = 10000;  // 10 seconds instead of 5
 
 # Option 2: Use offline mode
-yo ml-container-creator --offline
+yo @aws/ml-container-creator --offline
 
 # Option 3: Check network connectivity
 curl -I https://huggingface.co
@@ -1202,7 +1202,7 @@ Warning: Model 'my-org/my-model' not found on HuggingFace, proceeding with defau
 }
 
 # Option 3: Use offline mode
-yo ml-container-creator --offline
+yo @aws/ml-container-creator --offline
 
 # Option 4: Proceed without model-specific config
 # Generator will use framework defaults
@@ -1222,10 +1222,10 @@ Warning: HuggingFace API rate limit exceeded, using cached data
 
 # Option 2: Use HF_TOKEN for higher limits
 export HF_TOKEN=hf_your_token_here
-yo ml-container-creator
+yo @aws/ml-container-creator
 
 # Option 3: Use offline mode
-yo ml-container-creator --offline
+yo @aws/ml-container-creator --offline
 
 # Option 4: Use model registry
 # Pre-configure models in local registry
@@ -1291,7 +1291,7 @@ Warning: Environment variable 'CUSTOM_FLAG' not found in known flags registry
 }
 
 # Option 2: Disable validation
-yo ml-container-creator --validate-env-vars=false
+yo @aws/ml-container-creator --validate-env-vars=false
 
 # Option 3: Contribute flag definition
 # See docs/REGISTRY_CONTRIBUTION_GUIDE.md
@@ -1352,7 +1352,7 @@ Warning: Environment variable 'GPU_MEMORY_UTILIZATION' value 1.5 exceeds maximum
 GPU_MEMORY_UTILIZATION=0.9
 
 # Or disable validation
-yo ml-container-creator --validate-env-vars=false
+yo @aws/ml-container-creator --validate-env-vars=false
 ```
 
 ### Deprecated Environment Variable

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ This is a Yeoman generator that creates Docker containers for deploying ML model
 For newcomers, here's how the generator works:
 
 ```
-User runs: yo ml-container-creator
+User runs: yo @aws/ml-container-creator
            ↓
     ┌─────────────────┐
     │   index.js      │  ← Main generator (orchestration)
@@ -234,7 +234,7 @@ Files are conditionally excluded based on configuration:
    - Orchestration: `generators/app/index.js`
 2. Edit templates in `generators/app/templates/`
 3. Run `npm link` to test locally
-4. Test with `yo ml-container-creator`
+4. Test with `yo @aws/ml-container-creator`
 5. Run `npm test` before committing
 
 ### Testing

--- a/docs/aws-sagemaker.md
+++ b/docs/aws-sagemaker.md
@@ -169,7 +169,7 @@ You can specify any AWS SageMaker instance type using the custom option:
 
 ```bash
 # CLI usage
-yo ml-container-creator --instance-type=custom --custom-instance-type=ml.g4dn.xlarge
+yo @aws/ml-container-creator --instance-type=custom --custom-instance-type=ml.g4dn.xlarge
 
 # Configuration file
 {

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -165,7 +165,7 @@ except Exception as e:
 const helpers = require('yeoman-test');
 const assert = require('yeoman-assert');
 
-describe('generator-ml-container-creator:app', () => {
+describe('@aws/generator-ml-container-creator:app', () => {
     it('creates expected files', async () => {
         await helpers.run(path.join(__dirname, '../generators/app'))
             .withPrompts({

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ Configuration sources are applied in strict precedence order (highest to lowest 
 | Priority | Source | Description | Example |
 |----------|--------|-------------|---------|
 | **1** | CLI Options | Command-line flags | `--framework=sklearn` |
-| **2** | CLI Arguments | Positional arguments | `yo ml-container-creator my-project` |
+| **2** | CLI Arguments | Positional arguments | `yo @aws/ml-container-creator my-project` |
 | **3** | Environment Variables | Shell environment | `export AWS_REGION=us-east-1` |
 | **4** | CLI Config File | `--config` specified file | `--config=production.json` |
 | **5** | Custom Config File | `config/mcp.json` | Auto-discovered in current directory |
@@ -58,7 +58,7 @@ This table shows which parameters are supported by each configuration source:
 The simplest approach - just run the generator and answer the prompts:
 
 ```bash
-yo ml-container-creator
+yo @aws/ml-container-creator
 ```
 
 The generator will guide you through all configuration options with smart defaults and validation.
@@ -69,14 +69,14 @@ Use command-line flags for quick one-off configurations:
 
 ```bash
 # Basic sklearn project
-yo ml-container-creator my-project \
+yo @aws/ml-container-creator my-project \
   --framework=sklearn \
   --model-server=flask \
   --model-format=pkl \
   --skip-prompts
 
 # Advanced configuration
-yo ml-container-creator my-llm-project \
+yo @aws/ml-container-creator my-llm-project \
   --framework=transformers \
   --model-server=vllm \
   --instance-type=gpu-enabled \
@@ -109,7 +109,7 @@ Use positional arguments for the project name:
 
 ```bash
 # Project name as first argument
-yo ml-container-creator my-awesome-model --framework=sklearn --skip-prompts
+yo @aws/ml-container-creator my-awesome-model --framework=sklearn --skip-prompts
 ```
 
 ### 4. Environment Variables
@@ -124,7 +124,7 @@ export AWS_ROLE="arn:aws:iam::123456789012:role/SageMakerRole"
 export ML_CONTAINER_CREATOR_CONFIG="./production.json"
 
 # Generate with environment config + CLI options for core parameters
-yo ml-container-creator --framework=transformers --model-server=vllm --skip-prompts
+yo @aws/ml-container-creator --framework=transformers --model-server=vllm --skip-prompts
 ```
 
 #### Supported Environment Variables
@@ -165,7 +165,7 @@ Create a configuration file in your project directory:
 
 ```bash
 # Use the config file
-yo ml-container-creator --skip-prompts
+yo @aws/ml-container-creator --skip-prompts
 ```
 
 #### CLI Config File (`--config`)
@@ -174,11 +174,11 @@ Specify a custom config file location:
 
 ```bash
 # Use specific config file
-yo ml-container-creator --config=production.json --skip-prompts
+yo @aws/ml-container-creator --config=production.json --skip-prompts
 
 # Config file via environment variable
 export ML_CONTAINER_CREATOR_CONFIG="./staging.json"
-yo ml-container-creator --skip-prompts
+yo @aws/ml-container-creator --skip-prompts
 ```
 
 #### Package.json Section
@@ -207,7 +207,7 @@ Special CLI commands for configuration management:
 ### Interactive Configuration Setup
 
 ```bash
-yo ml-container-creator configure
+yo @aws/ml-container-creator configure
 ```
 
 Guides you through creating configuration files with validation and examples.
@@ -215,7 +215,7 @@ Guides you through creating configuration files with validation and examples.
 ### Generate Empty Config
 
 ```bash
-yo ml-container-creator generate-empty-config
+yo @aws/ml-container-creator generate-empty-config
 ```
 
 Creates an empty configuration file template that you can customize.
@@ -223,9 +223,9 @@ Creates an empty configuration file template that you can customize.
 ### Help
 
 ```bash
-yo ml-container-creator help
+yo @aws/ml-container-creator help
 # or
-yo ml-container-creator --help
+yo @aws/ml-container-creator --help
 ```
 
 Shows comprehensive help with all options, examples, and configuration methods.
@@ -266,7 +266,7 @@ You can:
 
 ```bash
 # Direct token
-yo ml-container-creator my-llm-project \
+yo @aws/ml-container-creator my-llm-project \
   --framework=transformers \
   --model-name=meta-llama/Llama-2-7b-hf \
   --model-server=vllm \
@@ -274,7 +274,7 @@ yo ml-container-creator my-llm-project \
   --skip-prompts
 
 # Environment variable reference
-yo ml-container-creator my-llm-project \
+yo @aws/ml-container-creator my-llm-project \
   --framework=transformers \
   --model-name=meta-llama/Llama-2-7b-hf \
   --model-server=vllm \
@@ -303,7 +303,7 @@ yo ml-container-creator my-llm-project \
 1. **Use environment variable references for CI/CD**:
    ```bash
    export HF_TOKEN=hf_your_token_here
-   yo ml-container-creator --framework=transformers --hf-token='$HF_TOKEN' --skip-prompts
+   yo @aws/ml-container-creator --framework=transformers --hf-token='$HF_TOKEN' --skip-prompts
    ```
 
 2. **Never commit tokens to version control**: Use `$HF_TOKEN` in config files, not actual tokens.
@@ -344,7 +344,7 @@ For more troubleshooting, see the [Troubleshooting Guide](./TROUBLESHOOTING.md).
 
 ```bash
 # scikit-learn with Flask
-yo ml-container-creator sklearn-project \
+yo @aws/ml-container-creator sklearn-project \
   --framework=sklearn \
   --model-server=flask \
   --model-format=pkl \
@@ -352,7 +352,7 @@ yo ml-container-creator sklearn-project \
   --skip-prompts
 
 # XGBoost with FastAPI
-yo ml-container-creator xgb-project \
+yo @aws/ml-container-creator xgb-project \
   --framework=xgboost \
   --model-server=fastapi \
   --model-format=json \
@@ -360,7 +360,7 @@ yo ml-container-creator xgb-project \
   --skip-prompts
 
 # TensorFlow with custom format
-yo ml-container-creator tf-project \
+yo @aws/ml-container-creator tf-project \
   --framework=tensorflow \
   --model-server=flask \
   --model-format=SavedModel \
@@ -379,7 +379,7 @@ yo ml-container-creator tf-project \
 
 ```bash
 # Transformers with vLLM
-yo ml-container-creator llm-project \
+yo @aws/ml-container-creator llm-project \
   --framework=transformers \
   --model-server=vllm \
   --instance-type=gpu-enabled \
@@ -387,7 +387,7 @@ yo ml-container-creator llm-project \
   --skip-prompts
 
 # Transformers with SGLang
-yo ml-container-creator llm-project \
+yo @aws/ml-container-creator llm-project \
   --framework=transformers \
   --model-server=sglang \
   --instance-type=gpu-enabled \
@@ -454,13 +454,13 @@ yo ml-container-creator llm-project \
 
 ```bash
 # DON'T: sklearn with vLLM server
-yo ml-container-creator --framework=sklearn --model-server=vllm --skip-prompts
+yo @aws/ml-container-creator --framework=sklearn --model-server=vllm --skip-prompts
 
 # DON'T: transformers with model format
-yo ml-container-creator --framework=transformers --model-format=pkl --skip-prompts
+yo @aws/ml-container-creator --framework=transformers --model-format=pkl --skip-prompts
 
 # DON'T: transformers with sample model
-yo ml-container-creator --framework=transformers --include-sample --skip-prompts
+yo @aws/ml-container-creator --framework=transformers --include-sample --skip-prompts
 ```
 
 ### ❌ Using Unsupported Environment Variables
@@ -472,7 +472,7 @@ export ML_MODEL_SERVER=flask       # Not supported
 export ML_MODEL_FORMAT=pkl         # Not supported
 
 # DO: Use CLI options or config files for core parameters
-yo ml-container-creator --framework=sklearn --model-server=flask --skip-prompts
+yo @aws/ml-container-creator --framework=sklearn --model-server=flask --skip-prompts
 ```
 
 ### ❌ Invalid Configuration Files
@@ -493,7 +493,7 @@ yo ml-container-creator --framework=sklearn --model-server=flask --skip-prompts
 ```bash
 # DON'T: Rely on precedence for critical settings
 export AWS_REGION=us-east-1
-yo ml-container-creator --region=us-west-2 --skip-prompts
+yo @aws/ml-container-creator --region=us-west-2 --skip-prompts
 # Confusing: CLI option wins, but not obvious
 ```
 
@@ -504,28 +504,28 @@ The generator validates all configuration and provides clear error messages:
 ### Framework Validation
 
 ```bash
-yo ml-container-creator --framework=invalid --skip-prompts
+yo @aws/ml-container-creator --framework=invalid --skip-prompts
 # Error: ⚠️ invalid not implemented yet.
 ```
 
 ### Format Validation
 
 ```bash
-yo ml-container-creator --framework=sklearn --model-format=json --skip-prompts
+yo @aws/ml-container-creator --framework=sklearn --model-format=json --skip-prompts
 # Error: Invalid model format 'json' for framework 'sklearn'
 ```
 
 ### ARN Validation
 
 ```bash
-yo ml-container-creator --role-arn=invalid-arn --skip-prompts
+yo @aws/ml-container-creator --role-arn=invalid-arn --skip-prompts
 # Error: Invalid AWS Role ARN format
 ```
 
 ### Required Parameter Validation
 
 ```bash
-yo ml-container-creator --skip-prompts
+yo @aws/ml-container-creator --skip-prompts
 # Error: Missing required parameter: framework
 ```
 
@@ -535,8 +535,8 @@ yo ml-container-creator --skip-prompts
 
 ```bash
 # Create once, use many times
-yo ml-container-creator configure
-yo ml-container-creator --skip-prompts  # Uses config/mcp.json
+yo @aws/ml-container-creator configure
+yo @aws/ml-container-creator --skip-prompts  # Uses config/mcp.json
 ```
 
 ### 2. Use Environment Variables for Deployment Environments
@@ -551,7 +551,7 @@ export AWS_REGION=us-west-2     # Production
 
 ```bash
 # Quick test with different server
-yo ml-container-creator --model-server=fastapi --skip-prompts
+yo @aws/ml-container-creator --model-server=fastapi --skip-prompts
 ```
 
 ### 4. Combine Methods Strategically
@@ -559,14 +559,14 @@ yo ml-container-creator --model-server=fastapi --skip-prompts
 ```bash
 # Base config in file, environment-specific overrides
 export AWS_REGION=us-west-2
-yo ml-container-creator --config=base-config.json --skip-prompts
+yo @aws/ml-container-creator --config=base-config.json --skip-prompts
 ```
 
 ### 5. Validate Configuration Before Deployment
 
 ```bash
 # Test configuration without skipping prompts first
-yo ml-container-creator --config=production.json
+yo @aws/ml-container-creator --config=production.json
 # Review all settings, then use --skip-prompts for automation
 ```
 
@@ -577,7 +577,7 @@ yo ml-container-creator --config=production.json
 The generator shows which configuration sources are being used:
 
 ```bash
-yo ml-container-creator --framework=sklearn --skip-prompts
+yo @aws/ml-container-creator --framework=sklearn --skip-prompts
 
 # Output shows:
 # ⚙️ Configuration will be collected from prompts and merged with:
@@ -596,13 +596,13 @@ yo ml-container-creator --framework=sklearn --skip-prompts
 
 ```bash
 # Show all configuration options
-yo ml-container-creator help
+yo @aws/ml-container-creator help
 
 # Show interactive configuration
-yo ml-container-creator configure
+yo @aws/ml-container-creator configure
 
 # Show environment variable examples
-yo ml-container-creator configure  # Choose "Show environment variable examples"
+yo @aws/ml-container-creator configure  # Choose "Show environment variable examples"
 ```
 
 This comprehensive configuration system ensures you can use ML Container Creator in any workflow, from interactive development to fully automated CI/CD pipelines.

--- a/docs/generative-models.md
+++ b/docs/generative-models.md
@@ -24,7 +24,7 @@ Some HuggingFace models are gated, requiring a HuggingFace API Token to access t
 
 1. CLI Flag (highest precedence)
 ```bash
-yo ml-container-creator \
+yo @aws/ml-container-creator \
   --framework=transformers \
   --model-name="meta-llama/Llama-2-7b-chat-hf" \
   --hf-token="hf_your_token_here"
@@ -32,14 +32,14 @@ yo ml-container-creator \
 2. Environment Variable 
 ```bash
 export HF_TOKEN="hf_your_token_here"
-yo ml-container-creator \
+yo @aws/ml-container-creator \
   --framework=transformers \
   --model-name="meta-llama/Llama-2-7b-chat-hf" \
   --hf-token='$HF_TOKEN'
 ```
 3. Interactive Prompt (Yeoman REPL)
 ```bash
-yo ml-container-creator
+yo @aws/ml-container-creator
 # When prompted for transformers, you'll be asked for HF token
 # Enter: $HF_TOKEN (to use env var) or hf_your_token_here (direct)
 ```

--- a/docs/generator-flow-section.md
+++ b/docs/generator-flow-section.md
@@ -5,7 +5,7 @@ The ML Container Creator follows a structured flow to collect configuration and 
 ### Interactive Mode
 
 ```bash
-yo ml-container-creator
+yo @aws/ml-container-creator
 ```
 
 **Step 1: Project Configuration**
@@ -82,7 +82,7 @@ yo ml-container-creator
 For automation or CI/CD pipelines, skip prompts entirely:
 
 ```bash
-yo ml-container-creator \
+yo @aws/ml-container-creator \
   --skip-prompts \
   --project-name="my-sklearn-model" \
   --framework="sklearn" \
@@ -120,7 +120,7 @@ The generator merges configuration from multiple sources in this precedence orde
 
 3. **Config File** (`--config` flag)
    ```bash
-   yo ml-container-creator --config=production.json
+   yo @aws/ml-container-creator --config=production.json
    ```
 
 4. **Default Config File** (`config/mcp.json`)
@@ -148,7 +148,7 @@ The generator merges configuration from multiple sources in this precedence orde
 For generative AI models, the flow differs slightly:
 
 ```bash
-yo ml-container-creator
+yo @aws/ml-container-creator
 ```
 
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,7 @@ yo --generators
 npm test
 
 # Generate your project
-yo ml-container-creator
+yo @aws/ml-container-creator
 ```
 
 ## Predictive ML
@@ -78,12 +78,12 @@ In this example, we'll use the sample Abalone classifier. This deployment option
 
 ### Step 2: Generate Container Project
 
-Run the generator using the `yo` command and selecting the generator from the provided list. Alternatively, specify the generator inline: `yo ml-container-creator`. You'll be prompted with questions. Each option creates conditional branching logic custom to the selected values. For a basic scikit-learn container using the default regression model, follow the prompts as defined below. You'll want to do this in a new directory.
+Run the generator using the `yo` command and selecting the generator from the provided list. Alternatively, specify the generator inline: `yo @aws/ml-container-creator`. You'll be prompted with questions. Each option creates conditional branching logic custom to the selected values. For a basic scikit-learn container using the default regression model, follow the prompts as defined below. You'll want to do this in a new directory.
 
 ```
 (base) frgud@842f5776eab6 ml-container-creator % mkdir scikit-test
 (base) frgud@842f5776eab6 ml-container-creator % cd scikit-test 
-(base) frgud@842f5776eab6 scikit-test % yo ml-container-creator scikit-test-project
+(base) frgud@842f5776eab6 scikit-test % yo @aws/ml-container-creator scikit-test-project
 
 📚 Registry System Initialized
    • Framework Registry: Loaded
@@ -386,7 +386,7 @@ Just as with the [predictive scenario](#predictive-ml), we can use MCC to genera
 
 
 ```bash
-(base) frgud@842f5776eab6 transformers-test % yo ml-container-creator sglang-gptoss-test 
+(base) frgud@842f5776eab6 transformers-test % yo @aws/ml-container-creator sglang-gptoss-test 
 
 📚 Registry System Initialized
    • Framework Registry: Loaded
@@ -626,7 +626,7 @@ Skip prompts entirely using CLI options:
 
 ```bash
 # Generate sklearn project with CLI options
-yo ml-container-creator iris-classifier \
+yo @aws/ml-container-creator iris-classifier \
   --framework=sklearn \
   --model-server=flask \
   --model-format=pkl \
@@ -641,7 +641,7 @@ Set deployment-specific variables:
 ```bash
 export AWS_REGION=us-west-2
 export ML_INSTANCE_TYPE=gpu-enabled
-yo ml-container-creator --framework=transformers --model-server=vllm --skip-prompts
+yo @aws/ml-container-creator --framework=transformers --model-server=vllm --skip-prompts
 ```
 
 ### Configuration Precedence
@@ -649,7 +649,7 @@ yo ml-container-creator --framework=transformers --model-server=vllm --skip-prom
 Configuration sources are applied in order (highest to lowest priority):
 
 1. **CLI Options** (`--framework=sklearn`)
-2. **CLI Arguments** (`yo ml-container-creator my-project`)
+2. **CLI Arguments** (`yo @aws/ml-container-creator my-project`)
 3. **Environment Variables** (`AWS_REGION=us-east-1`)
 4. **Config Files** (`--config=prod.json` or `config/mcp.json`)
 5. **Package.json** (`"ml-container-creator": {...}`)

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ npm install
 npm link
 
 # Generate your project
-yo ml-container-creator
+yo @aws/ml-container-creator
 ```
 
 The Yeoman generator prompts users for details about the deployment they are building. Answer a few questions about your model, the configuration, and the serving architecture, and get a complete project directory containging model serving, mdoel testing, deployment, and endpoint testing scripts. 

--- a/docs/mcp-configuration.md
+++ b/docs/mcp-configuration.md
@@ -12,7 +12,7 @@ sequenceDiagram
     participant Generator as ML Container Creator
     participant MCP as MCP Server (child process)
 
-    User->>Generator: yo ml-container-creator
+    User->>Generator: yo @aws/ml-container-creator
     Generator->>Generator: Load config files
     Generator->>MCP: Spawn process, handshake
     Generator->>MCP: Call get_ml_config tool
@@ -66,7 +66,7 @@ MCP servers can return values for any parameter, but the generator silently disc
 The fastest way to set up MCP is to register all bundled servers at once:
 
 ```bash
-yo ml-container-creator mcp init
+yo @aws/ml-container-creator mcp init
 ```
 
 This creates `config/mcp.json` with every bundled server pre-configured. Existing servers are preserved (not overwritten). Run this after cloning the repo or whenever you need to recreate the config file.
@@ -76,13 +76,13 @@ This creates `config/mcp.json` with every bundled server pre-configured. Existin
 Register an MCP server in your `config/mcp.json`:
 
 ```bash
-yo ml-container-creator mcp add team-config -- node path/to/server.js
+yo @aws/ml-container-creator mcp add team-config -- node path/to/server.js
 ```
 
 With environment variables and options:
 
 ```bash
-yo ml-container-creator mcp add team-config -- npx -y @corp/mcp-config \
+yo @aws/ml-container-creator mcp add team-config -- npx -y @corp/mcp-config \
   -e TEAM_ID=ml-platform \
   --tool-name get_approved_config \
   --limit 5
@@ -93,7 +93,7 @@ yo ml-container-creator mcp add team-config -- npx -y @corp/mcp-config \
 The generator ships with first-party MCP servers in the `servers/` directory:
 
 ```bash
-yo ml-container-creator mcp add instance-recommender --bundled
+yo @aws/ml-container-creator mcp add instance-recommender --bundled
 ```
 
 Dependencies are installed automatically on first use.
@@ -102,26 +102,26 @@ Dependencies are installed automatically on first use.
 
 ```bash
 # List configured servers
-yo ml-container-creator mcp list
+yo @aws/ml-container-creator mcp list
 
 # List available bundled servers
-yo ml-container-creator mcp list --bundled
+yo @aws/ml-container-creator mcp list --bundled
 ```
 
 ### Inspect a Server
 
 ```bash
-yo ml-container-creator mcp get team-config
+yo @aws/ml-container-creator mcp get team-config
 ```
 
 ### Remove a Server
 
 ```bash
-yo ml-container-creator mcp remove team-config
+yo @aws/ml-container-creator mcp remove team-config
 ```
 
 !!! note "Registration vs. Execution"
-    The `mcp add` command only **registers** a server in your config file. The server is actually **spawned and queried** later, when you run `yo ml-container-creator` to generate a project. This separation means you can configure servers without them needing to be available at registration time.
+    The `mcp add` command only **registers** a server in your config file. The server is actually **spawned and queried** later, when you run `yo @aws/ml-container-creator` to generate a project. This separation means you can configure servers without them needing to be available at registration time.
 
 ## Config File Format
 
@@ -160,13 +160,13 @@ When multiple servers are configured, they are queried in order. Later servers t
 Recommends SageMaker instance types based on the current framework. Traditional ML frameworks (sklearn, xgboost, tensorflow) get CPU instance suggestions; transformer frameworks get GPU instances.
 
 ```bash
-yo ml-container-creator mcp add instance-recommender --bundled
+yo @aws/ml-container-creator mcp add instance-recommender --bundled
 ```
 
 With Bedrock-powered smart recommendations:
 
 ```bash
-yo ml-container-creator mcp add instance-recommender --bundled \
+yo @aws/ml-container-creator mcp add instance-recommender --bundled \
   -e BEDROCK_SMART=true
 ```
 
@@ -176,16 +176,16 @@ Suggests AWS regions based on a search term. Set the `REGION_SEARCH` environment
 
 ```bash
 # Filter for European regions
-yo ml-container-creator mcp add region-picker --bundled -e REGION_SEARCH=europe
+yo @aws/ml-container-creator mcp add region-picker --bundled -e REGION_SEARCH=europe
 
 # Popular regions (no filter)
-yo ml-container-creator mcp add region-picker --bundled
+yo @aws/ml-container-creator mcp add region-picker --bundled
 ```
 
 With Bedrock-powered smart recommendations:
 
 ```bash
-yo ml-container-creator mcp add region-picker --bundled \
+yo @aws/ml-container-creator mcp add region-picker --bundled \
   -e REGION_SEARCH=europe \
   -e BEDROCK_SMART=true
 ```
@@ -228,14 +228,14 @@ The calling identity needs `bedrock:InvokeModel` permission on the inference pro
 
 ```bash
 # Add instance-recommender with smart mode and a custom model
-yo ml-container-creator mcp add instance-recommender --bundled \
+yo @aws/ml-container-creator mcp add instance-recommender --bundled \
   -e BEDROCK_SMART=true \
   -e BEDROCK_MODEL=us.anthropic.claude-sonnet-4-20250514-v1:0 \
   -e BEDROCK_REGION=us-west-2
 ```
 
 !!! tip "Cost"
-    Each `yo ml-container-creator` run with smart mode enabled makes one Bedrock API call per server. With Claude Sonnet 4, this typically costs a fraction of a cent per invocation.
+    Each `yo @aws/ml-container-creator` run with smart mode enabled makes one Bedrock API call per server. With Claude Sonnet 4, this typically costs a fraction of a cent per invocation.
 
 ## Graceful Degradation
 
@@ -330,7 +330,7 @@ await server.connect(transport)
 Register it:
 
 ```bash
-yo ml-container-creator mcp add my-server -- node path/to/my-server.js
+yo @aws/ml-container-creator mcp add my-server -- node path/to/my-server.js
 ```
 
 See `servers/README.md` for the full directory structure and license requirements for bundled servers.

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -76,7 +76,7 @@ Profiles provide pre-configured optimization settings for common use cases:
 **Example Usage:**
 
 ```bash
-yo ml-container-creator \
+yo @aws/ml-container-creator \
   --framework=transformers \
   --model-server=vllm \
   --framework-version=0.4.0 \
@@ -183,7 +183,7 @@ When you run the generator, registries are loaded automatically:
 The generator matches your selections against registry entries:
 
 ```bash
-yo ml-container-creator \
+yo @aws/ml-container-creator \
   --framework=transformers \
   --model-server=vllm \
   --model-name="meta-llama/Llama-2-7b-chat-hf"
@@ -224,7 +224,7 @@ The registry system validates environment variables against framework requiremen
 ### View Available Frameworks
 
 ```bash
-yo ml-container-creator --help
+yo @aws/ml-container-creator --help
 ```
 
 Look for the "REGISTRY SYSTEM" section showing available frameworks and versions.
@@ -266,7 +266,7 @@ Or via CLI:
 If you don't have internet access or want to skip HuggingFace API lookups:
 
 ```bash
-yo ml-container-creator --offline
+yo @aws/ml-container-creator --offline
 ```
 
 This disables:
@@ -298,10 +298,10 @@ By default, the generator validates environment variables:
 
 ```bash
 # Enable validation (default)
-yo ml-container-creator --validate-env-vars=true
+yo @aws/ml-container-creator --validate-env-vars=true
 
 # Disable validation
-yo ml-container-creator --validate-env-vars=false
+yo @aws/ml-container-creator --validate-env-vars=false
 ```
 
 **What gets validated:**
@@ -315,7 +315,7 @@ yo ml-container-creator --validate-env-vars=false
 For advanced validation, enable Docker introspection:
 
 ```bash
-yo ml-container-creator \
+yo @aws/ml-container-creator \
   --validate-env-vars=true \
   --validate-with-docker=true
 ```
@@ -337,7 +337,7 @@ The registry is community-driven. You can contribute:
 Try a new framework version and report results:
 
 ```bash
-yo ml-container-creator \
+yo @aws/ml-container-creator \
   --framework=transformers \
   --model-server=vllm \
   --framework-version=0.5.0
@@ -434,7 +434,7 @@ For enterprise deployments, you can maintain a custom registry:
 
 ```bash
 export REGISTRY_PATH=/path/to/custom/registries
-yo ml-container-creator
+yo @aws/ml-container-creator
 ```
 
 ### Registry Versioning

--- a/docs/template-system.md
+++ b/docs/template-system.md
@@ -197,7 +197,7 @@ Document the new template and when it's included/excluded.
 npm link
 
 # Run generator
-yo ml-container-creator
+yo @aws/ml-container-creator
 
 # Test different configurations
 # - sklearn + flask

--- a/generators/app/config/registries/frameworks.js
+++ b/generators/app/config/registries/frameworks.js
@@ -386,5 +386,124 @@ export default {
             },
             notes: 'DJL Serving 0.32.0 with PyTorch backend. Flexible Java-based serving framework with Python engine support'
         }
+    },
+    'triton-fil': {
+        '24.08': {
+            baseImage: 'nvcr.io/nvidia/tritonserver:24.08-py3',
+            accelerator: {
+                type: 'cuda',
+                version: '12.5',
+                versionRange: { min: '12.0', max: '12.6' }
+            },
+            envVars: {
+                'TRITON_MODEL_REPOSITORY': '/opt/ml/model/model_repository'
+            },
+            inferenceAmiVersion: 'al2-ami-sagemaker-inference-gpu-3-2',
+            recommendedInstanceTypes: ['ml.g5.xlarge', 'ml.g5.2xlarge'],
+            validationLevel: 'experimental',
+            notes: 'Triton FIL backend for tree-based models (XGBoost, LightGBM). GPU optional but recommended for performance'
+        }
+    },
+    'triton-onnxruntime': {
+        '24.08': {
+            baseImage: 'nvcr.io/nvidia/tritonserver:24.08-py3',
+            accelerator: {
+                type: 'cuda',
+                version: '12.5',
+                versionRange: { min: '12.0', max: '12.6' }
+            },
+            envVars: {
+                'TRITON_MODEL_REPOSITORY': '/opt/ml/model/model_repository'
+            },
+            inferenceAmiVersion: 'al2-ami-sagemaker-inference-gpu-3-2',
+            recommendedInstanceTypes: ['ml.g5.xlarge', 'ml.g5.2xlarge'],
+            validationLevel: 'experimental',
+            notes: 'Triton ONNX Runtime backend for ONNX models. GPU optional but recommended for performance'
+        }
+    },
+    'triton-tensorflow': {
+        '24.08': {
+            baseImage: 'nvcr.io/nvidia/tritonserver:24.08-py3',
+            accelerator: {
+                type: 'cuda',
+                version: '12.5',
+                versionRange: { min: '12.0', max: '12.6' }
+            },
+            envVars: {
+                'TRITON_MODEL_REPOSITORY': '/opt/ml/model/model_repository'
+            },
+            inferenceAmiVersion: 'al2-ami-sagemaker-inference-gpu-3-2',
+            recommendedInstanceTypes: ['ml.g5.xlarge', 'ml.g5.2xlarge'],
+            validationLevel: 'experimental',
+            notes: 'Triton TensorFlow backend for SavedModel format. GPU optional but recommended for performance'
+        }
+    },
+    'triton-pytorch': {
+        '24.08': {
+            baseImage: 'nvcr.io/nvidia/tritonserver:24.08-py3',
+            accelerator: {
+                type: 'cuda',
+                version: '12.5',
+                versionRange: { min: '12.0', max: '12.6' }
+            },
+            envVars: {
+                'TRITON_MODEL_REPOSITORY': '/opt/ml/model/model_repository'
+            },
+            inferenceAmiVersion: 'al2-ami-sagemaker-inference-gpu-3-2',
+            recommendedInstanceTypes: ['ml.g5.xlarge', 'ml.g5.2xlarge'],
+            validationLevel: 'experimental',
+            notes: 'Triton PyTorch backend for TorchScript models. GPU recommended for performance'
+        }
+    },
+    'triton-vllm': {
+        '24.08': {
+            baseImage: 'nvcr.io/nvidia/tritonserver:24.08-py3',
+            accelerator: {
+                type: 'cuda',
+                version: '12.5',
+                versionRange: { min: '12.0', max: '12.6' }
+            },
+            envVars: {
+                'TRITON_MODEL_REPOSITORY': '/opt/ml/model/model_repository'
+            },
+            inferenceAmiVersion: 'al2-ami-sagemaker-inference-gpu-3-2',
+            recommendedInstanceTypes: ['ml.g5.xlarge', 'ml.g5.2xlarge', 'ml.g5.4xlarge'],
+            validationLevel: 'experimental',
+            notes: 'Triton vLLM backend for LLM serving. Requires GPU instance'
+        }
+    },
+    'triton-tensorrtllm': {
+        '24.08': {
+            baseImage: 'nvcr.io/nvidia/tritonserver:24.08-py3',
+            accelerator: {
+                type: 'cuda',
+                version: '12.5',
+                versionRange: { min: '12.0', max: '12.6' }
+            },
+            envVars: {
+                'TRITON_MODEL_REPOSITORY': '/opt/ml/model/model_repository'
+            },
+            inferenceAmiVersion: 'al2-ami-sagemaker-inference-gpu-3-2',
+            recommendedInstanceTypes: ['ml.g5.2xlarge', 'ml.g5.4xlarge', 'ml.g5.12xlarge'],
+            validationLevel: 'experimental',
+            notes: 'Triton TensorRT-LLM backend for optimized LLM serving. Requires GPU instance'
+        }
+    },
+    'triton-python': {
+        '24.08': {
+            baseImage: 'nvcr.io/nvidia/tritonserver:24.08-py3',
+            accelerator: {
+                type: 'cuda',
+                version: '12.5',
+                versionRange: { min: '12.0', max: '12.6' }
+            },
+            envVars: {
+                'TRITON_MODEL_REPOSITORY': '/opt/ml/model/model_repository'
+            },
+            inferenceAmiVersion: 'al2-ami-sagemaker-inference-gpu-3-2',
+            recommendedInstanceTypes: ['ml.g5.xlarge', 'ml.g5.2xlarge'],
+            validationLevel: 'experimental',
+            notes: 'Triton Python backend for custom model serving with TritonPythonModel interface. GPU optional'
+        }
     }
 };

--- a/generators/app/config/registries/triton-backends.js
+++ b/generators/app/config/registries/triton-backends.js
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Triton Backend Metadata Registry
+ *
+ * Stores metadata for each Triton backend, used by PromptRunner and TemplateEngine
+ * to adapt prompt flow and template generation per backend.
+ *
+ * Schema:
+ * {
+ *   "backendName": {
+ *     requiresGpu: boolean,
+ *     modelFormats: string[] | null,
+ *     modelArtifactName: string | null,
+ *     requiresModelName: boolean,
+ *     supportsSampleModel: boolean
+ *   }
+ * }
+ */
+
+export default {
+    'fil': {
+        requiresGpu: false,
+        modelFormats: ['xgboost_json', 'xgboost_ubj', 'lightgbm_txt'],
+        modelArtifactName: 'xgboost.json',
+        requiresModelName: false,
+        supportsSampleModel: true
+    },
+    'onnxruntime': {
+        requiresGpu: false,
+        modelFormats: ['onnx'],
+        modelArtifactName: 'model.onnx',
+        requiresModelName: false,
+        supportsSampleModel: true
+    },
+    'tensorflow': {
+        requiresGpu: false,
+        modelFormats: ['savedmodel'],
+        modelArtifactName: 'model.savedmodel/',
+        requiresModelName: false,
+        supportsSampleModel: true
+    },
+    'pytorch': {
+        requiresGpu: false,
+        modelFormats: ['torchscript'],
+        modelArtifactName: 'model.pt',
+        requiresModelName: false,
+        supportsSampleModel: false
+    },
+    'vllm': {
+        requiresGpu: true,
+        modelFormats: null,
+        modelArtifactName: null,
+        requiresModelName: true,
+        supportsSampleModel: false
+    },
+    'tensorrtllm': {
+        requiresGpu: true,
+        modelFormats: null,
+        modelArtifactName: null,
+        requiresModelName: true,
+        supportsSampleModel: false
+    },
+    'python': {
+        requiresGpu: false,
+        modelFormats: ['pkl', 'joblib', 'custom'],
+        modelArtifactName: 'model.py',
+        requiresModelName: false,
+        supportsSampleModel: true
+    }
+}

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -7,6 +7,8 @@ import TemplateManager from './lib/template-manager.js';
 import ConfigManager from './lib/config-manager.js';
 import CliHandler from './lib/cli-handler.js';
 import ConfigurationManager from './lib/configuration-manager.js';
+import DeploymentConfigResolver from './lib/deployment-config-resolver.js';
+import tritonBackends from './config/registries/triton-backends.js';
 
 /**
  * ML Container Creator Generator
@@ -277,6 +279,12 @@ export default class extends Generator {
             if (this.baseConfig.projectName !== 'ml-container-creator') {
                 console.log(`   • Project name: ${this.baseConfig.projectName}`);
             }
+            if (this.baseConfig.deploymentConfig) {
+                console.log(`   • Deployment config: ${this.baseConfig.deploymentConfig}`);
+            }
+            if (this.baseConfig.architecture) {
+                console.log(`   • Architecture: ${this.baseConfig.architecture}`);
+            }
             if (this.baseConfig.framework) {
                 console.log(`   • Framework: ${this.baseConfig.framework}`);
             }
@@ -364,7 +372,7 @@ export default class extends Generator {
 
         // Validate environment variables if registry system is available
         // Requirements: 13.1, 13.2, 13.3, 13.4, 13.5, 13.6, 13.7, 13.19, 13.20, 13.21, 13.22, 13.23
-        if (this.registryConfigManager && this.answers.frameworkVersion) {
+        if (this.registryConfigManager && (this.answers.frameworkVersion || this.answers.architecture === 'triton')) {
             await this._validateEnvironmentVariables();
         }
 
@@ -399,6 +407,34 @@ export default class extends Generator {
             ignorePatterns.push('**/hyperpod/**');
         }
 
+        // Determine architecture from deployment-config using DeploymentConfigResolver
+        // Requirements: 4.1, 4.2, 4.3, 4.4, 5.5, 5.6
+        const resolver = new DeploymentConfigResolver();
+        let architecture = this.answers.architecture;
+        
+        // If architecture not already set, derive it from deploymentConfig
+        if (!architecture && this.answers.deploymentConfig) {
+            try {
+                const parts = resolver.decompose(this.answers.deploymentConfig);
+                architecture = parts.architecture;
+            } catch (e) {
+                // Fallback: derive from framework for backward compatibility
+                architecture = this.answers.framework === 'transformers' ? 'transformers' : 'http';
+            }
+        } else if (!architecture) {
+            // Fallback: derive from framework for backward compatibility
+            architecture = this.answers.framework === 'transformers' ? 'transformers' : 'http';
+        }
+
+        // Always exclude triton source directory from initial copy (it's a source, not output)
+        ignorePatterns.push('**/triton/**');
+
+        // For triton architecture, exclude the default Dockerfile from initial copy
+        // The triton case generates its own Dockerfile via _generateTritonFiles()
+        if (architecture === 'triton') {
+            ignorePatterns.push('**/Dockerfile');
+        }
+
         // Copy all templates, processing EJS variables
         this.fs.copyTpl(
             this.templatePath('**/*'),
@@ -408,31 +444,72 @@ export default class extends Generator {
             { globOptions: { ignore: ignorePatterns, dot: true } }
         );
 
-        // Remove files that don't belong in this deployment configuration
-        // Transformer-only files: not needed for sklearn, xgboost, tensorflow
-        if (this.answers.framework !== 'transformers') {
+        // Three-way architecture routing for file cleanup and Triton-specific generation
+        // Requirements: 4.1, 4.2, 4.3, 4.4
+        switch (architecture) {
+        case 'http':
+            // HTTP architecture: delete transformers and triton files
+            // Delete transformers-specific files
             this.fs.delete(this.destinationPath('code/chat_template.jinja'));
             this.fs.delete(this.destinationPath('code/serve'));
             this.fs.delete(this.destinationPath('code/serving.properties'));
             this.fs.delete(this.destinationPath('code/start_server.sh'));
-        }
+                
+            // Flask directory: not needed for FastAPI-based configurations
+            if (this.answers.modelServer !== 'flask' && this.answers.backend !== 'flask') {
+                this.fs.delete(this.destinationPath('code/flask/wsgi.py'));
+                this.fs.delete(this.destinationPath('code/flask/gunicorn_config.py'));
+            }
 
-        // Traditional ML files: not needed for transformers (vLLM, SGLang, TensorRT-LLM, LMI, DJL)
-        if (this.answers.framework === 'transformers') {
+            break;
+
+        case 'transformers':
+            // Transformers architecture: delete HTTP and triton files
+            // Delete HTTP-specific files
             this.fs.delete(this.destinationPath('code/model_handler.py'));
             this.fs.delete(this.destinationPath('code/serve.py'));
             this.fs.delete(this.destinationPath('code/start_server.py'));
             this.fs.delete(this.destinationPath('nginx-predictors.conf'));
-        }
-
-        // Flask directory: not needed for FastAPI-based configurations
-        if (this.answers.modelServer !== 'flask') {
+                
+            // Flask directory not needed for transformers
             this.fs.delete(this.destinationPath('code/flask/wsgi.py'));
             this.fs.delete(this.destinationPath('code/flask/gunicorn_config.py'));
+
+            break;
+
+        case 'triton':
+            // Triton architecture: delete HTTP and transformers files, generate model repository
+            // Requirements: 4.3, 4.4, 5.1, 5.2, 5.3, 5.4
+                
+            // Delete HTTP-specific files
+            this.fs.delete(this.destinationPath('code/serve.py'));
+            this.fs.delete(this.destinationPath('code/model_handler.py'));
+            this.fs.delete(this.destinationPath('code/start_server.py'));
+            this.fs.delete(this.destinationPath('nginx-predictors.conf'));
+            this.fs.delete(this.destinationPath('code/flask/wsgi.py'));
+            this.fs.delete(this.destinationPath('code/flask/gunicorn_config.py'));
+                
+            // Delete transformers-specific files
+            this.fs.delete(this.destinationPath('code/chat_template.jinja'));
+            this.fs.delete(this.destinationPath('code/serve'));
+            this.fs.delete(this.destinationPath('code/serving.properties'));
+            this.fs.delete(this.destinationPath('code/start_server.sh'));
+
+            // Generate Triton-specific files (Dockerfile excluded from initial copy via ignorePatterns)
+            await this._generateTritonFiles(templateVars);
+            break;
+
+        default:
+            // Fallback to HTTP behavior for unknown architectures
+            this.fs.delete(this.destinationPath('code/chat_template.jinja'));
+            this.fs.delete(this.destinationPath('code/serve'));
+            this.fs.delete(this.destinationPath('code/serving.properties'));
+            this.fs.delete(this.destinationPath('code/start_server.sh'));
+
         }
 
         // nginx-tensorrt.conf: only needed for TensorRT-LLM
-        if (this.answers.modelServer !== 'tensorrt-llm') {
+        if (this.answers.modelServer !== 'tensorrt-llm' && this.answers.backend !== 'tensorrt-llm') {
             this.fs.delete(this.destinationPath('nginx-tensorrt.conf'));
         }
 
@@ -442,6 +519,57 @@ export default class extends Generator {
             this.destinationPath('README.md'),
             templateVars
         );
+    }
+
+    /**
+     * Generate Triton-specific files including model repository structure
+     * Requirements: 4.4, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6
+     * @private
+     * @param {Object} templateVars - Template variables for EJS processing
+     */
+    async _generateTritonFiles(templateVars) {
+        const modelName = this.answers.modelName || 'model';
+        const backend = this.answers.backend;
+        
+        // Copy Triton Dockerfile
+        this.fs.copyTpl(
+            this.templatePath('triton/Dockerfile'),
+            this.destinationPath('Dockerfile'),
+            templateVars
+        );
+        
+        // Create model repository directory structure
+        // model_repository/<model-name>/config.pbtxt
+        // model_repository/<model-name>/1/
+        const modelRepoPath = `model_repository/${modelName}`;
+        
+        // Copy config.pbtxt to model repository
+        this.fs.copyTpl(
+            this.templatePath('triton/config.pbtxt'),
+            this.destinationPath(`${modelRepoPath}/config.pbtxt`),
+            templateVars
+        );
+        
+        // Create version 1 directory with .gitkeep
+        this.fs.write(
+            this.destinationPath(`${modelRepoPath}/1/.gitkeep`),
+            '# Placeholder for model artifacts\n'
+        );
+        
+        // For triton-python backend only: copy model.py and requirements.txt
+        if (backend === 'python') {
+            this.fs.copyTpl(
+                this.templatePath('triton/model.py'),
+                this.destinationPath(`${modelRepoPath}/1/model.py`),
+                templateVars
+            );
+            
+            this.fs.copyTpl(
+                this.templatePath('triton/requirements.txt'),
+                this.destinationPath('triton/requirements.txt'),
+                templateVars
+            );
+        }
     }
 
     /**
@@ -460,7 +588,11 @@ export default class extends Generator {
         }
 
         // Run sample model training if requested
-        if (this.answers.includeSampleModel && this.answers.framework !== 'transformers') {
+        // Skip for transformers and ineligible Triton backends
+        const architecture = this.answers.architecture;
+        const skipSampleTraining = architecture === 'transformers' || 
+            (architecture === 'triton' && !tritonBackends[this.answers.backend]?.supportsSampleModel);
+        if (this.answers.includeSampleModel && !skipSampleTraining) {
             await this._runSampleModelTraining();
         }
         
@@ -478,8 +610,10 @@ export default class extends Generator {
         console.log('\n🤖 Training sample model...');
         console.log('This will generate the model file needed for Docker build.');
 
-        const trainingScript = this.destinationPath('sample_model/train_abalone.py');
+        const trainingScriptName = 'train_abalone.py';
+        const trainingScript = this.destinationPath(`sample_model/${trainingScriptName}`);
         const sampleModelDir = this.destinationPath('sample_model');
+        const requirementsFile = this.destinationPath('requirements.txt');
 
         try {
             // Check if training script exists
@@ -488,9 +622,35 @@ export default class extends Generator {
                 return;
             }
 
+            // Install dependencies from requirements.txt before training
+            if (this.fs.exists(requirementsFile)) {
+                console.log('📦 Installing dependencies from requirements.txt...');
+                await new Promise((resolve) => {
+                    const pipProcess = spawn('pip', ['install', '-q', '-r', requirementsFile], {
+                        cwd: this.destinationPath(),
+                        stdio: 'inherit'
+                    });
+
+                    pipProcess.on('close', (code) => {
+                        if (code === 0) {
+                            console.log('✅ Dependencies installed');
+                            resolve(true);
+                        } else {
+                            console.log('⚠️  pip install failed, training may fail due to missing dependencies');
+                            resolve(false);
+                        }
+                    });
+
+                    pipProcess.on('error', () => {
+                        console.log('⚠️  pip not found, skipping dependency install');
+                        resolve(false);
+                    });
+                });
+            }
+
             // Run the training script
             await new Promise((resolve, _reject) => {
-                const pythonProcess = spawn('python', ['train_abalone.py'], {
+                const pythonProcess = spawn('python', [trainingScriptName], {
                     cwd: sampleModelDir,
                     stdio: 'inherit'
                 });
@@ -503,7 +663,7 @@ export default class extends Generator {
                     } else {
                         console.log(`⚠️  Training script exited with code ${code}`);
                         console.log('You may need to install dependencies: pip install -r requirements.txt');
-                        console.log('Or run the training manually: python sample_model/train_abalone.py');
+                        console.log(`Or run the training manually: python sample_model/${trainingScriptName}`);
                         resolve(); // Don't fail the generator, just warn
                     }
                 });
@@ -511,14 +671,14 @@ export default class extends Generator {
                 pythonProcess.on('error', (error) => {
                     console.log('⚠️  Could not run training script automatically');
                     console.log('Error:', error.message);
-                    console.log('Please run manually: python sample_model/train_abalone.py');
+                    console.log(`Please run manually: python sample_model/${trainingScriptName}`);
                     resolve(); // Don't fail the generator, just warn
                 });
             });
 
         } catch (error) {
             console.log('⚠️  Error during sample model training:', error.message);
-            console.log('Please run manually: python sample_model/train_abalone.py');
+            console.log(`Please run manually: python sample_model/${trainingScriptName}`);
         }
     }
     
@@ -598,7 +758,22 @@ export default class extends Generator {
      */
     async _validateEnvironmentVariables() {
         // Get framework configuration
-        const frameworkConfig = this.registryConfigManager.frameworkRegistry?.[this.answers.framework]?.[this.answers.frameworkVersion];
+        // For Triton configs, look up using deploymentConfig key (e.g. 'triton-fil')
+        // For other configs, use the traditional framework/version lookup
+        // Requirements: 6.2
+        let frameworkConfig;
+        if (this.answers.architecture === 'triton' && this.answers.deploymentConfig) {
+            const tritonEntry = this.registryConfigManager.frameworkRegistry?.[this.answers.deploymentConfig];
+            if (tritonEntry) {
+                const versions = Object.keys(tritonEntry);
+                if (versions.length > 0) {
+                    frameworkConfig = tritonEntry[versions[0]];
+                }
+            }
+        }
+        if (!frameworkConfig) {
+            frameworkConfig = this.registryConfigManager.frameworkRegistry?.[this.answers.framework]?.[this.answers.frameworkVersion];
+        }
         
         if (!frameworkConfig || !frameworkConfig.envVars) {
             return; // No env vars to validate
@@ -756,6 +931,9 @@ export default class extends Generator {
             recommendedInstanceTypes: [],
             roleArn: null,
             deploymentConfig: '',
+            architecture: null,
+            backend: null,
+            engine: null,
             codebuildComputeType: null,
             codebuildProjectName: null,
             modelName: null,
@@ -780,16 +958,61 @@ export default class extends Generator {
             }
         });
 
+        // Backward compatibility: populate framework and modelServer from architecture/backend
+        // so EJS templates that use <%= framework %> and <%= modelServer %> still work
+        // Requirements: 6.2
+        if (!this.answers.framework && this.answers.architecture) {
+            this.answers.framework = this.answers.architecture;
+        }
+        if (!this.answers.modelServer && this.answers.backend) {
+            this.answers.modelServer = this.answers.backend;
+        }
+
         // Always include testing with all available test types for the framework
         this.answers.includeTesting = true;
         if (!this.answers.testTypes || this.answers.testTypes.length === 0) {
-            if (this.answers.framework === 'transformers') {
+            if (this.answers.architecture === 'transformers' || this.answers.framework === 'transformers') {
                 this.answers.testTypes = ['hosted-model-endpoint'];
             } else {
                 this.answers.testTypes = ['local-model-cli', 'local-model-server', 'hosted-model-endpoint'];
             }
         }
         
+        // For Triton architecture, set default base image fallback
+        // Requirements: 10.1, 10.2
+        if (this.answers.architecture === 'triton' && !this.answers.baseImage) {
+            // Try to look up base image from framework registry using deployment-config key
+            const tritonRegistryKey = this.answers.deploymentConfig; // e.g. 'triton-fil'
+            if (tritonRegistryKey && this.registryConfigManager?.frameworkRegistry) {
+                const tritonFrameworkConfig = this.registryConfigManager.frameworkRegistry[tritonRegistryKey];
+                if (tritonFrameworkConfig) {
+                    // Get the latest version entry
+                    const versions = Object.keys(tritonFrameworkConfig).sort((a, b) =>
+                        b.localeCompare(a, undefined, { numeric: true })
+                    );
+                    if (versions.length > 0) {
+                        const latestConfig = tritonFrameworkConfig[versions[0]];
+                        if (latestConfig.baseImage) {
+                            this.answers.baseImage = latestConfig.baseImage;
+                        }
+                        if (latestConfig.envVars) {
+                            this.answers.envVars = { ...latestConfig.envVars, ...this.answers.envVars };
+                        }
+                        if (latestConfig.inferenceAmiVersion && !this.answers.inferenceAmiVersion) {
+                            this.answers.inferenceAmiVersion = latestConfig.inferenceAmiVersion;
+                        }
+                        if (latestConfig.accelerator) {
+                            this.answers.accelerator = latestConfig.accelerator;
+                        }
+                    }
+                }
+            }
+            // Final fallback: hardcoded default Triton base image
+            if (!this.answers.baseImage) {
+                this.answers.baseImage = 'nvcr.io/nvidia/tritonserver:24.08-py3';
+            }
+        }
+
         // For transformer models, try to enrich with registry data if available
         if (this.answers.framework === 'transformers' && this.answers.modelName && this.registryConfigManager) {
             try {

--- a/generators/app/lib/cli-handler.js
+++ b/generators/app/lib/cli-handler.js
@@ -5,9 +5,9 @@
  * CLI Handler - Handles special CLI arguments and commands
  * 
  * Supports behavioral CLI arguments like:
- * - yo ml-container-creator configure
- * - yo ml-container-creator generate-empty-config
- * - yo ml-container-creator --help
+ * - yo @aws/ml-container-creator configure
+ * - yo @aws/ml-container-creator generate-empty-config
+ * - yo @aws/ml-container-creator --help
  */
 
 import fs from 'fs';
@@ -143,7 +143,7 @@ export default class CliHandler {
 🚀 ML Container Creator Generator
 
 USAGE:
-  yo ml-container-creator [command] [project-name] [options]
+  yo @aws/ml-container-creator [command] [project-name] [options]
 
 COMMANDS:
   configure              Interactive configuration setup
@@ -151,11 +151,11 @@ COMMANDS:
   help                   Show this help message
 
 EXAMPLES:
-  yo ml-container-creator                           # Interactive mode
-  yo ml-container-creator my-project               # With project name
-  yo ml-container-creator --skip-prompts           # Skip prompts, use config
-  yo ml-container-creator --framework=sklearn      # With CLI options
-  yo ml-container-creator --config=prod.json       # With config file
+  yo @aws/ml-container-creator                           # Interactive mode
+  yo @aws/ml-container-creator my-project               # With project name
+  yo @aws/ml-container-creator --skip-prompts           # Skip prompts, use config
+  yo @aws/ml-container-creator --framework=sklearn      # With CLI options
+  yo @aws/ml-container-creator --config=prod.json       # With config file
 
 CLI OPTIONS:
   --skip-prompts              Skip interactive prompts
@@ -238,7 +238,7 @@ CONFIGURATION FILES (in precedence order):
 
 TRANSFORMER MODEL EXAMPLES:
   # vLLM with Llama-2 7B
-  yo ml-container-creator --framework=transformers \\
+  yo @aws/ml-container-creator --framework=transformers \\
     --model-name=meta-llama/Llama-2-7b-chat-hf \\
     --model-server=vllm \\
     --instance-type=ml.g5.xlarge \\
@@ -246,14 +246,14 @@ TRANSFORMER MODEL EXAMPLES:
     --skip-prompts
 
   # TensorRT-LLM with custom model
-  yo ml-container-creator --framework=transformers \\
+  yo @aws/ml-container-creator --framework=transformers \\
     --model-name=openai/gpt-oss-20b \\
     --model-server=tensorrt-llm \\
     --instance-type=ml.g6.12xlarge \\
     --skip-prompts
 
   # SGLang with Mistral
-  yo ml-container-creator --framework=transformers \\
+  yo @aws/ml-container-creator --framework=transformers \\
     --model-name=mistralai/Mistral-7B-Instruct-v0.2 \\
     --model-server=sglang \\
     --instance-type=ml.g5.xlarge \\
@@ -288,7 +288,7 @@ For more information, visit: https://github.com/awslabs/ml-container-creator
 
         fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
         console.log(`\n✅ Added configuration to ${packageJsonPath}`);
-        console.log('\n📝 You can now run: yo ml-container-creator --skip-prompts');
+        console.log('\n📝 You can now run: yo @aws/ml-container-creator --skip-prompts');
     }
 
     /**
@@ -304,7 +304,7 @@ For more information, visit: https://github.com/awslabs/ml-container-creator
         }
         fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
         console.log(`\n✅ Created configuration file: ${configPath}`);
-        console.log('\n📝 You can now run: yo ml-container-creator --skip-prompts');
+        console.log('\n📝 You can now run: yo @aws/ml-container-creator --skip-prompts');
     }
 
 
@@ -405,7 +405,7 @@ export AWS_ROLE="arn:aws:iam::123456789012:role/SageMakerRole"
 export ML_CONTAINER_CREATOR_CONFIG="./my-config.json"
 
 # Then run with CLI options for core parameters:
-yo ml-container-creator --framework=sklearn --model-server=flask --model-format=pkl --skip-prompts
+yo @aws/ml-container-creator --framework=sklearn --model-server=flask --model-format=pkl --skip-prompts
 `);
     }
 
@@ -418,14 +418,14 @@ yo ml-container-creator --framework=sklearn --model-server=flask --model-format=
 💻 CLI Option Examples:
 
 # Basic sklearn project
-yo ml-container-creator my-sklearn-project \\
+yo @aws/ml-container-creator my-sklearn-project \\
   --framework=sklearn \\
   --model-server=flask \\
   --model-format=pkl \\
   --skip-prompts
 
 # Transformers project with vLLM
-yo ml-container-creator my-llm-project \\
+yo @aws/ml-container-creator my-llm-project \\
   --framework=transformers \\
   --model-name=meta-llama/Llama-2-7b-chat-hf \\
   --model-server=vllm \\
@@ -435,7 +435,7 @@ yo ml-container-creator my-llm-project \\
   --skip-prompts
 
 # TensorRT-LLM with custom instance type
-yo ml-container-creator my-tensorrt-project \\
+yo @aws/ml-container-creator my-tensorrt-project \\
   --framework=transformers \\
   --model-name=openai/gpt-oss-20b \\
   --model-server=tensorrt-llm \\
@@ -443,7 +443,7 @@ yo ml-container-creator my-tensorrt-project \\
   --skip-prompts
 
 # SGLang with Mistral model
-yo ml-container-creator my-sglang-project \\
+yo @aws/ml-container-creator my-sglang-project \\
   --framework=transformers \\
   --model-name=mistralai/Mistral-7B-Instruct-v0.2 \\
   --model-server=sglang \\
@@ -451,7 +451,7 @@ yo ml-container-creator my-sglang-project \\
   --skip-prompts
 
 # XGBoost with FastAPI and custom role
-yo ml-container-creator my-xgb-project \\
+yo @aws/ml-container-creator my-xgb-project \\
   --framework=xgboost \\
   --model-server=fastapi \\
   --model-format=json \\
@@ -461,7 +461,7 @@ yo ml-container-creator my-xgb-project \\
   --skip-prompts
 
 # CodeBuild deployment target
-yo ml-container-creator my-codebuild-project \\
+yo @aws/ml-container-creator my-codebuild-project \\
   --framework=sklearn \\
   --model-server=flask \\
   --model-format=pkl \\
@@ -471,10 +471,10 @@ yo ml-container-creator my-codebuild-project \\
   --skip-prompts
 
 # Using configuration file
-yo ml-container-creator --config=production.json --skip-prompts
+yo @aws/ml-container-creator --config=production.json --skip-prompts
 
 # With validation options
-yo ml-container-creator \\
+yo @aws/ml-container-creator \\
   --framework=transformers \\
   --model-name=meta-llama/Llama-2-7b-chat-hf \\
   --model-server=vllm \\

--- a/generators/app/lib/comment-generator.js
+++ b/generators/app/lib/comment-generator.js
@@ -48,9 +48,10 @@ export default class CommentGenerator {
             return '# No accelerator requirements specified';
         }
 
+        const frameworkLabel = config.backend || config.framework
         const lines = [
             '# Accelerator Compatibility Information',
-            `# Framework: ${config.framework} ${config.version}`,
+            `# Framework: ${frameworkLabel} ${config.version}`,
             `# Required Accelerator: ${config.accelerator.type} ${config.accelerator.version || 'any'}`
         ];
 
@@ -107,7 +108,8 @@ export default class CommentGenerator {
         }
 
         // Group environment variables by category
-        const groups = this._groupEnvVars(config.envVars, config.framework);
+        const frameworkLabel = config.backend || config.framework
+        const groups = this._groupEnvVars(config.envVars, frameworkLabel);
 
         for (const [category, vars] of Object.entries(groups)) {
             const categoryComments = [
@@ -116,7 +118,7 @@ export default class CommentGenerator {
             ];
 
             // Add warnings for specific variable types
-            const warnings = this._getEnvVarWarnings(vars, config.framework);
+            const warnings = this._getEnvVarWarnings(vars, frameworkLabel);
             if (warnings.length > 0) {
                 categoryComments.push('# Warnings:');
                 warnings.forEach(warning => {
@@ -125,7 +127,7 @@ export default class CommentGenerator {
             }
 
             // Add documentation links if available
-            const docLink = this._getDocumentationLink(config.framework, category);
+            const docLink = this._getDocumentationLink(frameworkLabel, category);
             if (docLink) {
                 categoryComments.push(`# Documentation: ${docLink}`);
             }
@@ -194,9 +196,10 @@ export default class CommentGenerator {
         ];
 
         // Framework-specific tips
-        const frameworkTips = this._getFrameworkTroubleshootingTips(config.framework);
+        const frameworkLabel = config.backend || config.framework
+        const frameworkTips = this._getFrameworkTroubleshootingTips(frameworkLabel);
         if (frameworkTips.length > 0) {
-            lines.push(`# ${config.framework} Common Issues:`);
+            lines.push(`# ${frameworkLabel} Common Issues:`);
             frameworkTips.forEach(tip => {
                 lines.push(`#   - ${tip}`);
             });
@@ -257,11 +260,12 @@ export default class CommentGenerator {
      * @returns {string} Deployment header comment
      */
     generateDeploymentHeader(config) {
+        const frameworkLabel = config.backend || config.framework
         const lines = [
             '#!/bin/bash',
             '#',
             '# SageMaker Deployment Script',
-            `# Framework: ${config.framework} ${config.version}`,
+            `# Framework: ${frameworkLabel} ${config.version}`,
             `# Generated: ${config.generatedAt || new Date().toISOString().split('T')[0]}`,
             '#'
         ];
@@ -431,7 +435,11 @@ export default class CommentGenerator {
             'vllm': 'https://docs.vllm.ai/en/latest/serving/env_vars.html',
             'tensorrt-llm': 'https://nvidia.github.io/TensorRT-LLM/',
             'sglang': 'https://sgl-project.github.io/',
-            'transformers': 'https://huggingface.co/docs/transformers/'
+            'transformers': 'https://huggingface.co/docs/transformers/',
+            'fil': 'https://github.com/triton-inference-server/fil_backend',
+            'onnxruntime': 'https://onnxruntime.ai/docs/',
+            'tensorrtllm': 'https://nvidia.github.io/TensorRT-LLM/',
+            'triton-python': 'https://github.com/triton-inference-server/python_backend'
         };
 
         return links[framework?.toLowerCase()] || null;
@@ -477,6 +485,26 @@ export default class CommentGenerator {
                 'Verify model files are present in /opt/ml/model/',
                 'Check tokenizer configuration for chat models',
                 'Ensure sufficient memory for model loading'
+            ],
+            'fil': [
+                'Verify model format matches config.pbtxt backend setting',
+                'Check that model file is in the correct version directory',
+                'Ensure input tensor dimensions match your model features'
+            ],
+            'onnxruntime': [
+                'Verify ONNX model was exported correctly',
+                'Check input/output tensor names match config.pbtxt',
+                'Ensure ONNX opset version is supported by the runtime'
+            ],
+            'tensorrtllm': [
+                'Ensure CUDA version matches TensorRT-LLM requirements',
+                'Model must be converted to TensorRT format before deployment',
+                'Check GPU memory is sufficient for the model'
+            ],
+            'python': [
+                'Verify model.py implements initialize(), execute(), finalize()',
+                'Check that dependencies are listed in requirements.txt',
+                'Ensure model artifacts are in the correct version directory'
             ]
         };
 

--- a/generators/app/lib/config-manager.js
+++ b/generators/app/lib/config-manager.js
@@ -19,6 +19,8 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'node:url';
 import { McpClient } from './mcp-client.js';
+import DeploymentConfigResolver from './deployment-config-resolver.js';
+import tritonBackends from '../config/registries/triton-backends.js';
 
 // Resolve the generator project root (three levels up from generators/app/lib/)
 const __filename = fileURLToPath(import.meta.url);
@@ -54,6 +56,7 @@ export default class ConfigManager {
         this.generator = generator;
         this.config = {};
         this.skipPrompts = false;
+        this.deploymentConfigResolver = new DeploymentConfigResolver();
         this.parameterMatrix = this._getParameterMatrix();
         this.mcpSources = {};
         this.mcpChoices = {};
@@ -128,18 +131,20 @@ export default class ConfigManager {
             }
         });
 
-        // Derive framework and modelServer from deploymentConfig if present.
-        // In prompted mode the PromptRunner does this split, but in --skip-prompts
+        // Derive architecture, backend, and engine from deploymentConfig using DeploymentConfigResolver.
+        // In prompted mode the PromptRunner may do this, but in --skip-prompts
         // mode we need to do it here so the values are available for downstream logic.
         if (finalConfig.deploymentConfig) {
-            const parts = finalConfig.deploymentConfig.split('-');
-            const derivedFramework = parts[0];
-            const derivedModelServer = parts.slice(1).join('-');
-            if (!finalConfig.framework || finalConfig.framework === null) {
-                finalConfig.framework = derivedFramework;
-            }
-            if (!finalConfig.modelServer || finalConfig.modelServer === null) {
-                finalConfig.modelServer = derivedModelServer;
+            const parts = this.deploymentConfigResolver.decompose(finalConfig.deploymentConfig)
+            finalConfig.architecture = parts.architecture
+            finalConfig.backend = parts.backend
+            // For http architecture, engine comes from the --engine CLI option or prompt
+            if (parts.architecture === 'http') {
+                if (!finalConfig.engine) {
+                    finalConfig.engine = parts.engine
+                }
+            } else {
+                finalConfig.engine = parts.engine
             }
         }
 
@@ -150,30 +155,25 @@ export default class ConfigManager {
                     (finalConfig[param] === null || finalConfig[param] === undefined)) {
                     
                     // Provide reasonable defaults for missing required parameters
-                    if (param === 'framework') {
-                        finalConfig[param] = 'sklearn'; // Default framework
-                    } else if (param === 'modelServer') {
-                        // Infer model server from framework
-                        const framework = finalConfig.framework || 'sklearn';
-                        finalConfig[param] = framework === 'transformers' ? 'vllm' : 'flask';
-                    } else if (param === 'modelFormat') {
-                        // Infer model format from framework (skip for transformers)
-                        const framework = finalConfig.framework || 'sklearn';
-                        if (framework !== 'transformers') {
+                    if (param === 'modelFormat') {
+                        // Infer model format from architecture/engine (skip for transformers/triton)
+                        const architecture = finalConfig.architecture || 'http'
+                        if (architecture === 'http') {
+                            const engine = finalConfig.engine || 'sklearn'
                             const formatMap = {
                                 'sklearn': 'pkl',
                                 'xgboost': 'json',
                                 'tensorflow': 'keras'
-                            };
-                            finalConfig[param] = formatMap[framework] || 'pkl';
+                            }
+                            finalConfig[param] = formatMap[engine] || 'pkl'
                         }
                     } else if (param === 'instanceType') {
-                        // Default to ml.m5.large for traditional ML, ml.g5.xlarge for transformers
-                        const framework = finalConfig.framework || 'sklearn';
-                        finalConfig[param] = framework === 'transformers' ? 'ml.g5.xlarge' : 'ml.m5.large';
+                        // Default to ml.m5.large for http, ml.g5.xlarge for transformers/triton
+                        const architecture = finalConfig.architecture || 'http'
+                        finalConfig[param] = architecture === 'http' ? 'ml.m5.large' : 'ml.g5.xlarge'
                     } else if (param === 'projectName') {
                         // Generate project name
-                        finalConfig[param] = this._generateProjectName(finalConfig.framework);
+                        finalConfig[param] = this._generateProjectName(finalConfig.architecture)
                     } else if (config.default !== null) {
                         // Use default value if available
                         finalConfig[param] = config.default;
@@ -188,8 +188,8 @@ export default class ConfigManager {
                 (finalConfig[param] === null || finalConfig[param] === undefined)) {
                 
                 if (param === 'projectName') {
-                    // Generate project name based on framework or use default
-                    finalConfig[param] = this._generateProjectName(finalConfig.framework);
+                    // Generate project name based on architecture or use default
+                    finalConfig[param] = this._generateProjectName(finalConfig.architecture);
                 } else if (config.default !== null) {
                     // Use default value if available
                     finalConfig[param] = config.default;
@@ -197,10 +197,15 @@ export default class ConfigManager {
             }
         });
 
-        // Apply framework-specific overrides
-        if (finalConfig.framework === 'transformers') {
-            // Transformers don't support sample models
+        // Apply architecture-specific overrides
+        if (finalConfig.architecture === 'transformers') {
             finalConfig.includeSampleModel = false;
+        }
+        if (finalConfig.architecture === 'triton') {
+            const backendMeta = tritonBackends[finalConfig.backend];
+            if (!backendMeta || !backendMeta.supportsSampleModel) {
+                finalConfig.includeSampleModel = false;
+            }
         }
         
         // Set destinationDir based on projectName if not explicitly provided via --project-dir
@@ -227,7 +232,7 @@ export default class ConfigManager {
         if ((finalConfig.buildTarget === 'codebuild' || finalConfig.deployTarget === 'codebuild') && !finalConfig.codebuildProjectName) {
             finalConfig.codebuildProjectName = this._generateCodeBuildProjectName(
                 finalConfig.projectName, 
-                finalConfig.framework
+                finalConfig.architecture
             );
         }
 
@@ -280,29 +285,40 @@ export default class ConfigManager {
                 packageJson: false,
                 mcp: false,
                 promptable: true,
-                required: false,  // Not required because we support backward compatibility with framework + modelServer
+                required: true,
                 default: null,
                 valueSpace: 'bounded'
             },
-            framework: {
-                cliOption: 'framework',
+            architecture: {
+                cliOption: null,
+                envVar: null,
+                configFile: false,
+                packageJson: false,
+                mcp: false,
+                promptable: false,
+                required: false,
+                default: null,
+                valueSpace: 'bounded'
+            },
+            backend: {
+                cliOption: null,
+                envVar: null,
+                configFile: false,
+                packageJson: false,
+                mcp: false,
+                promptable: false,
+                required: false,
+                default: null,
+                valueSpace: 'bounded'
+            },
+            engine: {
+                cliOption: 'engine',
                 envVar: null,
                 configFile: true,
                 packageJson: false,
                 mcp: false,
                 promptable: true,
-                required: true,
-                default: null,
-                valueSpace: 'bounded'
-            },
-            modelServer: {
-                cliOption: 'model-server',
-                envVar: null,
-                configFile: true,
-                packageJson: false,
-                mcp: false,
-                promptable: true,
-                required: true,
+                required: false,
                 default: null,
                 valueSpace: 'bounded'
             },
@@ -898,15 +914,18 @@ export default class ConfigManager {
             .filter(([_param, config]) => config.required && config.promptable)
             .map(([param]) => param);
         
-        // Special case: modelFormat is not required for transformers
-        const requiredForFramework = promptableRequired.filter(param => {
-            if (param === 'modelFormat' && this.config.framework === 'transformers') {
-                return false;
+        // Special case: modelFormat is not required for transformers/triton architectures
+        const requiredForConfig = promptableRequired.filter(param => {
+            if (param === 'modelFormat') {
+                const architecture = this.config.architecture
+                if (architecture === 'transformers' || architecture === 'triton') {
+                    return false
+                }
             }
             return true;
         });
         
-        return requiredForFramework.every(key => 
+        return requiredForConfig.every(key => 
             this.config[key] !== undefined && this.config[key] !== null
         );
     }
@@ -918,31 +937,52 @@ export default class ConfigManager {
      */
     validateConfiguration() {
         const errors = [];
-        const supportedOptions = this._getSupportedOptions();
 
-        // Validate framework
-        if (this.config.framework && !supportedOptions.frameworks.includes(this.config.framework)) {
-            errors.push(`Unsupported framework: ${this.config.framework}. Supported: ${supportedOptions.frameworks.join(', ')}`);
+        // Old-format deployment-config migration messages
+        const oldFormatMigration = {
+            'sklearn-flask': 'Use --deployment-config=http-flask --engine=sklearn instead',
+            'sklearn-fastapi': 'Use --deployment-config=http-fastapi --engine=sklearn instead',
+            'xgboost-flask': 'Use --deployment-config=http-flask --engine=xgboost instead',
+            'xgboost-fastapi': 'Use --deployment-config=http-fastapi --engine=xgboost instead',
+            'tensorflow-flask': 'Use --deployment-config=http-flask --engine=tensorflow instead',
+            'tensorflow-fastapi': 'Use --deployment-config=http-fastapi --engine=tensorflow instead'
         }
 
-        // Validate model server based on framework
-        if (this.config.modelServer && this.config.framework) {
-            const validServers = supportedOptions.modelServers[this.config.framework] || [];
-            if (!validServers.includes(this.config.modelServer)) {
-                // Special error message for tensorrt-llm with non-transformers framework
-                if (this.config.modelServer === 'tensorrt-llm' && this.config.framework !== 'transformers') {
-                    errors.push('TensorRT-LLM is only supported with the transformers framework. Please select "transformers" as your framework or choose a different model server.');
-                } else {
-                    errors.push(`Unsupported model server '${this.config.modelServer}' for framework '${this.config.framework}'. Supported: ${validServers.join(', ')}`);
-                }
+        // Validate deployment-config
+        if (this.config.deploymentConfig) {
+            const migrationMsg = oldFormatMigration[this.config.deploymentConfig]
+            if (migrationMsg) {
+                errors.push(`Unsupported deployment-config: ${this.config.deploymentConfig}. This value has been replaced. ${migrationMsg}`)
+            } else if (!this.deploymentConfigResolver.isValid(this.config.deploymentConfig)) {
+                const valid = this.deploymentConfigResolver.getAllConfigs().join(', ')
+                errors.push(`Unsupported deployment-config: ${this.config.deploymentConfig}. Valid configs: ${valid}`)
             }
         }
 
-        // Validate model format based on framework (transformers don't need model format)
-        if (this.config.modelFormat && this.config.framework) {
-            const validFormats = supportedOptions.modelFormats[this.config.framework] || [];
-            if (validFormats.length > 0 && !validFormats.includes(this.config.modelFormat)) {
-                errors.push(`Unsupported model format '${this.config.modelFormat}' for framework '${this.config.framework}'. Supported: ${validFormats.join(', ')}`);
+        // Validate engine (only valid for http architecture)
+        if (this.config.engine) {
+            const validEngines = ['sklearn', 'xgboost', 'tensorflow']
+            if (!validEngines.includes(this.config.engine)) {
+                errors.push(`Unsupported engine: ${this.config.engine}. Supported: ${validEngines.join(', ')}`)
+            }
+        }
+
+        // Validate model format based on architecture/engine
+        if (this.config.modelFormat && this.config.deploymentConfig) {
+            try {
+                const parts = this.deploymentConfigResolver.decompose(this.config.deploymentConfig)
+                if (parts.architecture === 'http') {
+                    const engine = this.config.engine || parts.engine
+                    if (engine) {
+                        const supportedOptions = this._getSupportedOptions()
+                        const validFormats = supportedOptions.modelFormats[engine] || []
+                        if (validFormats.length > 0 && !validFormats.includes(this.config.modelFormat)) {
+                            errors.push(`Unsupported model format '${this.config.modelFormat}' for engine '${engine}'. Supported: ${validFormats.join(', ')}`)
+                        }
+                    }
+                }
+            } catch {
+                // deploymentConfig already flagged as invalid above
             }
         }
 
@@ -961,13 +1001,13 @@ export default class ConfigManager {
 
         // Validate build target (renamed from deployTarget)
         const buildTarget = this.config.buildTarget || this.config.deployTarget;
-        if (buildTarget && !supportedOptions.buildTargets.includes(buildTarget)) {
-            errors.push(`Unsupported build target: ${buildTarget}. Supported targets: ${supportedOptions.buildTargets.join(', ')}`);
+        if (buildTarget && !this._getSupportedOptions().buildTargets.includes(buildTarget)) {
+            errors.push(`Unsupported build target: ${buildTarget}. Supported targets: ${this._getSupportedOptions().buildTargets.join(', ')}`);
         }
 
         // Validate CodeBuild compute type
-        if (this.config.codebuildComputeType && !supportedOptions.codebuildComputeTypes.includes(this.config.codebuildComputeType)) {
-            errors.push(`Unsupported CodeBuild compute type: ${this.config.codebuildComputeType}. Supported types: ${supportedOptions.codebuildComputeTypes.join(', ')}`);
+        if (this.config.codebuildComputeType && !this._getSupportedOptions().codebuildComputeTypes.includes(this.config.codebuildComputeType)) {
+            errors.push(`Unsupported CodeBuild compute type: ${this.config.codebuildComputeType}. Supported types: ${this._getSupportedOptions().codebuildComputeTypes.join(', ')}`);
         }
 
         // Validate CodeBuild project name format
@@ -985,9 +1025,17 @@ export default class ConfigManager {
                 if (config.required && 
                     (this.config[param] === null || this.config[param] === undefined)) {
                     
-                    // Special case: modelFormat is not required for transformers
-                    if (param === 'modelFormat' && this.config.framework === 'transformers') {
-                        return; // Skip validation for transformers
+                    // Special case: modelFormat is not required for transformers/triton
+                    if (param === 'modelFormat') {
+                        try {
+                            const parts = this.deploymentConfigResolver.decompose(this.config.deploymentConfig)
+                            if (parts.architecture === 'transformers' || parts.architecture === 'triton') {
+                                return
+                            }
+                        } catch {
+                            // If deploymentConfig is invalid, skip this check
+                            return
+                        }
                     }
                     
                     // Only error for promptable required parameters that have no default and can't be auto-generated
@@ -1031,9 +1079,9 @@ export default class ConfigManager {
                 const value = finalConfig[param];
                 const isEmpty = value === null || value === undefined || value === '';
                 
-                // Special case: modelFormat is not required for transformers
-                if (param === 'modelFormat' && finalConfig.framework === 'transformers') {
-                    return; // Skip validation for transformers
+                // Special case: modelFormat is not required for transformers/triton
+                if (param === 'modelFormat' && (finalConfig.architecture === 'transformers' || finalConfig.architecture === 'triton')) {
+                    return; // Skip validation
                 }
                 
                 // Special case: instanceType is not required for hyperpod-eks
@@ -1046,7 +1094,7 @@ export default class ConfigManager {
                 if (isEmpty) {
                     if (config.promptable) {
                         // Promptable required parameter is missing - this should not happen after prompting
-                        errors.push(`Required parameter '${param}' is missing. This parameter is required for ${finalConfig.framework || 'the selected'} framework.`);
+                        errors.push(`Required parameter '${param}' is missing. This parameter is required for ${finalConfig.architecture || 'the selected'} architecture.`);
                     } else {
                         // Non-promptable required parameter is missing - this is a configuration error
                         errors.push(`Required non-promptable parameter '${param}' is missing. This parameter must be provided through CLI options, environment variables, or configuration files.`);
@@ -1074,9 +1122,16 @@ export default class ConfigManager {
         // Additional combination validations that aren't covered by individual parameter validation
         // For example, complex business rules that involve multiple parameters
         
-        // Validate that transformers framework has sample model disabled
-        if (config.framework === 'transformers' && config.includeSampleModel === true) {
-            errors.push('Framework \'transformers\' does not support sample models. The \'includeSampleModel\' parameter will be automatically set to false.');
+        // Validate that transformers architecture has sample model disabled
+        if (config.architecture === 'transformers' && config.includeSampleModel === true) {
+            errors.push(`Architecture '${config.architecture}' does not support sample models. The 'includeSampleModel' parameter will be automatically set to false.`);
+        }
+        // Validate that ineligible Triton backends have sample model disabled
+        if (config.architecture === 'triton' && config.includeSampleModel === true) {
+            const backendMeta = tritonBackends[config.backend];
+            if (!backendMeta || !backendMeta.supportsSampleModel) {
+                errors.push(`Triton backend '${config.backend}' does not support sample models. The 'includeSampleModel' parameter will be automatically set to false.`);
+            }
         }
 
         return errors;
@@ -1091,9 +1146,7 @@ export default class ConfigManager {
     _canAutoGenerate(param) {
         // Parameters that can be auto-generated even when missing
         const autoGeneratable = [
-            'framework',     // Can default to a reasonable choice
-            'modelServer',   // Can be inferred from framework
-            'modelFormat',   // Can be inferred from framework
+            'modelFormat',        // Can be inferred from engine
             'includeSampleModel', // Has default
             'includeTesting',     // Has default
             'instanceType'        // Has default
@@ -1108,17 +1161,16 @@ export default class ConfigManager {
      * @returns {string} Generated project name
      * @private
      */
-    _generateProjectName(framework) {
+    _generateProjectName(architecture) {
         const adjectives = [
             'smart', 'fast', 'clever', 'bright', 'swift', 'agile', 'sharp', 'quick',
             'wise', 'keen', 'bold', 'sleek', 'neat', 'cool', 'fresh', 'prime'
         ];
         
-        const frameworkNames = {
-            'sklearn': ['sklearn', 'scikit', 'sk'],
-            'xgboost': ['xgb', 'xgboost', 'boost'],
-            'tensorflow': ['tf', 'tensorflow', 'tensor'],
-            'transformers': ['llm', 'transformer', 'gpt', 'bert', 'ai']
+        const architectureNames = {
+            'http': ['http', 'api', 'serve'],
+            'transformers': ['llm', 'transformer', 'gpt', 'bert', 'ai'],
+            'triton': ['triton', 'inference', 'nvidia']
         };
         
         const suffixes = [
@@ -1128,12 +1180,12 @@ export default class ConfigManager {
         
         // Get random elements
         const adjective = adjectives[Math.floor(Math.random() * adjectives.length)];
-        const frameworkName = frameworkNames[framework] ? 
-            frameworkNames[framework][Math.floor(Math.random() * frameworkNames[framework].length)] :
+        const archName = architectureNames[architecture] ? 
+            architectureNames[architecture][Math.floor(Math.random() * architectureNames[architecture].length)] :
             'ml';
         const suffix = suffixes[Math.floor(Math.random() * suffixes.length)];
         
-        return `${adjective}-${frameworkName}-${suffix}`;
+        return `${adjective}-${archName}-${suffix}`;
     }
 
     /**
@@ -1143,19 +1195,18 @@ export default class ConfigManager {
      * @returns {string} Generated CodeBuild project name
      * @private
      */
-    _generateCodeBuildProjectName(projectName, framework) {
-        const frameworkMap = {
-            'sklearn': 'sklearn',
-            'xgboost': 'xgboost', 
-            'tensorflow': 'tensorflow',
-            'transformers': 'llm'
+    _generateCodeBuildProjectName(projectName, architecture) {
+        const architectureMap = {
+            'http': 'http',
+            'transformers': 'llm',
+            'triton': 'triton'
         };
         
-        const frameworkName = frameworkMap[framework] || 'ml';
+        const archName = architectureMap[architecture] || 'ml';
         const timestamp = new Date().toISOString().slice(0, 10).replace(/-/g, ''); // YYYYMMDD
         
         // Create a descriptive name that indicates it's a build project
-        const buildProjectName = `${projectName}-${frameworkName}-build-${timestamp}`;
+        const buildProjectName = `${projectName}-${archName}-build-${timestamp}`;
         
         // Ensure it meets AWS CodeBuild naming requirements (2-255 chars, alphanumeric + hyphens/underscores)
         return buildProjectName
@@ -1178,35 +1229,55 @@ export default class ConfigManager {
         const supportedOptions = this._getSupportedOptions();
         
         switch (parameter) {
-        case 'framework':
-            if (value && !supportedOptions.frameworks.includes(value)) {
-                throw new ValidationError(
-                    `Unsupported framework: ${value}. Supported: ${supportedOptions.frameworks.join(', ')}`,
-                    parameter,
-                    value
-                );
-            }
-            break;
-                
-        case 'modelServer':
-            if (value && context.framework) {
-                const validServers = supportedOptions.modelServers[context.framework] || [];
-                if (!validServers.includes(value)) {
+        case 'deploymentConfig':
+            if (value) {
+                // Check for old-format configs with migration messages
+                const oldFormatMigration = {
+                    'sklearn-flask': 'Use --deployment-config=http-flask --engine=sklearn instead',
+                    'sklearn-fastapi': 'Use --deployment-config=http-fastapi --engine=sklearn instead',
+                    'xgboost-flask': 'Use --deployment-config=http-flask --engine=xgboost instead',
+                    'xgboost-fastapi': 'Use --deployment-config=http-fastapi --engine=xgboost instead',
+                    'tensorflow-flask': 'Use --deployment-config=http-flask --engine=tensorflow instead',
+                    'tensorflow-fastapi': 'Use --deployment-config=http-fastapi --engine=tensorflow instead'
+                }
+                const migrationMsg = oldFormatMigration[value]
+                if (migrationMsg) {
                     throw new ValidationError(
-                        `Model server '${value}' is not compatible with framework '${context.framework}'. Compatible servers: ${validServers.join(', ')}`,
+                        `Unsupported deployment-config: ${value}. This value has been replaced. ${migrationMsg}`,
                         parameter,
                         value
-                    );
+                    )
+                }
+                if (!this.deploymentConfigResolver.isValid(value)) {
+                    const valid = this.deploymentConfigResolver.getAllConfigs().join(', ')
+                    throw new ValidationError(
+                        `Unsupported deployment-config: ${value}. Valid configs: ${valid}`,
+                        parameter,
+                        value
+                    )
                 }
             }
-            break;
+            break
+
+        case 'engine':
+            if (value) {
+                const validEngines = ['sklearn', 'xgboost', 'tensorflow']
+                if (!validEngines.includes(value)) {
+                    throw new ValidationError(
+                        `Unsupported engine: ${value}. Supported: ${validEngines.join(', ')}`,
+                        parameter,
+                        value
+                    )
+                }
+            }
+            break
                 
         case 'modelFormat':
-            if (value && context.framework && context.framework !== 'transformers') {
-                const validFormats = supportedOptions.modelFormats[context.framework] || [];
+            if (value && context.architecture === 'http' && context.engine) {
+                const validFormats = supportedOptions.modelFormats[context.engine] || [];
                 if (validFormats.length > 0 && !validFormats.includes(value)) {
                     throw new ValidationError(
-                        `Model format '${value}' is not compatible with framework '${context.framework}'. Compatible formats: ${validFormats.join(', ')}`,
+                        `Model format '${value}' is not compatible with engine '${context.engine}'. Compatible formats: ${validFormats.join(', ')}`,
                         parameter,
                         value
                     );
@@ -1225,13 +1296,12 @@ export default class ConfigManager {
                         value
                     );
                 }
-                // Warn about CPU instances for transformers (but don't block)
-                if (context.framework === 'transformers') {
+                // Warn about CPU instances for transformers/triton (but don't block)
+                if (context.architecture === 'transformers' || context.architecture === 'triton') {
                     const cpuFamilies = ['t2', 't3', 't3a', 't4g', 'm4', 'm5', 'm5a', 'm5ad', 'm5d', 'm5dn', 'm5n', 'm5zn', 'm6a', 'm6g', 'm6gd', 'm6i', 'm6id', 'm6idn', 'm6in', 'c4', 'c5', 'c5a', 'c5ad', 'c5d', 'c5n', 'c6a', 'c6g', 'c6gd', 'c6gn', 'c6i', 'c6id', 'c6in', 'r4', 'r5', 'r5a', 'r5ad', 'r5b', 'r5d', 'r5dn', 'r5n', 'r6a', 'r6g', 'r6gd', 'r6i', 'r6id', 'r6idn', 'r6in'];
                     const instanceFamily = value.split('.')[1];
                     if (cpuFamilies.includes(instanceFamily)) {
-                        // This is a warning, not an error - user might know what they're doing
-                        console.warn(`⚠️  Warning: Using CPU instance ${value} with transformers framework. GPU instances are recommended for better performance.`);
+                        console.warn(`⚠️  Warning: Using CPU instance ${value} with ${context.architecture} architecture. GPU instances are recommended for better performance.`);
                     }
                 }
             }
@@ -1340,18 +1410,12 @@ export default class ConfigManager {
      */
     _getSupportedOptions() {
         return {
-            frameworks: ['sklearn', 'xgboost', 'tensorflow', 'transformers'],
-            modelServers: {
-                'sklearn': ['flask', 'fastapi'],
-                'xgboost': ['flask', 'fastapi'],
-                'tensorflow': ['flask', 'fastapi'],
-                'transformers': ['vllm', 'sglang', 'tensorrt-llm', 'lmi', 'djl']
-            },
+            deploymentConfigs: this.deploymentConfigResolver.getAllConfigs(),
+            engines: ['sklearn', 'xgboost', 'tensorflow'],
             modelFormats: {
                 'sklearn': ['pkl', 'joblib'],
                 'xgboost': ['json', 'model', 'ubj'],
-                'tensorflow': ['keras', 'h5', 'SavedModel'],
-                'transformers': [] // No format needed
+                'tensorflow': ['keras', 'h5', 'SavedModel']
             },
             buildTargets: ['codebuild'],
             codebuildComputeTypes: ['BUILD_GENERAL1_SMALL', 'BUILD_GENERAL1_MEDIUM', 'BUILD_GENERAL1_LARGE'],

--- a/generators/app/lib/deployment-config-resolver.js
+++ b/generators/app/lib/deployment-config-resolver.js
@@ -1,0 +1,100 @@
+/**
+ * DeploymentConfigResolver
+ *
+ * Decomposes a flat deployment-config string into a structured
+ * { architecture, backend, engine } triple. This is the single source
+ * of truth for all valid deployment-config values, replacing the
+ * scattered split('-') logic that was previously in ConfigManager,
+ * PromptRunner, and index.js.
+ *
+ * Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7
+ */
+
+/**
+ * Canonical mapping from deployment-config strings to structured parts.
+ * 2 http + 5 transformers + 7 triton = 14 total configs.
+ */
+const CANONICAL_CONFIGS = new Map([
+    // HTTP architecture (2)
+    ['http-flask',              { architecture: 'http',         backend: 'flask',         engine: null }],
+    ['http-fastapi',            { architecture: 'http',         backend: 'fastapi',       engine: null }],
+
+    // Transformers architecture (5)
+    ['transformers-vllm',       { architecture: 'transformers', backend: 'vllm',          engine: null }],
+    ['transformers-sglang',     { architecture: 'transformers', backend: 'sglang',        engine: null }],
+    ['transformers-tensorrt-llm', { architecture: 'transformers', backend: 'tensorrt-llm', engine: null }],
+    ['transformers-lmi',        { architecture: 'transformers', backend: 'lmi',           engine: null }],
+    ['transformers-djl',        { architecture: 'transformers', backend: 'djl',           engine: null }],
+
+    // Triton architecture (7)
+    ['triton-fil',              { architecture: 'triton',       backend: 'fil',           engine: null }],
+    ['triton-onnxruntime',      { architecture: 'triton',       backend: 'onnxruntime',   engine: null }],
+    ['triton-tensorflow',       { architecture: 'triton',       backend: 'tensorflow',    engine: null }],
+    ['triton-pytorch',          { architecture: 'triton',       backend: 'pytorch',       engine: null }],
+    ['triton-vllm',             { architecture: 'triton',       backend: 'vllm',          engine: null }],
+    ['triton-tensorrtllm',      { architecture: 'triton',       backend: 'tensorrtllm',   engine: null }],
+    ['triton-python',           { architecture: 'triton',       backend: 'python',        engine: null }],
+])
+
+export default class DeploymentConfigResolver {
+    /**
+     * Decompose a deployment-config string into its constituent parts.
+     *
+     * @param {string} deploymentConfig - e.g. 'http-flask', 'transformers-vllm', 'triton-fil'
+     * @returns {{ architecture: string, backend: string, engine: string|null }}
+     * @throws {Error} if the deployment-config is not one of the 14 canonical values
+     */
+    decompose(deploymentConfig) {
+        const parts = CANONICAL_CONFIGS.get(deploymentConfig)
+        if (!parts) {
+            const valid = this.getAllConfigs().join(', ')
+            throw new Error(
+                `Unsupported deployment-config: ${deploymentConfig}. Valid configs: ${valid}`
+            )
+        }
+        return { ...parts }
+    }
+
+    /**
+     * Compose a deployment-config string from structured parts.
+     * Inverse of decompose().
+     *
+     * @param {{ architecture: string, backend: string, engine?: string }} parts
+     * @returns {string}
+     */
+    compose(parts) {
+        return `${parts.architecture}-${parts.backend}`
+    }
+
+    /**
+     * Get all 14 valid deployment-config strings.
+     *
+     * @returns {string[]}
+     */
+    getAllConfigs() {
+        return [...CANONICAL_CONFIGS.keys()]
+    }
+
+    /**
+     * Get valid deployment-config strings for a given architecture.
+     *
+     * @param {string} architecture - 'http' | 'transformers' | 'triton'
+     * @returns {string[]}
+     */
+    getConfigsForArchitecture(architecture) {
+        return this.getAllConfigs().filter(
+            (dc) => CANONICAL_CONFIGS.get(dc).architecture === architecture
+        )
+    }
+
+    /**
+     * Check if a deployment-config string is valid.
+     * Old-format strings (e.g. 'sklearn-flask') return false.
+     *
+     * @param {string} deploymentConfig
+     * @returns {boolean}
+     */
+    isValid(deploymentConfig) {
+        return CANONICAL_CONFIGS.has(deploymentConfig)
+    }
+}

--- a/generators/app/lib/mcp-command-handler.js
+++ b/generators/app/lib/mcp-command-handler.js
@@ -73,7 +73,7 @@ export default class McpCommandHandler {
      */
     async _handleAdd(positionalArgs, options) {
         if (positionalArgs.length === 0) {
-            console.log('Usage: yo ml-container-creator mcp add <name> -- <command> [args...]');
+            console.log('Usage: yo @aws/ml-container-creator mcp add <name> -- <command> [args...]');
             return;
         }
 
@@ -97,7 +97,7 @@ export default class McpCommandHandler {
             // Find the '--' separator to split name from command
             const separatorIndex = positionalArgs.indexOf('--');
             if (separatorIndex === -1 || separatorIndex + 1 >= positionalArgs.length) {
-                console.log('Usage: yo ml-container-creator mcp add <name> -- <command> [args...]');
+                console.log('Usage: yo @aws/ml-container-creator mcp add <name> -- <command> [args...]');
                 console.log('The "--" separator is required between the server name and the command.');
                 return;
             }
@@ -233,7 +233,7 @@ export default class McpCommandHandler {
 
         if (!servers || Object.keys(servers).length === 0) {
             console.log('No MCP servers configured.');
-            console.log('Use "yo ml-container-creator mcp add <name> -- <command> [args...]" to add one.');
+            console.log('Use "yo @aws/ml-container-creator mcp add <name> -- <command> [args...]" to add one.');
             return;
         }
 
@@ -251,7 +251,7 @@ export default class McpCommandHandler {
      */
     _handleGet(name) {
         if (!name) {
-            console.log('Usage: yo ml-container-creator mcp get <name>');
+            console.log('Usage: yo @aws/ml-container-creator mcp get <name>');
             return;
         }
 
@@ -283,7 +283,7 @@ export default class McpCommandHandler {
      */
     async _handleRemove(name) {
         if (!name) {
-            console.log('Usage: yo ml-container-creator mcp remove <name>');
+            console.log('Usage: yo @aws/ml-container-creator mcp remove <name>');
             return;
         }
 
@@ -314,7 +314,7 @@ export default class McpCommandHandler {
 MCP Server Management
 
 USAGE:
-  yo ml-container-creator mcp <subcommand> [options]
+  yo @aws/ml-container-creator mcp <subcommand> [options]
 
 SUBCOMMANDS:
   init                                Add all bundled servers at once
@@ -332,14 +332,14 @@ ADD OPTIONS:
   --bundled                           Use a bundled server from servers/
 
 EXAMPLES:
-  yo ml-container-creator mcp init
-  yo ml-container-creator mcp add team-config -- node servers/instance-recommender/index.js
-  yo ml-container-creator mcp add instance-recommender --bundled
-  yo ml-container-creator mcp add corp-policy -- npx -y @corp/mcp-policy -e TEAM_ID=ml-platform
-  yo ml-container-creator mcp list
-  yo ml-container-creator mcp list --bundled
-  yo ml-container-creator mcp get team-config
-  yo ml-container-creator mcp remove team-config
+  yo @aws/ml-container-creator mcp init
+  yo @aws/ml-container-creator mcp add team-config -- node servers/instance-recommender/index.js
+  yo @aws/ml-container-creator mcp add instance-recommender --bundled
+  yo @aws/ml-container-creator mcp add corp-policy -- npx -y @corp/mcp-policy -e TEAM_ID=ml-platform
+  yo @aws/ml-container-creator mcp list
+  yo @aws/ml-container-creator mcp list --bundled
+  yo @aws/ml-container-creator mcp get team-config
+  yo @aws/ml-container-creator mcp remove team-config
 `);
     }
 
@@ -421,7 +421,7 @@ EXAMPLES:
         for (const server of servers) {
             console.log(`  ${server.name}: ${server.description}`);
         }
-        console.log('\nUse "yo ml-container-creator mcp add <name> --bundled" to add one.');
+        console.log('\nUse "yo @aws/ml-container-creator mcp add <name> --bundled" to add one.');
         console.log('');
     }
 

--- a/generators/app/lib/prompt-runner.js
+++ b/generators/app/lib/prompt-runner.js
@@ -10,6 +10,7 @@
 
 import {
     deploymentConfigPrompts,
+    enginePrompts,
     frameworkVersionPrompts,
     frameworkProfilePrompts,
     modelFormatPrompts,
@@ -30,6 +31,7 @@ import {
 } from './prompts.js';
 
 import instanceAcceleratorMapping from '../config/registries/instance-accelerator-mapping.js';
+import tritonBackends from '../config/registries/triton-backends.js';
 
 export default class PromptRunner {
     constructor(generator) {
@@ -93,32 +95,45 @@ export default class PromptRunner {
         };
 
         // Phase 2: Core ML Configuration
-        // Requirements: 3.2 — ML configuration prompts run after infrastructure
+        // Requirements: 3.1, 3.2 — ML configuration prompts run after infrastructure
         console.log('\n🔧 Core ML Configuration');
         const deploymentConfigAnswers = await this._runPhase(deploymentConfigPrompts, { ...infraAnswers }, explicitConfig, existingConfig);
         
-        // Derive framework and modelServer from deploymentConfig
-        // Requirements: 16.3
-        let framework, modelServer;
+        // Derive architecture, backend, and legacy framework/modelServer from deploymentConfig
+        // Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7
+        let architecture, backend, framework, modelServer;
         if (deploymentConfigAnswers.deploymentConfig) {
             const parts = deploymentConfigAnswers.deploymentConfig.split('-');
-            framework = parts[0];
-            // Handle multi-part model servers (e.g., tensorrt-llm)
-            modelServer = parts.slice(1).join('-');
+            architecture = parts[0];
+            backend = parts.slice(1).join('-');
+            // Legacy compatibility: derive framework and modelServer
+            framework = architecture;
+            modelServer = backend;
         }
         
         // Add derived values to answers
         const frameworkAnswers = {
             ...deploymentConfigAnswers,
+            architecture: architecture || deploymentConfigAnswers.architecture,
+            backend: backend || deploymentConfigAnswers.backend,
             framework: framework || deploymentConfigAnswers.framework,
             modelServer: modelServer || deploymentConfigAnswers.modelServer
         };
+        
+        // Engine prompt for http architecture
+        // Requirements: 3.7
+        const engineAnswers = await this._runPhase(enginePrompts, { ...frameworkAnswers }, explicitConfig, existingConfig);
+        
+        // Auto-set model format for Triton backends with single format
+        // Requirements: 3.3, 3.4, 3.5
+        const tritonAutoFormat = this._getTritonAutoModelFormat(architecture, backend);
         
         // Query base-image-picker MCP server for base image choices
         // Requirements: 5.1, 5.2, 5.3
         await this._queryMcpForBaseImage(frameworkAnswers, explicitConfig)
         const baseImagePreviousAnswers = {
             ...frameworkAnswers,
+            ...engineAnswers,
             ...(this._mcpBaseImageChoices ? { _mcpBaseImageChoices: this._mcpBaseImageChoices } : {})
         }
         const baseImageAnswers = await this._runPhase(
@@ -132,7 +147,7 @@ export default class PromptRunner {
         const frameworkVersionChoices = this._getFrameworkVersionChoices(frameworkAnswers.framework);
         const frameworkVersionAnswers = await this._runPhase(
             frameworkVersionPrompts, 
-            {...frameworkAnswers, _frameworkVersionChoices: frameworkVersionChoices}, 
+            {...frameworkAnswers, ...engineAnswers, _frameworkVersionChoices: frameworkVersionChoices}, 
             explicitConfig, 
             existingConfig
         );
@@ -149,14 +164,14 @@ export default class PromptRunner {
         );
         const frameworkProfileAnswers = await this._runPhase(
             frameworkProfilePrompts,
-            {...frameworkAnswers, ...frameworkVersionAnswers, _frameworkProfileChoices: frameworkProfileChoices},
+            {...frameworkAnswers, ...engineAnswers, ...frameworkVersionAnswers, _frameworkProfileChoices: frameworkProfileChoices},
             explicitConfig,
             existingConfig
         );
         
         const modelFormatAnswers = await this._runPhase(
             modelFormatPrompts, 
-            {...frameworkAnswers, ...frameworkVersionAnswers, ...frameworkProfileAnswers}, 
+            {...frameworkAnswers, ...engineAnswers, ...frameworkVersionAnswers, ...frameworkProfileAnswers}, 
             explicitConfig, 
             existingConfig
         );
@@ -164,13 +179,13 @@ export default class PromptRunner {
         // Model server prompts are now deprecated (empty array)
         const modelServerAnswers = await this._runPhase(
             modelServerPrompts, 
-            {...frameworkAnswers, ...frameworkVersionAnswers, ...frameworkProfileAnswers}, 
+            {...frameworkAnswers, ...engineAnswers, ...frameworkVersionAnswers, ...frameworkProfileAnswers}, 
             explicitConfig, 
             existingConfig
         );
         
         // Populate model profile choices from registry (if model ID is available)
-        const currentAnswers = {...frameworkAnswers, ...frameworkVersionAnswers, ...frameworkProfileAnswers, ...modelFormatAnswers, ...modelServerAnswers};
+        const currentAnswers = {...frameworkAnswers, ...engineAnswers, ...frameworkVersionAnswers, ...frameworkProfileAnswers, ...modelFormatAnswers, ...modelServerAnswers};
         const modelId = currentAnswers.customModelName || currentAnswers.modelName;
         
         // Fetch model information from HuggingFace and Model Registry
@@ -188,11 +203,11 @@ export default class PromptRunner {
         );
         
         const hfTokenAnswers = await this._runPhase(hfTokenPrompts, 
-            { ...frameworkAnswers, ...frameworkVersionAnswers, ...frameworkProfileAnswers, ...modelFormatAnswers, ...modelServerAnswers, ...modelProfileAnswers }, 
+            { ...frameworkAnswers, ...engineAnswers, ...frameworkVersionAnswers, ...frameworkProfileAnswers, ...modelFormatAnswers, ...modelServerAnswers, ...modelProfileAnswers }, 
             explicitConfig, existingConfig);
 
         const ngcApiKeyAnswers = await this._runPhase(ngcApiKeyPrompts,
-            { ...frameworkAnswers, ...frameworkVersionAnswers, ...frameworkProfileAnswers, ...modelFormatAnswers, ...modelServerAnswers, ...modelProfileAnswers },
+            { ...frameworkAnswers, ...engineAnswers, ...frameworkVersionAnswers, ...frameworkProfileAnswers, ...modelFormatAnswers, ...modelServerAnswers, ...modelProfileAnswers },
             explicitConfig, existingConfig);
 
         // Validate instance type against framework requirements (now that framework is known)
@@ -221,10 +236,12 @@ export default class PromptRunner {
         // Phase 3: Module Selection
         // Requirements: 3.3 — module selection after ML configuration
         console.log('\n📦 Module Selection');
-        const moduleAnswers = await this._runPhase(modulePrompts, frameworkAnswers, explicitConfig, existingConfig);
+        const moduleAnswers = await this._runPhase(modulePrompts, { ...frameworkAnswers, ...engineAnswers }, explicitConfig, existingConfig);
         
-        // Ensure transformers don't get sample model
-        if (frameworkAnswers.framework === 'transformers') {
+        // Ensure transformers and ineligible Triton backends don't get sample model
+        if (frameworkAnswers.architecture === 'transformers' ||
+            (frameworkAnswers.architecture === 'triton' && 
+             !tritonBackends[frameworkAnswers.backend]?.supportsSampleModel)) {
             moduleAnswers.includeSampleModel = false;
         }
 
@@ -233,6 +250,7 @@ export default class PromptRunner {
         console.log('\n📋 Project Configuration');
         const allTechnicalAnswers = {
             ...frameworkAnswers,
+            ...engineAnswers,
             ...modelFormatAnswers,
             ...modelServerAnswers,
             ...moduleAnswers,
@@ -242,13 +260,11 @@ export default class PromptRunner {
         const destinationAnswers = await this._runPhase(destinationPrompts, 
             { ...allTechnicalAnswers, ...projectAnswers }, explicitConfig, existingConfig);
 
-        // Deployment Instructions
-        this._showDeploymentInstructions();
-
         // Combine all answers
         const combinedAnswers = {
             ...infraAnswers,
             ...frameworkAnswers,
+            ...engineAnswers,
             ...baseImageAnswers,
             ...frameworkVersionAnswers,
             ...frameworkProfileAnswers,
@@ -263,8 +279,16 @@ export default class PromptRunner {
             buildTimestamp
         };
 
-        // Handle custom model name for transformers
-        if (combinedAnswers.framework === 'transformers' && combinedAnswers.customModelName) {
+        // Apply auto-set model format for Triton backends with single format
+        // Requirements: 3.3, 3.4, 3.5
+        if (tritonAutoFormat) {
+            combinedAnswers.modelFormat = tritonAutoFormat
+        }
+
+        // Handle custom model name for transformers and Triton LLM backends
+        if ((combinedAnswers.architecture === 'transformers' || 
+             (combinedAnswers.architecture === 'triton' && (combinedAnswers.backend === 'vllm' || combinedAnswers.backend === 'tensorrtllm'))) 
+            && combinedAnswers.customModelName) {
             combinedAnswers.modelName = combinedAnswers.customModelName;
             delete combinedAnswers.customModelName;
         }
@@ -402,16 +426,27 @@ export default class PromptRunner {
     }
 
     /**
-     * Shows deployment instructions to user
+     * Get auto-set model format for Triton backends with a single format.
+     * Returns null if the backend requires user selection (FIL, Python) or
+     * doesn't use model formats (vllm, tensorrtllm).
+     * Requirements: 3.3, 3.4, 3.5
+     * @param {string} architecture - Resolved architecture
+     * @param {string} backend - Resolved backend
+     * @returns {string|null} Auto-set model format or null
      * @private
      */
-    _showDeploymentInstructions() {
-        console.log('\n🚀 Manual Deployment');
-        console.log('\n☁️ The following steps assume authentication to an AWS account.');
-        console.log('\n💰 The following commands will incur charges to your AWS account.');
-        console.log('\t ./build_and_push.sh -- Builds the image and pushes to ECR.');
-        console.log('\t ./deploy.sh -- Deploys the image to a SageMaker AI Managed Inference Endpoint.');
-        console.log('\t\t deploy.sh needs a valid IAM Role ARN as a parameter.');
+    _getTritonAutoModelFormat(architecture, backend) {
+        if (architecture !== 'triton') return null
+
+        const meta = tritonBackends[backend]
+        if (!meta || !meta.modelFormats) return null
+
+        // Only auto-set if there's exactly one format
+        if (meta.modelFormats.length === 1) {
+            return meta.modelFormats[0]
+        }
+
+        return null
     }
 
     /**
@@ -563,11 +598,13 @@ export default class PromptRunner {
         const smart = this.generator.options.smart === true
         const framework = frameworkAnswers.framework
         const modelServer = frameworkAnswers.modelServer
+        const architecture = frameworkAnswers.architecture || frameworkAnswers.deploymentConfig?.split('-')[0]
         const isTransformer = framework === 'transformers'
+        const isTriton = architecture === 'triton'
 
-        // For non-transformer frameworks, prompt for optional search criteria
+        // For non-transformer, non-triton frameworks, prompt for optional search criteria
         let searchCriteria
-        if (!isTransformer) {
+        if (!isTransformer && !isTriton) {
             const searchAnswer = await this.generator.prompt(baseImageSearchPrompts.map(p => ({
                 ...p,
                 when: () => true // Always show for non-transformer since we already checked
@@ -577,7 +614,7 @@ export default class PromptRunner {
 
         console.log(`   🔍 Querying base-image-picker${smart ? ' [smart]' : ''}...`)
 
-        const context = { framework, modelServer }
+        const context = { framework, modelServer, architecture }
         if (searchCriteria && searchCriteria.trim()) {
             context.searchCriteria = searchCriteria.trim()
         }
@@ -586,7 +623,7 @@ export default class PromptRunner {
 
         if (result && result.metadata?.baseImage?.length > 0) {
             const entries = result.metadata.baseImage
-            this._mcpBaseImageChoices = formatImageChoices(entries, isTransformer)
+            this._mcpBaseImageChoices = formatImageChoices(entries, isTransformer || isTriton)
             const count = entries.length
             console.log(`   ✓ ${count} base image(s) available`)
         } else {

--- a/generators/app/lib/prompts.js
+++ b/generators/app/lib/prompts.js
@@ -45,8 +45,8 @@ function generateProjectName(framework) {
 
 /**
  * Phase 1: Core ML configuration (moved to first)
- * Flattened deployment configuration combining framework + model server
- * Requirements: 16.1, 16.2, 16.3, 16.4, 16.8, 16.9
+ * Flattened deployment configuration combining architecture + backend
+ * Requirements: 3.1, 3.2, 16.1, 16.2, 16.3, 16.4, 16.8, 16.9
  */
 const deploymentConfigPrompts = [
     {
@@ -80,36 +80,52 @@ const deploymentConfigPrompts = [
                 value: 'transformers-djl',
                 short: 'transformers-djl'
             },
-            { type: 'separator', separator: '── Traditional ML ──' },
+            { type: 'separator', separator: '── HTTP Serving ──' },
             {
-                name: 'scikit-learn with Flask',
-                value: 'sklearn-flask',
-                short: 'sklearn-flask'
+                name: 'HTTP with Flask',
+                value: 'http-flask',
+                short: 'http-flask'
             },
             {
-                name: 'scikit-learn with FastAPI',
-                value: 'sklearn-fastapi',
-                short: 'sklearn-fastapi'
+                name: 'HTTP with FastAPI',
+                value: 'http-fastapi',
+                short: 'http-fastapi'
+            },
+            { type: 'separator', separator: '── NVIDIA Triton Inference Server ──' },
+            {
+                name: 'Triton FIL (XGBoost, LightGBM)',
+                value: 'triton-fil',
+                short: 'triton-fil'
             },
             {
-                name: 'XGBoost with Flask',
-                value: 'xgboost-flask',
-                short: 'xgboost-flask'
+                name: 'Triton ONNX Runtime',
+                value: 'triton-onnxruntime',
+                short: 'triton-onnxruntime'
             },
             {
-                name: 'XGBoost with FastAPI',
-                value: 'xgboost-fastapi',
-                short: 'xgboost-fastapi'
+                name: 'Triton TensorFlow',
+                value: 'triton-tensorflow',
+                short: 'triton-tensorflow'
             },
             {
-                name: 'TensorFlow with Flask',
-                value: 'tensorflow-flask',
-                short: 'tensorflow-flask'
+                name: 'Triton PyTorch',
+                value: 'triton-pytorch',
+                short: 'triton-pytorch'
             },
             {
-                name: 'TensorFlow with FastAPI',
-                value: 'tensorflow-fastapi',
-                short: 'tensorflow-fastapi'
+                name: 'Triton vLLM',
+                value: 'triton-vllm',
+                short: 'triton-vllm'
+            },
+            {
+                name: 'Triton TensorRT-LLM',
+                value: 'triton-tensorrtllm',
+                short: 'triton-tensorrtllm'
+            },
+            {
+                name: 'Triton Python Backend',
+                value: 'triton-python',
+                short: 'triton-python'
             }
         ]
     }
@@ -117,6 +133,27 @@ const deploymentConfigPrompts = [
 
 // Keep legacy frameworkPrompts for backward compatibility (deprecated)
 const frameworkPrompts = deploymentConfigPrompts;
+
+/**
+ * Engine selection prompt for http architecture
+ * Requirements: 3.7
+ */
+const enginePrompts = [
+    {
+        type: 'list',
+        name: 'engine',
+        message: 'Select ML engine:',
+        choices: [
+            { name: 'scikit-learn', value: 'sklearn' },
+            { name: 'XGBoost', value: 'xgboost' },
+            { name: 'TensorFlow', value: 'tensorflow' }
+        ],
+        when: (answers) => {
+            const architecture = answers.architecture || answers.deploymentConfig?.split('-')[0]
+            return architecture === 'http'
+        }
+    }
+];
 
 /**
  * Framework version selection prompts (for registry system)
@@ -164,19 +201,71 @@ const modelFormatPrompts = [
         name: 'modelFormat',
         message: 'In which format is your model serialized?',
         choices: (answers) => {
-            // Derive framework from deploymentConfig if not already set
-            const framework = answers.framework || answers.deploymentConfig?.split('-')[0];
+            // Derive architecture from deploymentConfig
+            const architecture = answers.architecture || answers.deploymentConfig?.split('-')[0]
+            const backend = answers.backend || answers.deploymentConfig?.split('-').slice(1).join('-')
+            
+            // For http architecture, use engine to determine formats
+            if (architecture === 'http') {
+                const engine = answers.engine
+                const formatMap = {
+                    'xgboost': ['json', 'model', 'ubj'],
+                    'sklearn': ['pkl', 'joblib'],
+                    'tensorflow': ['keras', 'h5', 'SavedModel']
+                }
+                return formatMap[engine] || []
+            }
+            
+            // For triton architecture, use backend-specific formats
+            if (architecture === 'triton') {
+                // FIL backend has multiple format choices
+                if (backend === 'fil') {
+                    return ['xgboost_json', 'xgboost_ubj', 'lightgbm_txt']
+                }
+                // Python backend has multiple format choices
+                if (backend === 'python') {
+                    return ['pkl', 'joblib', 'custom']
+                }
+                // Other Triton backends have auto-set formats (handled in when clause)
+                return []
+            }
+            
+            // Legacy support for old format (should not be reached with new configs)
+            const framework = answers.framework || architecture
             const formatMap = {
                 'xgboost': ['json', 'model', 'ubj'],
                 'sklearn': ['pkl', 'joblib'],
                 'tensorflow': ['keras', 'h5', 'SavedModel']
-            };
-            return formatMap[framework] || [];
+            }
+            return formatMap[framework] || []
         },
         when: answers => {
-            // Derive framework from deploymentConfig if not already set
-            const framework = answers.framework || answers.deploymentConfig?.split('-')[0];
-            return framework !== 'transformers';
+            const architecture = answers.architecture || answers.deploymentConfig?.split('-')[0]
+            const backend = answers.backend || answers.deploymentConfig?.split('-').slice(1).join('-')
+            
+            // Skip for transformers (they use HF Hub)
+            if (architecture === 'transformers') {
+                return false
+            }
+            
+            // For http architecture, always show
+            if (architecture === 'http') {
+                return true
+            }
+            
+            // For triton architecture, only show for backends with multiple format choices
+            if (architecture === 'triton') {
+                // FIL and Python backends have multiple format choices
+                if (backend === 'fil' || backend === 'python') {
+                    return true
+                }
+                // Other backends have auto-set formats
+                return false
+            }
+            
+            // Legacy support
+            const framework = answers.framework || architecture
+            return framework !== 'transformers'
         }
     },
     {
@@ -191,9 +280,20 @@ const modelFormatPrompts = [
         ],
         default: 'openai/gpt-oss-20b',
         when: answers => {
-            // Derive framework from deploymentConfig if not already set
-            const framework = answers.framework || answers.deploymentConfig?.split('-')[0];
-            return framework === 'transformers';
+            const architecture = answers.architecture || answers.deploymentConfig?.split('-')[0]
+            const backend = answers.backend || answers.deploymentConfig?.split('-').slice(1).join('-')
+            
+            // Show for transformers architecture
+            if (architecture === 'transformers') {
+                return true
+            }
+            
+            // Show for Triton LLM backends (vllm, tensorrtllm)
+            if (architecture === 'triton' && (backend === 'vllm' || backend === 'tensorrtllm')) {
+                return true
+            }
+            
+            return false
         }
     },
     {
@@ -202,18 +302,29 @@ const modelFormatPrompts = [
         message: 'Enter the Hugging Face model path:',
         validate: (input) => {
             if (!input || input.trim() === '') {
-                return 'Model name is required for transformers';
+                return 'Model name is required'
             }
             // Basic validation for Hugging Face model format (org/model-name)
             if (!input.includes('/')) {
-                return 'Please use the full Hugging Face model path (e.g., microsoft/DialoGPT-medium)';
+                return 'Please use the full Hugging Face model path (e.g., microsoft/DialoGPT-medium)'
             }
-            return true;
+            return true
         },
         when: answers => {
-            // Derive framework from deploymentConfig if not already set
-            const framework = answers.framework || answers.deploymentConfig?.split('-')[0];
-            return framework === 'transformers' && answers.modelName === 'Custom (enter manually)';
+            const architecture = answers.architecture || answers.deploymentConfig?.split('-')[0]
+            const backend = answers.backend || answers.deploymentConfig?.split('-').slice(1).join('-')
+            
+            // Show for transformers with custom model selection
+            if (architecture === 'transformers' && answers.modelName === 'Custom (enter manually)') {
+                return true
+            }
+            
+            // Show for Triton LLM backends with custom model selection
+            if (architecture === 'triton' && (backend === 'vllm' || backend === 'tensorrtllm') && answers.modelName === 'Custom (enter manually)') {
+                return true
+            }
+            
+            return false
         }
     }
 ];
@@ -258,42 +369,48 @@ const hfTokenPrompts = [
         name: 'hfToken',
         message: 'HuggingFace token (enter token, "$HF_TOKEN" for env var, or leave empty):',
         when: (answers) => {
-            // Derive framework from deploymentConfig if not already set
-            const framework = answers.framework || answers.deploymentConfig?.split('-')[0];
+            const architecture = answers.architecture || answers.deploymentConfig?.split('-')[0]
+            const backend = answers.backend || answers.deploymentConfig?.split('-').slice(1).join('-')
             
-            // Only prompt for transformers framework
-            if (framework !== 'transformers') {
-                return false;
+            // Prompt for transformers architecture
+            const isTransformers = architecture === 'transformers'
+            
+            // Prompt for Triton LLM backends (vllm, tensorrtllm)
+            // Requirements: 9.1, 9.2
+            const isTritonLlm = architecture === 'triton' && (backend === 'vllm' || backend === 'tensorrtllm')
+            
+            if (!isTransformers && !isTritonLlm) {
+                return false
             }
             
             // Display security warning before prompting
-            console.log('\n🔐 HuggingFace Authentication');
-            console.log('   Many models (e.g. Llama, Mistral) are gated and require a token.');
-            console.log('⚠️  Security Note: The token will be baked into the Docker image.');
-            console.log('   Anyone with access to the image can extract the token using \'docker inspect\'.');
-            console.log('   For CI/CD pipelines, use "$HF_TOKEN" to reference an environment variable.');
-            console.log('   This keeps the token out of the image and allows rotation without rebuilding.\n');
+            console.log('\n🔐 HuggingFace Authentication')
+            console.log('   Many models (e.g. Llama, Mistral) are gated and require a token.')
+            console.log('⚠️  Security Note: The token will be baked into the Docker image.')
+            console.log('   Anyone with access to the image can extract the token using \'docker inspect\'.')
+            console.log('   For CI/CD pipelines, use "$HF_TOKEN" to reference an environment variable.')
+            console.log('   This keeps the token out of the image and allows rotation without rebuilding.\n')
             
-            return true;
+            return true
         },
         validate: (input) => {
             // Empty is valid (not all models require auth)
             if (!input || input.trim() === '') {
-                return true;
+                return true
             }
             
             // $HF_TOKEN reference is valid
             if (input.trim() === '$HF_TOKEN') {
-                return true;
+                return true
             }
             
             // Direct token should start with hf_ (warning only, not blocking)
             if (!input.startsWith('hf_')) {
-                console.warn('\n⚠️  Warning: HuggingFace tokens typically start with "hf_"');
-                console.warn('   If this is intentional, you can ignore this warning.');
+                console.warn('\n⚠️  Warning: HuggingFace tokens typically start with "hf_"')
+                console.warn('   If this is intentional, you can ignore this warning.')
             }
             
-            return true; // Always return true (non-blocking validation)
+            return true // Always return true (non-blocking validation)
         }
     }
 ];
@@ -304,30 +421,37 @@ const ngcApiKeyPrompts = [
         name: 'ngcApiKey',
         message: 'NVIDIA NGC API key (enter key, "$NGC_API_KEY" for env var, or leave empty):',
         when: (answers) => {
-            const modelServer = answers.modelServer || answers.deploymentConfig?.split('-').slice(1).join('-');
+            const architecture = answers.architecture || answers.deploymentConfig?.split('-')[0]
+            const backend = answers.backend || answers.deploymentConfig?.split('-').slice(1).join('-')
             
-            if (modelServer !== 'tensorrt-llm') {
-                return false;
+            // Never prompt for NGC key for Triton configs (public images)
+            // Requirements: 9.2
+            if (architecture === 'triton') {
+                return false
             }
             
-            console.log('\n🔐 NVIDIA NGC Authentication');
-            console.log('   TensorRT-LLM base images are hosted on NVIDIA NGC and require an API key.');
-            console.log('   1. Create account at: https://ngc.nvidia.com/');
-            console.log('   2. Generate API key in account settings');
-            console.log('   For CI/CD pipelines, use "$NGC_API_KEY" to reference an environment variable.\n');
+            // Only prompt for transformers-tensorrt-llm
+            if (architecture === 'transformers' && backend === 'tensorrt-llm') {
+                console.log('\n🔐 NVIDIA NGC Authentication')
+                console.log('   TensorRT-LLM base images are hosted on NVIDIA NGC and require an API key.')
+                console.log('   1. Create account at: https://ngc.nvidia.com/')
+                console.log('   2. Generate API key in account settings')
+                console.log('   For CI/CD pipelines, use "$NGC_API_KEY" to reference an environment variable.\n')
+                return true
+            }
             
-            return true;
+            return false
         },
         validate: (input) => {
             if (!input || input.trim() === '') {
-                return true;
+                return true
             }
             
             if (input.trim() === '$NGC_API_KEY') {
-                return true;
+                return true
             }
             
-            return true;
+            return true
         }
     }
 ];
@@ -339,9 +463,26 @@ const modulePrompts = [
         message: 'Include sample Abalone classifier?',
         default: false,
         when: (answers) => {
-            // Derive framework from deploymentConfig if not already set
-            const framework = answers.framework || answers.deploymentConfig?.split('-')[0];
-            return framework !== 'transformers';
+            const architecture = answers.architecture || answers.deploymentConfig?.split('-')[0]
+            const backend = answers.backend || answers.deploymentConfig?.split('-').slice(1).join('-')
+            
+            // Never for transformers
+            if (architecture === 'transformers') {
+                return false
+            }
+            
+            // For Triton, check if backend supports sample model
+            if (architecture === 'triton') {
+                // Triton LLM backends don't support sample model
+                if (backend === 'vllm' || backend === 'tensorrtllm' || backend === 'pytorch') {
+                    return false
+                }
+                // Other Triton backends support sample model
+                return true
+            }
+            
+            // For http architecture, always show
+            return true
         }
     },
     {
@@ -349,20 +490,31 @@ const modulePrompts = [
         name: 'testTypes',
         message: 'Test type?',
         choices: (answers) => {
-            // Derive framework from deploymentConfig if not already set
-            const framework = answers.framework || answers.deploymentConfig?.split('-')[0];
-            if (framework === 'transformers') {
-                return ['hosted-model-endpoint'];
+            const architecture = answers.architecture || answers.deploymentConfig?.split('-')[0]
+            const backend = answers.backend || answers.deploymentConfig?.split('-').slice(1).join('-')
+            
+            // Transformers and Triton LLM backends only support hosted endpoint tests
+            if (architecture === 'transformers') {
+                return ['hosted-model-endpoint']
             }
-            return ['local-model-cli', 'local-model-server', 'hosted-model-endpoint'];
+            if (architecture === 'triton' && (backend === 'vllm' || backend === 'tensorrtllm')) {
+                return ['hosted-model-endpoint']
+            }
+            
+            return ['local-model-cli', 'local-model-server', 'hosted-model-endpoint']
         },
         default: (answers) => {
-            // Derive framework from deploymentConfig if not already set
-            const framework = answers.framework || answers.deploymentConfig?.split('-')[0];
-            if (framework === 'transformers') {
-                return ['hosted-model-endpoint'];
+            const architecture = answers.architecture || answers.deploymentConfig?.split('-')[0]
+            const backend = answers.backend || answers.deploymentConfig?.split('-').slice(1).join('-')
+            
+            if (architecture === 'transformers') {
+                return ['hosted-model-endpoint']
             }
-            return ['local-model-cli', 'local-model-server', 'hosted-model-endpoint'];
+            if (architecture === 'triton' && (backend === 'vllm' || backend === 'tensorrtllm')) {
+                return ['hosted-model-endpoint']
+            }
+            
+            return ['local-model-cli', 'local-model-server', 'hosted-model-endpoint']
         }
     }
 ];
@@ -675,8 +827,9 @@ const baseImageSearchPrompts = [
         message: '🔌 Search for a Python base image (e.g. "3.11", "3.10", or leave empty for all):',
         default: '',
         when: (answers) => {
-            const framework = answers.framework || answers.deploymentConfig?.split('-')[0]
-            return framework !== 'transformers'
+            const architecture = answers.architecture || answers.deploymentConfig?.split('-')[0]
+            // Skip for transformers (uses model-server images) and triton (uses NGC images)
+            return architecture !== 'transformers' && architecture !== 'triton'
         }
     }
 ]
@@ -719,6 +872,7 @@ const baseImagePrompts = [
 export {
     deploymentConfigPrompts,
     frameworkPrompts, // Deprecated: kept for backward compatibility
+    enginePrompts,
     frameworkVersionPrompts,
     frameworkProfilePrompts,
     modelFormatPrompts,

--- a/generators/app/lib/template-manager.js
+++ b/generators/app/lib/template-manager.js
@@ -8,14 +8,41 @@
  * supported by the generator. With do-framework integration, conditional
  * file exclusion logic has been removed - all template files are now
  * generated unconditionally, and runtime scripts handle conditional logic.
+ * 
+ * Requirements: 7.1, 7.2, 7.3, 7.4, 2.1
  */
+
+/**
+ * GPU-requiring Triton backends that must use GPU instance types
+ */
+const GPU_REQUIRING_BACKENDS = ['triton-vllm', 'triton-tensorrtllm']
+
+/**
+ * CPU-only instance type families (patterns that indicate non-GPU instances)
+ */
+const CPU_ONLY_INSTANCE_PATTERNS = [
+    /^ml\.m[0-9]+\./,   // ml.m4.*, ml.m5.*, ml.m6i.*, etc.
+    /^ml\.c[0-9]+\./,   // ml.c4.*, ml.c5.*, ml.c6i.*, etc.
+    /^ml\.t[0-9]+\./,   // ml.t2.*, ml.t3.*, etc.
+    /^ml\.r[0-9]+\./,   // ml.r5.*, ml.r6i.*, etc.
+]
+
+/**
+ * Check if an instance type is CPU-only (no GPU)
+ * @param {string} instanceType - e.g. 'ml.m5.large', 'ml.g5.xlarge'
+ * @returns {boolean} true if CPU-only, false if GPU-capable
+ */
+function isCpuOnlyInstance(instanceType) {
+    if (!instanceType || instanceType === 'custom') {
+        return false
+    }
+    return CPU_ONLY_INSTANCE_PATTERNS.some(pattern => pattern.test(instanceType))
+}
 
 export default class TemplateManager {
     constructor(answers) {
-        this.answers = answers;
+        this.answers = answers
     }
-
-
 
     /**
      * Validates that the configuration is supported
@@ -23,12 +50,16 @@ export default class TemplateManager {
      */
     validate() {
         const supportedOptions = {
+            // 14 canonical deployment-config values (2 http, 5 transformers, 7 triton)
             deploymentConfigs: [
-                'sklearn-flask', 'sklearn-fastapi',
-                'xgboost-flask', 'xgboost-fastapi',
-                'tensorflow-flask', 'tensorflow-fastapi',
+                // HTTP architecture (2)
+                'http-flask', 'http-fastapi',
+                // Transformers architecture (5)
                 'transformers-vllm', 'transformers-sglang',
-                'transformers-tensorrt-llm', 'transformers-lmi', 'transformers-djl'
+                'transformers-tensorrt-llm', 'transformers-lmi', 'transformers-djl',
+                // Triton architecture (7)
+                'triton-fil', 'triton-onnxruntime', 'triton-tensorflow',
+                'triton-pytorch', 'triton-vllm', 'triton-tensorrtllm', 'triton-python'
             ],
             buildTargets: ['codebuild'],
             deploymentTargets: ['managed-inference', 'hyperpod-eks'],
@@ -39,57 +70,75 @@ export default class TemplateManager {
                 'ap-southeast-1', 'ap-southeast-2', 'ap-northeast-1',
                 'ca-central-1', 'sa-east-1'
             ]
-        };
+        }
 
         // Validate deployment configuration if present
         if (this.answers.deploymentConfig) {
-            this._validateChoice('deploymentConfig', supportedOptions.deploymentConfigs);
+            this._validateChoice('deploymentConfig', supportedOptions.deploymentConfigs)
+            
+            // GPU instance type enforcement for GPU-requiring backends
+            this._validateGpuRequirement()
         } else {
-            // Fallback: validate framework and modelServer separately (for backward compatibility)
-            const frameworks = ['sklearn', 'xgboost', 'tensorflow', 'transformers'];
-            const modelServers = ['flask', 'fastapi', 'vllm', 'sglang', 'tensorrt-llm', 'lmi', 'djl'];
+            // Fallback: validate architecture and backend separately (new canonical format)
+            const architectures = ['http', 'transformers', 'triton']
+            const backends = [
+                // http backends
+                'flask', 'fastapi',
+                // transformers backends
+                'vllm', 'sglang', 'tensorrt-llm', 'lmi', 'djl',
+                // triton backends
+                'fil', 'onnxruntime', 'tensorflow', 'pytorch', 'tensorrtllm', 'python'
+            ]
             
-            this._validateChoice('framework', frameworks);
-            this._validateChoice('modelServer', modelServers);
+            this._validateChoice('architecture', architectures)
+            this._validateChoice('backend', backends)
             
-            // Validate tensorrt-llm is only used with transformers framework
-            if (this.answers.modelServer === 'tensorrt-llm' && this.answers.framework !== 'transformers') {
-                throw new Error('⚠️  TensorRT-LLM is only supported with the transformers framework. Please select "transformers" as your framework or choose a different model server.');
+            // Validate tensorrt-llm is only used with transformers architecture
+            if (this.answers.backend === 'tensorrt-llm' && this.answers.architecture !== 'transformers') {
+                throw new Error('⚠️  TensorRT-LLM is only supported with the transformers architecture. Please select "transformers" as your architecture or choose a different backend.')
+            }
+            
+            // GPU instance type enforcement for GPU-requiring backends (fallback path)
+            const deploymentConfig = this.answers.architecture && this.answers.backend
+                ? `${this.answers.architecture}-${this.answers.backend}`
+                : null
+            if (deploymentConfig && GPU_REQUIRING_BACKENDS.includes(deploymentConfig)) {
+                this._validateGpuRequirementForConfig(deploymentConfig)
             }
         }
 
         // Validate buildTarget (replaces deployTarget)
         if (this.answers.buildTarget) {
-            this._validateChoice('buildTarget', supportedOptions.buildTargets);
+            this._validateChoice('buildTarget', supportedOptions.buildTargets)
         } else if (this.answers.deployTarget) {
             // Backward compatibility: validate deployTarget against buildTargets
-            this._validateChoice('deployTarget', supportedOptions.buildTargets);
+            this._validateChoice('deployTarget', supportedOptions.buildTargets)
         }
 
         // Validate deploymentTarget
         if (this.answers.deploymentTarget) {
-            this._validateChoice('deploymentTarget', supportedOptions.deploymentTargets);
+            this._validateChoice('deploymentTarget', supportedOptions.deploymentTargets)
         }
 
         // Validate HyperPod EKS specific fields
         if (this.answers.deploymentTarget === 'hyperpod-eks') {
-            this._validateHyperPodConfig();
+            this._validateHyperPodConfig()
         }
         
         // Validate instance type format (ml.*.*) - only for managed-inference
         if (this.answers.instanceType && this.answers.instanceType !== 'custom') {
-            const instancePattern = /^ml\.[a-z0-9]+\.(nano|micro|small|medium|large|xlarge|[0-9]+xlarge)$/;
+            const instancePattern = /^ml\.[a-z0-9]+\.(nano|micro|small|medium|large|xlarge|[0-9]+xlarge)$/
             if (!instancePattern.test(this.answers.instanceType)) {
-                throw new Error(`⚠️  Invalid instance type format: ${this.answers.instanceType}. Expected format: ml.{family}.{size} (e.g., ml.m5.large, ml.g5.xlarge)`);
+                throw new Error(`⚠️  Invalid instance type format: ${this.answers.instanceType}. Expected format: ml.{family}.{size} (e.g., ml.m5.large, ml.g5.xlarge)`)
             }
         }
         
-        this._validateChoice('awsRegion', supportedOptions.awsRegions);
+        this._validateChoice('awsRegion', supportedOptions.awsRegions)
 
         // Validate test types if testing is enabled
         if (this.answers.includeTesting && this.answers.testTypes) {
             for (const testType of this.answers.testTypes) {
-                this._validateChoice('testType', supportedOptions.testTypes, testType);
+                this._validateChoice('testType', supportedOptions.testTypes, testType)
             }
         }
     }
@@ -102,21 +151,21 @@ export default class TemplateManager {
     _validateHyperPodConfig() {
         // Validate hyperPodCluster is non-empty
         if (!this.answers.hyperPodCluster || this.answers.hyperPodCluster.trim() === '') {
-            throw new Error('⚠️  hyperPodCluster is required when deploymentTarget is "hyperpod-eks". Please provide a valid HyperPod cluster name.');
+            throw new Error('⚠️  hyperPodCluster is required when deploymentTarget is "hyperpod-eks". Please provide a valid HyperPod cluster name.')
         }
 
         // Validate hyperPodNamespace conforms to RFC 1123 DNS label format
         if (this.answers.hyperPodNamespace) {
             if (!this._isValidRfc1123DnsLabel(this.answers.hyperPodNamespace)) {
-                throw new Error(`⚠️  Invalid hyperPodNamespace: "${this.answers.hyperPodNamespace}". Namespace must conform to RFC 1123 DNS label format: lowercase alphanumeric characters or hyphens, must start and end with an alphanumeric character, and be at most 63 characters.`);
+                throw new Error(`⚠️  Invalid hyperPodNamespace: "${this.answers.hyperPodNamespace}". Namespace must conform to RFC 1123 DNS label format: lowercase alphanumeric characters or hyphens, must start and end with an alphanumeric character, and be at most 63 characters.`)
             }
         }
 
         // Validate hyperPodReplicas is an integer >= 1
         if (this.answers.hyperPodReplicas !== undefined) {
-            const replicas = this.answers.hyperPodReplicas;
+            const replicas = this.answers.hyperPodReplicas
             if (!Number.isInteger(replicas) || replicas < 1) {
-                throw new Error(`⚠️  Invalid hyperPodReplicas: "${replicas}". Replicas must be an integer greater than or equal to 1.`);
+                throw new Error(`⚠️  Invalid hyperPodReplicas: "${replicas}". Replicas must be an integer greater than or equal to 1.`)
             }
         }
     }
@@ -129,11 +178,41 @@ export default class TemplateManager {
      */
     _isValidRfc1123DnsLabel(value) {
         if (!value || typeof value !== 'string') {
-            return false;
+            return false
         }
         // RFC 1123 DNS label: lowercase alphanumeric, hyphens allowed (not at start/end), max 63 chars
-        const rfc1123Pattern = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
-        return value.length <= 63 && rfc1123Pattern.test(value);
+        const rfc1123Pattern = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/
+        return value.length <= 63 && rfc1123Pattern.test(value)
+    }
+
+    /**
+     * Validates GPU instance type requirement for GPU-requiring backends.
+     * Called when deploymentConfig is present.
+     * @private
+     * @throws {Error} If a GPU-requiring backend is paired with a CPU-only instance
+     */
+    _validateGpuRequirement() {
+        const dc = this.answers.deploymentConfig
+        if (GPU_REQUIRING_BACKENDS.includes(dc)) {
+            this._validateGpuRequirementForConfig(dc)
+        }
+    }
+
+    /**
+     * Validates that a GPU-requiring deployment config is not paired with a CPU-only instance.
+     * @private
+     * @param {string} deploymentConfig - The deployment config string
+     * @throws {Error} If instance type is CPU-only
+     */
+    _validateGpuRequirementForConfig(deploymentConfig) {
+        const instanceType = this.answers.instanceType
+        if (isCpuOnlyInstance(instanceType)) {
+            throw new Error(
+                `⚠️  ${deploymentConfig} requires a GPU instance type. ` +
+                `Selected: ${instanceType}. ` +
+                `Recommended: ml.g5.xlarge, ml.g5.2xlarge`
+            )
+        }
     }
 
     /**
@@ -141,9 +220,9 @@ export default class TemplateManager {
      * @private
      */
     _validateChoice(field, supportedValues, value = null) {
-        const actualValue = value || this.answers[field];
+        const actualValue = value || this.answers[field]
         if (actualValue && !supportedValues.includes(actualValue)) {
-            throw new Error(`⚠️  ${actualValue} not implemented yet for ${field}.`);
+            throw new Error(`⚠️  ${actualValue} not implemented yet for ${field}.`)
         }
     }
 }

--- a/generators/app/templates/TEMPLATE_SYSTEM.md
+++ b/generators/app/templates/TEMPLATE_SYSTEM.md
@@ -207,7 +207,7 @@ Document the new template and when it's included/excluded.
 npm link
 
 # Run generator
-yo ml-container-creator
+yo @aws/ml-container-creator
 
 # Test different configurations
 # - sklearn + flask

--- a/generators/app/templates/do/export
+++ b/generators/app/templates/do/export
@@ -2,14 +2,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Export current configuration as a single yo ml-container-creator command
+# Export current configuration as a single yo @aws/ml-container-creator command
 
 # Source configuration (suppress the summary output)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/config" > /dev/null 2>&1
 
 # Build the command
-CMD="yo ml-container-creator"
+CMD="yo @aws/ml-container-creator"
 CMD="${CMD} --project-name=${PROJECT_NAME}"
 
 # Use deployment-config if available (bundles framework + model server)

--- a/generators/app/templates/requirements.txt
+++ b/generators/app/templates/requirements.txt
@@ -34,8 +34,28 @@ sagemaker-training==5.1.0
 psutil==6.0.0  # For system monitoring
 prometheus-client==0.20.0  # For metrics (if needed)
 
-<% if (includeSampleModel) { %>
+<% if (includeSampleModel && architecture !== 'triton') { %>
 # Sample model dependencies
 ucimlrepo
 pandas
+<% } %>
+
+<% if (includeSampleModel && architecture === 'triton') { %>
+# Triton sample model training dependencies
+ucimlrepo
+pandas
+numpy
+<% if (backend === 'fil' && (modelFormat === 'xgboost_json' || modelFormat === 'xgboost_ubj')) { %>
+xgboost
+<% } else if (backend === 'fil' && modelFormat === 'lightgbm_txt') { %>
+lightgbm
+<% } else if (backend === 'onnxruntime') { %>
+scikit-learn
+skl2onnx
+onnxruntime
+<% } else if (backend === 'tensorflow') { %>
+tensorflow
+<% } else if (backend === 'python') { %>
+scikit-learn
+<% } %>
 <% } %>

--- a/generators/app/templates/sample_model/test_inference.py
+++ b/generators/app/templates/sample_model/test_inference.py
@@ -2,6 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
+<% if (architecture === 'triton') { %>
+<% if (backend === 'fil' && (modelFormat === 'xgboost_json' || modelFormat === 'xgboost_ubj')) { %>
+import xgboost as xgb
+<% } else if (backend === 'fil' && modelFormat === 'lightgbm_txt') { %>
+import lightgbm as lgb
+<% } else if (backend === 'onnxruntime') { %>
+import onnxruntime as ort
+<% } else if (backend === 'tensorflow') { %>
+import tensorflow as tf
+<% } else if (backend === 'python' && modelFormat === 'pkl') { %>
+import pickle
+<% } else if (backend === 'python' && modelFormat === 'joblib') { %>
+import joblib
+<% } %>
+<% } else { %>
 <% if (framework === 'sklearn') { %>
 <% if (modelFormat === 'joblib') { %>import joblib
 <% } else if (modelFormat === 'pkl') { %>import pickle
@@ -9,8 +24,29 @@ import numpy as np
 <% } else if (framework === 'xgboost') { %>import xgboost as xgb
 <% } else if (framework === 'tensorflow') { %>import tensorflow as tf
 <% } %>
+<% } %>
 
 # Load the trained model
+<% if (architecture === 'triton') { %>
+<% if (backend === 'fil' && modelFormat === 'xgboost_json') { %>
+model = xgb.Booster()
+model.load_model('./abalone_model.json')
+<% } else if (backend === 'fil' && modelFormat === 'xgboost_ubj') { %>
+model = xgb.Booster()
+model.load_model('./abalone_model.ubj')
+<% } else if (backend === 'fil' && modelFormat === 'lightgbm_txt') { %>
+model = lgb.Booster(model_file='./abalone_model.txt')
+<% } else if (backend === 'onnxruntime') { %>
+session = ort.InferenceSession('./abalone_model.onnx')
+<% } else if (backend === 'tensorflow') { %>
+model = tf.saved_model.load('./abalone_model.savedmodel')
+<% } else if (backend === 'python' && modelFormat === 'pkl') { %>
+with open('./abalone_model.pkl', 'rb') as f:
+    model = pickle.load(f)
+<% } else if (backend === 'python' && modelFormat === 'joblib') { %>
+model = joblib.load('./abalone_model.joblib')
+<% } %>
+<% } else { %>
 <% if (framework === 'sklearn') { %>
 <% if (modelFormat === 'joblib') { %>model = joblib.load('./abalone_model.joblib')
 <% } else if (modelFormat === 'pkl') { -%>
@@ -29,6 +65,7 @@ with open('./abalone_model.pkl', 'rb') as f:
 model = model.signatures['serving_default']
 <% } %>
 <% } %>
+<% } %>
 
 # Create synthetic input array for abalone prediction
 # Features: [Sex, Length, Diameter, Height, Whole_weight, Shucked_weight, Viscera_weight, Shell_weight]
@@ -36,7 +73,7 @@ model = model.signatures['serving_default']
 synthetic_input = np.array([[
     1,      # Sex: Female
     0.455,  # Length
-    0.365,  # Diameter  
+    0.365,  # Diameter
     0.095,  # Height
     0.514,  # Whole weight
     0.2245, # Shucked weight
@@ -45,6 +82,31 @@ synthetic_input = np.array([[
 ]])
 
 # Make prediction
+<% if (architecture === 'triton') { %>
+<% if (backend === 'fil' && (modelFormat === 'xgboost_json' || modelFormat === 'xgboost_ubj')) { %>
+feature_names = ['Sex', 'Length', 'Diameter', 'Height', 'Whole_weight', 'Shucked_weight', 'Viscera_weight', 'Shell_weight']
+dtest = xgb.DMatrix(synthetic_input, feature_names=feature_names)
+prediction = model.predict(dtest)
+print(f"Predicted rings: {prediction[0]:.1f}")
+<% } else if (backend === 'fil' && modelFormat === 'lightgbm_txt') { %>
+prediction = model.predict(synthetic_input)
+print(f"Predicted rings: {prediction[0]:.1f}")
+<% } else if (backend === 'onnxruntime') { %>
+input_name = session.get_inputs()[0].name
+prediction = session.run(None, {input_name: synthetic_input.astype(np.float32)})
+print(f"Predicted rings: {prediction[0][0]:.1f}")
+<% } else if (backend === 'tensorflow') { %>
+infer = model.signatures['serving_default']
+input_tensor = tf.constant(synthetic_input, dtype=tf.float32)
+prediction = infer(input_tensor)
+output_key = list(prediction.keys())[0]
+result = prediction[output_key].numpy()
+print(f"Predicted rings: {result[0][0]:.1f}")
+<% } else if (backend === 'python') { %>
+prediction = model.predict(synthetic_input)
+print(f"Predicted rings: {prediction[0]:.1f}")
+<% } %>
+<% } else { %>
 <% if (framework === 'sklearn') { %>prediction = model.predict(synthetic_input)
 print(f"Predicted rings: {prediction[0]:.1f}")
 <% } else if (framework === 'xgboost') { %>feature_names = ['Sex', 'Length', 'Diameter', 'Height', 'Whole_weight', 'Shucked_weight', 'Viscera_weight', 'Shell_weight']
@@ -57,4 +119,5 @@ output_key = list(prediction.keys())[0]
 result = prediction[output_key].numpy()
 print(f"Prediction: {result[0][0]:.2f} rings")<% } else { %>prediction = model.predict(synthetic_input)
 print(f"Prediction: {prediction[0][0]:.2f} rings")<% } %>
+<% } %>
 <% } %>

--- a/generators/app/templates/sample_model/train_abalone.py
+++ b/generators/app/templates/sample_model/train_abalone.py
@@ -13,15 +13,75 @@ except ImportError:
     # If certifi is not available, disable SSL verification as fallback
     ssl._create_default_https_context = ssl._create_unverified_context
 
-from ucimlrepo import fetch_ucirepo
-<% if (framework === 'sklearn') { %>from sklearn.ensemble import RandomForestRegressor
+<% if (architecture === 'triton') { %>
+<% if (backend === 'fil' && (modelFormat === 'xgboost_json' || modelFormat === 'xgboost_ubj')) { %>
+try:
+    import xgboost as xgb
+except ImportError:
+    print("Error: xgboost is required. Install dependencies with: pip install -r requirements.txt")
+    raise
+<% } else if (backend === 'fil' && modelFormat === 'lightgbm_txt') { %>
+try:
+    import lightgbm as lgb
+except ImportError:
+    print("Error: lightgbm is required. Install dependencies with: pip install -r requirements.txt")
+    raise
+<% } else if (backend === 'onnxruntime') { %>
+try:
+    from sklearn.ensemble import RandomForestRegressor
+    from sklearn.model_selection import train_test_split
+    from skl2onnx import convert_sklearn
+    from skl2onnx.common.data_types import FloatTensorType
+    import onnx
+except ImportError:
+    print("Error: scikit-learn, skl2onnx, and onnx are required. Install dependencies with: pip install -r requirements.txt")
+    raise
+<% } else if (backend === 'tensorflow') { %>
+try:
+    import tensorflow as tf
+except ImportError:
+    print("Error: tensorflow is required. Install dependencies with: pip install -r requirements.txt")
+    raise
+<% } else if (backend === 'python') { %>
+try:
+    from sklearn.ensemble import RandomForestRegressor
+    from sklearn.model_selection import train_test_split
+    import pickle
+<% if (modelFormat === 'joblib') { %>
+    import joblib
+<% } %>
+except ImportError:
+    print("Error: scikit-learn is required. Install dependencies with: pip install -r requirements.txt")
+    raise
+<% } %>
+<% } else { %>
+<% const effectiveFramework = engine || framework; %>
+<% if (effectiveFramework === 'sklearn') { %>from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import train_test_split
 <% if (modelFormat === 'joblib') { %>import joblib
 <% } else if (modelFormat === 'pkl') { %>import pickle
 <% } %>
-<% } else if (framework === 'xgboost' || framework === 'tensorflow') { %>
-<% if (framework === 'xgboost') { %>import xgboost as xgb<% } %>
-<% if (framework === 'tensorflow') { %>import tensorflow as tf<% } %>
+<% } else if (effectiveFramework === 'xgboost' || effectiveFramework === 'tensorflow') { %>
+<% if (effectiveFramework === 'xgboost') { %>import xgboost as xgb<% } %>
+<% if (effectiveFramework === 'tensorflow') { %>import tensorflow as tf<% } %>
+
+def train_test_split(X, y, test_size=0.2, random_state=None):
+    if random_state is not None:
+        np.random.seed(random_state)
+
+    n_samples = len(X)
+    n_test = int(n_samples * test_size)
+
+    indices = np.random.permutation(n_samples)
+    test_indices = indices[:n_test]
+    train_indices = indices[n_test:]
+
+    return X.iloc[train_indices], X.iloc[test_indices], y[train_indices], y[test_indices]
+<% } %>
+<% } %>
+
+from ucimlrepo import fetch_ucirepo
+<% if (architecture === 'triton' && (backend === 'fil' || backend === 'tensorflow')) { %>
 
 def train_test_split(X, y, test_size=0.2, random_state=None):
     if random_state is not None:
@@ -44,21 +104,21 @@ try:
 except Exception as e:
     print(f"Warning: Could not download Abalone dataset from UCI repository: {e}")
     print("Creating synthetic data for demonstration...")
-    
+
     # Create synthetic abalone-like data
     np.random.seed(42)
     n_samples = 4177  # Same as original dataset
-    
+
     # Create synthetic features similar to abalone dataset
     # Features: Sex, Length, Diameter, Height, Whole weight, Shucked weight, Viscera weight, Shell weight
     X = np.random.rand(n_samples, 8)
     X[:, 0] = np.random.choice([0, 1, 2], n_samples)  # Sex (M=0, F=1, I=2)
     X[:, 1:] = X[:, 1:] * np.array([0.815, 0.650, 0.265, 2.826, 1.488, 0.760, 1.005])  # Scale to realistic ranges
-    
+
     # Create synthetic target (rings/age)
     y = (X[:, 1] * 10 + X[:, 4] * 5 + np.random.normal(0, 2, n_samples)).astype(int)
     y = np.clip(y, 1, 29)  # Clip to realistic range
-    
+
     # Convert to DataFrame-like structure for compatibility
     import pandas as pd
     feature_names = ['Sex', 'Length', 'Diameter', 'Height', 'Whole_weight', 'Shucked_weight', 'Viscera_weight', 'Shell_weight']
@@ -73,19 +133,71 @@ if hasattr(X, 'dtypes') and X['Sex'].dtype == 'object':
 # Split data
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
-<% if (framework === 'sklearn') { %># Train sklearn model
-model = RandomForestRegressor(n_estimators=100, random_state=42)
-model.fit(X_train, y_train)
-
-print(f"Model trained and saved. Test score: {model.score(X_test, y_test):.3f}")
-<% } else if (framework === 'xgboost') { %># Train XGBoost model
+<% if (architecture === 'triton') { %>
+<% if (backend === 'fil' && (modelFormat === 'xgboost_json' || modelFormat === 'xgboost_ubj')) { %>
+# Train XGBoost model
 model = xgb.XGBRegressor(n_estimators=100, random_state=42)
 model.fit(X_train, y_train)
 
 # Evaluate
 test_score = model.score(X_test, y_test)
 print(f"Model trained. Test score: {test_score:.3f}")
-<% } else if (framework === 'tensorflow') { %># Train TensorFlow model
+<% } else if (backend === 'fil' && modelFormat === 'lightgbm_txt') { %>
+# Train LightGBM model
+model = lgb.LGBMRegressor(n_estimators=100, random_state=42, verbose=-1)
+model.fit(X_train, y_train)
+
+# Evaluate
+test_score = model.score(X_test, y_test)
+print(f"Model trained. Test score: {test_score:.3f}")
+<% } else if (backend === 'onnxruntime') { %>
+# Train sklearn model
+model = RandomForestRegressor(n_estimators=100, random_state=42)
+model.fit(X_train, y_train)
+
+print(f"Model trained. Test score: {model.score(X_test, y_test):.3f}")
+
+# Convert to ONNX format
+initial_type = [('float_input', FloatTensorType([None, X_train.shape[1]]))]
+onnx_model = convert_sklearn(model, 'abalone_model', initial_types=initial_type)
+<% } else if (backend === 'tensorflow') { %>
+# Train TensorFlow model
+model = tf.keras.Sequential([
+    tf.keras.layers.Dense(64, activation='relu', input_shape=(X_train.shape[1],)),
+    tf.keras.layers.Dense(32, activation='relu'),
+    tf.keras.layers.Dense(1)
+])
+
+model.compile(optimizer='adam', loss='mse', metrics=['mae'])
+
+# Train model
+model.fit(X_train, y_train, epochs=50, batch_size=32, validation_split=0.2, verbose=0)
+
+# Calculate test score
+test_loss, test_mae = model.evaluate(X_test, y_test, verbose=0)
+print(f"Model trained. Test MAE: {test_mae:.3f}")
+<% } else if (backend === 'python') { %>
+# Train sklearn model
+model = RandomForestRegressor(n_estimators=100, random_state=42)
+model.fit(X_train, y_train)
+
+print(f"Model trained. Test score: {model.score(X_test, y_test):.3f}")
+<% } %>
+<% } else { %>
+<% const effectiveFramework = engine || framework; %>
+<% if (effectiveFramework === 'sklearn') { %># Train sklearn model
+model = RandomForestRegressor(n_estimators=100, random_state=42)
+model.fit(X_train, y_train)
+
+print(f"Model trained and saved. Test score: {model.score(X_test, y_test):.3f}")
+<% } else if (effectiveFramework === 'xgboost') { %># Train XGBoost model
+model = xgb.XGBRegressor(n_estimators=100, random_state=42)
+model.fit(X_train, y_train)
+
+# Evaluate
+test_score = model.score(X_test, y_test)
+print(f"Model trained. Test score: {test_score:.3f}")
+<% } else if (effectiveFramework === 'tensorflow') { %># Train TensorFlow model
 # Create TensorFlow model
 model = tf.keras.Sequential([
     tf.keras.layers.Dense(64, activation='relu', input_shape=(X_train.shape[1],)),
@@ -102,11 +214,28 @@ model.fit(X_train, y_train, epochs=50, batch_size=32, validation_split=0.2, verb
 test_loss, test_mae = model.evaluate(X_test, y_test, verbose=0)
 print(f"Model trained and saved. Test MAE: {test_mae:.3f}")
 <% } %>
+<% } %>
 
 # Save model
 # Get the directory where this script is located
 script_dir = os.path.dirname(os.path.abspath(__file__))
 
+<% if (architecture === 'triton') { %>
+<% if (backend === 'fil' && modelFormat === 'xgboost_json') { %>model.save_model(os.path.join(script_dir, 'abalone_model.json'))
+<% } else if (backend === 'fil' && modelFormat === 'xgboost_ubj') { %>model.save_model(os.path.join(script_dir, 'abalone_model.ubj'))
+<% } else if (backend === 'fil' && modelFormat === 'lightgbm_txt') { %>model.booster_.save_model(os.path.join(script_dir, 'abalone_model.txt'))
+<% } else if (backend === 'onnxruntime') { %>onnx.save_model(onnx_model, os.path.join(script_dir, 'abalone_model.onnx'))
+<% } else if (backend === 'tensorflow') { %>model.export(os.path.join(script_dir, 'abalone_model.savedmodel'))
+<% } else if (backend === 'python' && modelFormat === 'pkl') { %>
+with open(os.path.join(script_dir, 'abalone_model.pkl'), 'wb') as f:
+    pickle.dump(model, f)
+<% } else if (backend === 'python' && modelFormat === 'joblib') { %>joblib.dump(model, os.path.join(script_dir, 'abalone_model.joblib'))
+<% } else if (backend === 'python') { %>
+# Custom format: defaulting to pickle serialization
+with open(os.path.join(script_dir, 'abalone_model.pkl'), 'wb') as f:
+    pickle.dump(model, f)
+<% } %>
+<% } else { %>
 <% if (modelFormat === 'joblib') { %>joblib.dump(model, os.path.join(script_dir, 'abalone_model.joblib'))
 <% } else if (modelFormat === 'pkl') { -%>
 with open(os.path.join(script_dir, 'abalone_model.pkl'), 'wb') as f:
@@ -117,6 +246,7 @@ with open(os.path.join(script_dir, 'abalone_model.pkl'), 'wb') as f:
 <% } else if (modelFormat === 'h5') { %>model.save(os.path.join(script_dir, 'abalone_model.h5'))
 <% } else if (modelFormat === 'keras') { %>model.save(os.path.join(script_dir, 'abalone_model.keras'))
 <% } else if (modelFormat === 'SavedModel') { %>model.export(os.path.join(script_dir, 'abalone_model'))
+<% } %>
 <% } %>
 
 print("Model saved.")

--- a/generators/app/templates/triton/Dockerfile
+++ b/generators/app/templates/triton/Dockerfile
@@ -1,0 +1,128 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# NVIDIA Triton Inference Server Dockerfile
+# Backend: <%= backend %>
+
+<% if (comments && comments.acceleratorInfo) { %>
+<%= comments.acceleratorInfo %>
+<% } %>
+
+<% if (comments && comments.validationInfo) { %>
+<%= comments.validationInfo %>
+<% } %>
+
+# Triton Inference Server base image from NVIDIA NGC
+# Public image - no NGC authentication required
+ARG BASE_IMAGE=<%= baseImage || 'nvcr.io/nvidia/tritonserver:24.08-py3' %>
+FROM ${BASE_IMAGE}
+
+# Set a docker label to name this project, postpended with the build time
+LABEL project.name="<%= projectName %>-<%= buildTimestamp %>" \
+      project.base-name="<%= projectName %>" \
+      project.build-time="<%= buildTimestamp %>"
+
+# Set a docker label to advertise multi-model support on the container
+LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
+# Set a docker label to enable container to use SAGEMAKER_BIND_TO_PORT environment variable if present
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
+
+# Set working directory
+WORKDIR /opt/ml
+
+<% if (backend === 'vllm' || backend === 'tensorrtllm') { %>
+# HuggingFace model configuration for LLM backends
+ENV HF_MODEL_ID="<%= modelName %>"
+<% if (hfToken) { %>
+# Set HuggingFace authentication token for gated models
+ENV HF_TOKEN="<%= hfToken %>"
+<% } %>
+<% } %>
+
+<% if (backend === 'python') { %>
+# Install Python backend dependencies
+COPY triton/requirements.txt /tmp/triton_requirements.txt
+RUN pip install --no-cache-dir -r /tmp/triton_requirements.txt && \
+    rm /tmp/triton_requirements.txt
+<% } %>
+
+# Set up model repository directory structure
+# Triton expects models at: /opt/ml/model/model_repository/<model-name>/<version>/
+RUN mkdir -p /opt/ml/model/model_repository/<%= modelName || 'model' %>/1
+
+# Set permissions for model repository
+RUN chmod -R 755 /opt/ml/model/model_repository
+
+# Copy Triton model configuration
+COPY triton/config.pbtxt /opt/ml/model/model_repository/<%= modelName || 'model' %>/config.pbtxt
+
+<% if (backend === 'python') { %>
+# Copy Python backend model implementation
+COPY triton/model.py /opt/ml/model/model_repository/<%= modelName || 'model' %>/1/model.py
+<% } %>
+
+<% if (includeSampleModel) { %>
+# Copy sample model artifact
+<% if (backend === 'fil') { %>
+<% if (modelFormat === 'xgboost_json') { %>
+COPY sample_model/abalone_model.json /opt/ml/model/model_repository/<%= modelName || 'model' %>/1/xgboost.json
+<% } else if (modelFormat === 'xgboost_ubj') { %>
+COPY sample_model/abalone_model.ubj /opt/ml/model/model_repository/<%= modelName || 'model' %>/1/xgboost.ubj
+<% } else if (modelFormat === 'lightgbm_txt') { %>
+COPY sample_model/abalone_model.txt /opt/ml/model/model_repository/<%= modelName || 'model' %>/1/model.txt
+<% } %>
+<% } else if (backend === 'onnxruntime') { %>
+COPY sample_model/abalone_model.onnx /opt/ml/model/model_repository/<%= modelName || 'model' %>/1/model.onnx
+<% } else if (backend === 'tensorflow') { %>
+COPY sample_model/abalone_model.savedmodel /opt/ml/model/model_repository/<%= modelName || 'model' %>/1/model.savedmodel/
+<% } else if (backend === 'pytorch') { %>
+COPY sample_model/abalone_model.pt /opt/ml/model/model_repository/<%= modelName || 'model' %>/1/model.pt
+<% } else if (backend === 'python') { %>
+<% if (modelFormat === 'pkl') { %>
+COPY sample_model/abalone_model.pkl /opt/ml/model/model_repository/<%= modelName || 'model' %>/1/model.pkl
+<% } else if (modelFormat === 'joblib') { %>
+COPY sample_model/abalone_model.joblib /opt/ml/model/model_repository/<%= modelName || 'model' %>/1/model.joblib
+<% } %>
+<% } %>
+# Also copy training script for reference
+COPY sample_model/ /opt/ml/sample_model/
+<% } else { %>
+# Model artifacts should be placed in:
+# /opt/ml/model/model_repository/<%= modelName || 'model' %>/1/
+# COPY your_model_files /opt/ml/model/model_repository/<%= modelName || 'model' %>/1/
+<% } %>
+
+<% if (comments && comments.envVarExplanations && Object.keys(comments.envVarExplanations).length > 0) { %>
+# Environment Variables Configuration
+<% for (const [category, comment] of Object.entries(comments.envVarExplanations)) { %>
+<%= comment %>
+<% } %>
+<% } %>
+
+# Triton environment variables
+ENV TRITON_MODEL_REPOSITORY=/opt/ml/model/model_repository
+
+<% if (orderedEnvVars && orderedEnvVars.length > 0) { %>
+# Additional environment variables from configuration
+<% orderedEnvVars.forEach(({ key, value }) => { %>
+ENV <%= key %>=<%= value %>
+<% }); %>
+<% } %>
+
+# Expose port 8080 for SageMaker compatibility
+# Triton default ports: 8000 (HTTP), 8001 (gRPC), 8002 (metrics)
+# SageMaker requires port 8080
+EXPOSE 8080
+
+<% if (comments && comments.troubleshooting) { %>
+<%= comments.troubleshooting %>
+<% } %>
+
+# Start Triton Inference Server
+# --http-port=8080: SageMaker requires port 8080
+# --model-repository: Path to model repository
+# --strict-model-config=false: Allow Triton to auto-complete config for some backends
+ENTRYPOINT ["tritonserver", \
+            "--http-port=8080", \
+            "--model-repository=/opt/ml/model/model_repository", \
+            "--strict-model-config=false"]

--- a/generators/app/templates/triton/config.pbtxt
+++ b/generators/app/templates/triton/config.pbtxt
@@ -1,0 +1,163 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Triton Model Configuration
+# Backend: <%= backend %>
+# Model: <%= modelName || 'model' %>
+
+name: "<%= modelName || 'model' %>"
+backend: "<%= backend %>"
+
+<% if (backend === 'vllm' || backend === 'tensorrtllm') { %>
+# LLM backends (vllm, tensorrtllm) auto-configure most settings
+# Minimal configuration is sufficient
+max_batch_size: 0
+
+<% if (backend === 'vllm') { %>
+# vLLM backend parameters
+parameters: {
+    key: "model"
+    value: { string_value: "<%= modelName %>" }
+}
+parameters: {
+    key: "gpu_memory_utilization"
+    value: { string_value: "0.9" }
+}
+<% } else if (backend === 'tensorrtllm') { %>
+# TensorRT-LLM backend parameters
+parameters: {
+    key: "model"
+    value: { string_value: "<%= modelName %>" }
+}
+<% } %>
+<% } else { %>
+# Maximum batch size (0 = batching disabled)
+max_batch_size: 8
+
+<% if (backend === 'fil') { %>
+# FIL (Forest Inference Library) backend for tree-based models
+# Supports XGBoost, LightGBM, and scikit-learn random forests
+input [
+    {
+        name: "input__0"
+        data_type: TYPE_FP32
+        dims: [ -1 ]  # Dynamic feature dimension
+    }
+]
+output [
+    {
+        name: "output__0"
+        data_type: TYPE_FP32
+        dims: [ 1 ]  # Single prediction value
+    }
+]
+
+# FIL-specific parameters
+parameters: {
+    key: "model_type"
+<% if (modelFormat === 'xgboost_json' || modelFormat === 'xgboost_ubj') { %>
+    value: { string_value: "xgboost_json" }
+<% } else if (modelFormat === 'lightgbm_txt') { %>
+    value: { string_value: "lightgbm" }
+<% } %>
+}
+parameters: {
+    key: "output_class"
+    value: { string_value: "false" }
+}
+<% } else if (backend === 'onnxruntime') { %>
+# ONNX Runtime backend
+# Input/output shapes depend on your specific model
+input [
+    {
+        name: "input"
+        data_type: TYPE_FP32
+        dims: [ -1 ]  # Dynamic input dimension
+    }
+]
+output [
+    {
+        name: "output"
+        data_type: TYPE_FP32
+        dims: [ -1 ]  # Dynamic output dimension
+    }
+]
+<% } else if (backend === 'tensorflow') { %>
+# TensorFlow SavedModel backend
+# Input/output shapes depend on your specific model
+input [
+    {
+        name: "input"
+        data_type: TYPE_FP32
+        dims: [ -1 ]  # Dynamic input dimension
+    }
+]
+output [
+    {
+        name: "output"
+        data_type: TYPE_FP32
+        dims: [ -1 ]  # Dynamic output dimension
+    }
+]
+
+# TensorFlow-specific parameters
+parameters: {
+    key: "TF_INTER_OP_PARALLELISM"
+    value: { string_value: "0" }
+}
+parameters: {
+    key: "TF_INTRA_OP_PARALLELISM"
+    value: { string_value: "0" }
+}
+<% } else if (backend === 'pytorch') { %>
+# PyTorch TorchScript backend
+# Input/output shapes depend on your specific model
+input [
+    {
+        name: "INPUT__0"
+        data_type: TYPE_FP32
+        dims: [ -1 ]  # Dynamic input dimension
+    }
+]
+output [
+    {
+        name: "OUTPUT__0"
+        data_type: TYPE_FP32
+        dims: [ -1 ]  # Dynamic output dimension
+    }
+]
+<% } else if (backend === 'python') { %>
+# Python backend
+# Custom model implementation in model.py
+input [
+    {
+        name: "INPUT"
+        data_type: TYPE_FP32
+        dims: [ -1 ]  # Dynamic input dimension
+    }
+]
+output [
+    {
+        name: "OUTPUT"
+        data_type: TYPE_FP32
+        dims: [ -1 ]  # Dynamic output dimension
+    }
+]
+<% } %>
+
+# Instance group configuration
+# Specifies how many instances of the model to run and on which device
+instance_group [
+    {
+        count: 1
+        kind: KIND_AUTO  # Automatically select CPU or GPU based on availability
+    }
+]
+
+# Dynamic batching configuration
+# Enables automatic request batching for improved throughput
+dynamic_batching {
+    preferred_batch_size: [ 4, 8 ]
+    max_queue_delay_microseconds: 100
+}
+<% } %>

--- a/generators/app/templates/triton/model.py
+++ b/generators/app/templates/triton/model.py
@@ -1,0 +1,130 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Triton Python Backend Model Implementation
+
+This module implements the TritonPythonModel interface for serving
+custom Python models via NVIDIA Triton Inference Server.
+
+Backend: python
+Model: <%= modelName || 'model' %>
+"""
+
+import json
+import os
+
+import numpy as np
+import triton_python_backend_utils as pb_utils
+
+<% if (modelFormat === 'pkl') { %>
+import pickle
+<% } else if (modelFormat === 'joblib') { %>
+import joblib
+<% } %>
+
+
+class TritonPythonModel:
+    """Triton Python backend model implementation.
+
+    This class implements the required interface for Triton's Python backend:
+    - initialize(): Called once when the model is loaded
+    - execute(): Called for each inference request batch
+    - finalize(): Called once when the model is unloaded
+    """
+
+    def initialize(self, args):
+        """Initialize the model.
+
+        Called once when the model is loaded by Triton. Use this method to
+        load model artifacts and set up any required resources.
+
+        Args:
+            args: Dictionary containing model configuration:
+                - model_config: JSON string of the model configuration
+                - model_instance_kind: Device type (CPU/GPU)
+                - model_instance_device_id: Device ID
+                - model_repository: Path to the model repository
+                - model_version: Model version being loaded
+                - model_name: Name of the model
+        """
+        self.model_config = json.loads(args['model_config'])
+        model_repository = args['model_repository']
+        model_version = args['model_version']
+
+        # Construct path to model artifact
+        model_dir = os.path.join(model_repository, model_version)
+
+<% if (modelFormat === 'pkl') { %>
+        # Load pickle model
+        model_path = os.path.join(model_dir, 'model.pkl')
+        with open(model_path, 'rb') as f:
+            self.model = pickle.load(f)
+<% } else if (modelFormat === 'joblib') { %>
+        # Load joblib model
+        model_path = os.path.join(model_dir, 'model.joblib')
+        self.model = joblib.load(model_path)
+<% } else { %>
+        # Custom model loading
+        # TODO: Implement your model loading logic here
+        # model_path = os.path.join(model_dir, 'your_model_file')
+        self.model = None
+<% } %>
+
+        # Get output configuration from model config
+        output_config = pb_utils.get_output_config_by_name(
+            self.model_config, 'OUTPUT'
+        )
+        self.output_dtype = pb_utils.triton_string_to_numpy(
+            output_config['data_type']
+        )
+
+    def execute(self, requests):
+        """Handle inference requests.
+
+        Called for each batch of inference requests. Processes input tensors
+        and returns output tensors.
+
+        Args:
+            requests: List of pb_utils.InferenceRequest objects
+
+        Returns:
+            List of pb_utils.InferenceResponse objects
+        """
+        responses = []
+
+        for request in requests:
+            # Get input tensor
+            input_tensor = pb_utils.get_input_tensor_by_name(request, 'INPUT')
+            input_data = input_tensor.as_numpy()
+
+<% if (modelFormat === 'pkl' || modelFormat === 'joblib') { %>
+            # Run prediction
+            predictions = self.model.predict(input_data)
+            output_data = np.array(predictions, dtype=self.output_dtype)
+<% } else { %>
+            # Custom inference logic
+            # TODO: Implement your inference logic here
+            output_data = np.zeros(
+                (input_data.shape[0], 1), dtype=self.output_dtype
+            )
+<% } %>
+
+            # Create output tensor
+            output_tensor = pb_utils.Tensor('OUTPUT', output_data)
+
+            # Create inference response
+            inference_response = pb_utils.InferenceResponse(
+                output_tensors=[output_tensor]
+            )
+            responses.append(inference_response)
+
+        return responses
+
+    def finalize(self):
+        """Clean up resources.
+
+        Called once when the model is being unloaded. Use this method to
+        release any resources held by the model.
+        """
+        self.model = None

--- a/generators/app/templates/triton/requirements.txt
+++ b/generators/app/templates/triton/requirements.txt
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Python dependencies for Triton Python backend
+numpy>=1.24.0
+<% if (modelFormat === 'pkl') { %>
+scikit-learn>=1.3.0
+<% } else if (modelFormat === 'joblib') { %>
+scikit-learn>=1.3.0
+joblib>=1.3.0
+<% } %>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "generator-ml-container-creator",
+  "name": "@aws/generator-ml-container-creator",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "generator-ml-container-creator",
+      "name": "@aws/generator-ml-container-creator",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -67,7 +67,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -457,6 +456,7 @@
       "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -467,6 +467,7 @@
       "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
         "@inquirer/core": "^10.3.2",
@@ -492,6 +493,7 @@
       "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.2",
         "@inquirer/type": "^3.0.10"
@@ -514,6 +516,7 @@
       "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
         "@inquirer/figures": "^1.0.15",
@@ -542,6 +545,7 @@
       "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.2",
         "@inquirer/external-editor": "^1.0.3",
@@ -565,6 +569,7 @@
       "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.2",
         "@inquirer/type": "^3.0.10",
@@ -588,6 +593,7 @@
       "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chardet": "^2.1.1",
         "iconv-lite": "^0.7.0"
@@ -610,6 +616,7 @@
       "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -620,6 +627,7 @@
       "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.2",
         "@inquirer/type": "^3.0.10"
@@ -642,6 +650,7 @@
       "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.2",
         "@inquirer/type": "^3.0.10"
@@ -664,6 +673,7 @@
       "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
         "@inquirer/core": "^10.3.2",
@@ -687,6 +697,7 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -717,6 +728,7 @@
       "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.2",
         "@inquirer/type": "^3.0.10",
@@ -740,6 +752,7 @@
       "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.3.2",
         "@inquirer/figures": "^1.0.15",
@@ -764,6 +777,7 @@
       "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
         "@inquirer/core": "^10.3.2",
@@ -789,6 +803,7 @@
       "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1681,7 +1696,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
       "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -2120,7 +2134,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2424,7 +2437,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -2469,7 +2483,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2557,7 +2570,8 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
       "integrity": "sha512-iFY7JCgHbepc0b82yLaw4IMortylNb6wG4kL+4R0C3iv6i+RHGHux/yUX5BTiRvSX/shMnngjR1YyNMnXEFh5A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -2574,6 +2588,7 @@
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2642,6 +2657,7 @@
       "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -2670,6 +2686,7 @@
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2691,6 +2708,7 @@
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2700,6 +2718,7 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2709,6 +2728,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -2718,6 +2738,7 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -2732,13 +2753,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -2747,7 +2770,8 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/b4a": {
       "version": "1.7.3",
@@ -2798,6 +2822,7 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -2843,6 +2868,7 @@
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
       "integrity": "sha512-o9u3aS7w6RqoH9BErxuilhQG2fn3srr3ZekEEGailMnj5F+0p+R3TXENvO+vGaLnKlmq8xhhh/Fvl1RRxx/FdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-versions": "^1.0.0"
       },
@@ -2855,6 +2881,7 @@
       "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
       "integrity": "sha512-3lUeqGAbnWQG7OCfIiHXw1EmzzvAGlMYqqgRahkr7oDeY1Qra8r2DZH2bbfXZI4NA3aaD1Ap+xt8CeVO/fftrw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bin-version": "^1.0.0",
         "minimist": "^1.1.0",
@@ -2925,6 +2952,7 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.3.1.tgz",
       "integrity": "sha512-u9JPc+sK+tsB7uH0870GNESSm2I005T9nE9fug2X/6COxMJ9qXmSducVSFt5f3xdZgR/PtKXVJTxN296cMCP6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^1.1.1",
         "filled-array": "^1.0.0",
@@ -2942,6 +2970,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2951,6 +2980,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2960,6 +2990,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -2976,6 +3007,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -2985,6 +3017,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -2999,6 +3032,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -3011,6 +3045,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -3064,7 +3099,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3276,6 +3310,7 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha512-bA/Z/DERHKqoEOrp+qeGKw1QlvEQkGZSc0XaY6VnTxZr+Kv1G5zFwttpjv8qxZ/sBPT4nthwZaAcsAZTJlSKXQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "camelcase": "^2.0.0",
         "map-obj": "^1.0.0"
@@ -3289,6 +3324,7 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
       "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3318,7 +3354,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/chalk": {
       "version": "5.6.2",
@@ -3435,7 +3472,8 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/cli-list/-/cli-list-0.1.8.tgz",
       "integrity": "sha512-mb+TaXrOAHnLCu4rKprj/aBk178JUWZTC3KqFANUOEZU7GkbEfEYEASN9hPVxF6UXVwJy9cJR0hAQ0j6gKzPLQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cli-spinners": {
       "version": "2.9.2",
@@ -3443,6 +3481,7 @@
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -3592,6 +3631,7 @@
       "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
       "integrity": "sha512-KLLTJWrvwIP+OPfMn0x2PheDEP20RPUcGXj/ERegTgdmPEZylALQldygiqrPPu8P45uNuPs7ckmReLY6v/iA5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -3601,6 +3641,7 @@
       "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
       "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-regexp": "^1.0.0",
         "is-supported-regexp-flag": "^1.0.0"
@@ -3634,13 +3675,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
       "integrity": "sha512-au6ydSpg6nsrigcZ4m8Bc9hxjeW+GJ8xh5G3BJCMt4WXe1H10UNaVOamqQTmrx1kjVuxAHIQSNU6hY4Nsn9/ag==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cloneable-readable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
       "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "process-nextick-args": "^2.0.0",
@@ -3672,6 +3715,7 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3709,6 +3753,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3756,6 +3801,7 @@
         "node >= 0.8"
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -3784,6 +3830,7 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz",
       "integrity": "sha512-Zcx2SVdZC06IuRHd2MhkVYFNJBkZBj166LGdsJXRcqNC8Gs5Bwh8mosStNeCBBmtIm4wNii2uarD50qztjKOjw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "mkdirp": "^0.5.0",
@@ -3849,7 +3896,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -3900,6 +3948,7 @@
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-find-index": "^1.0.1"
       },
@@ -3912,6 +3961,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -4005,6 +4055,7 @@
       "resolved": "https://registry.npmjs.org/default-uid/-/default-uid-1.0.0.tgz",
       "integrity": "sha512-KqOPKqX9VLrCfdKK/zMll+xb9kZOP4QyguB6jyN4pKaPoedk1bMFIfyTCFhVdrHb3GU7aJvKjd8myKxFRRDwCg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4023,6 +4074,7 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4031,7 +4083,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -4068,6 +4121,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-8.0.2.tgz",
       "integrity": "sha512-xaBe6ZT4DHPkg0k4Ytbvn5xoxgpG0jOS1dYxSOwAHPuNLjP3/OzN0gH55SrLqpx8cBfSaVt91lXYkApjb+nYdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "type-fest": "^3.8.0"
       },
@@ -4083,6 +4137,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
       "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -4095,6 +4150,7 @@
       "resolved": "https://registry.npmjs.org/downgrade-root/-/downgrade-root-1.2.2.tgz",
       "integrity": "sha512-K/QnPfqybcxP6rriuM17fnaQ/zDnG0hh8ISbm9szzIqZSI4wtfaj4D5oL6WscT2xVFQ3kDISZrrgeUtd+rW8pQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "default-uid": "^1.0.0",
         "is-root": "^1.0.0"
@@ -4122,6 +4178,7 @@
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha512-0hJGub96skwr+sUojv7zQ0kc9i4jn3SwLiLk8Jr7KDz7aaaMzkN5UX3a/9ZhzC0OfZVyXHhlHcjC0KVOiKZ+HQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "onetime": "^1.0.0",
         "set-immediate-shim": "^1.0.0"
@@ -4135,6 +4192,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4150,6 +4208,7 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -4257,6 +4316,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -4296,6 +4356,7 @@
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -4347,7 +4408,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4662,6 +4722,7 @@
       "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
       "integrity": "sha512-/J0Q8CvOvlAdpvhfkD/WnTQ4H1eU0exze2nFGPj/RSC7jpQ0NkKe2r28T5eMkhEEs+fzepMZNy1kVRKNlC04nQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clone-regexp": "^1.0.0"
       },
@@ -4674,6 +4735,7 @@
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4775,13 +4837,15 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/external-editor": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
       "integrity": "sha512-0XYlP43jzxMgJjugDJ85Z0UDPnowkUbfFztNvsSGC9sJVIk97MZbGEb9WAhIVH0UgNxoLj/9ZQgB4CHJyz2GGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "extend": "^3.0.0",
         "spawn-sync": "^1.0.15",
@@ -4795,7 +4859,8 @@
       "engines": [
         "node >=0.6.0"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-check": {
       "version": "4.5.2",
@@ -4945,6 +5010,7 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5",
         "object-assign": "^4.1.0"
@@ -4958,6 +5024,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -5021,6 +5088,7 @@
       "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
       "integrity": "sha512-4XwZ1k4rgoF3Yap59MyXFmiUh2zu9fht32NYPSRYwLv4o8BWHxi60I1VH5kHje14qGMoS3qyfHQUsN16ROOugQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5097,6 +5165,7 @@
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
       "integrity": "sha512-t0ciYD8XnoFVirFJN2niUJAQ/kyZU5UDSJobyekmiMPCBsYsWd4nd75e7HU2Xf4m+1Y7iLEo3fovNRNIV5MaDQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-uniq": "^1.0.0",
         "get-stdin": "^4.0.1",
@@ -5188,7 +5257,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
       "integrity": "sha512-J+ler7Ta54FwwNcx6wQRDhTIbNeyDcARMkOcguEqnEdtm0jKvN3Li3PDAb2Du3ubJYEWfYL83XMROXdsXAXycw==",
-      "license": "Apache2"
+      "license": "Apache2",
+      "peer": true
     },
     "node_modules/foreground-child": {
       "version": "2.0.0",
@@ -5216,6 +5286,7 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -5225,6 +5296,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
       "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5315,6 +5387,7 @@
       "resolved": "https://registry.npmjs.org/fullname/-/fullname-2.1.0.tgz",
       "integrity": "sha512-OdtZe5wVRkAfBI5DUuaN5S+ocp9VWW+HlKVk76NjoDv/u4l9uBkZWQn+w1of8jVfnYx1bD7zISg3j7rqyG5ifQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "npmconf": "^2.1.1",
         "pify": "^2.2.0",
@@ -5339,6 +5412,7 @@
       "integrity": "sha512-fVbU2wRE91yDvKUnrIaQlHKAWKY5e08PmztCrwuH5YVQ+Z/p3d0ny2T48o6uvAAXHIUnfaQdHkmxYbQft1eHVA==",
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ansi": "^0.3.0",
         "has-unicode": "^2.0.0",
@@ -5431,6 +5505,7 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5457,6 +5532,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -5615,6 +5691,7 @@
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -5625,6 +5702,7 @@
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "deprecated": "this library is no longer supported",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -5638,6 +5716,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5653,13 +5732,15 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -5672,6 +5753,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5702,6 +5784,7 @@
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -5716,7 +5799,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/hasha": {
       "version": "5.2.2",
@@ -5785,7 +5869,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5854,6 +5937,7 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -5892,6 +5976,7 @@
       "resolved": "https://registry.npmjs.org/humanize-string/-/humanize-string-1.0.2.tgz",
       "integrity": "sha512-PH5GBkXqFxw5+4eKaKRIkD23y6vRd/IXSl7IldyJxEXpDH9SEIXRORkBtkGni/ae2P7RVOw6Wxypd2tGXhha1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "decamelize": "^1.0.0"
       },
@@ -5904,6 +5989,7 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6015,6 +6101,7 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha512-aqwDFWSgSgfRaEwao5lg5KEcVd/2a+D1rvoG7NdilmYz0NwRk6StWpWdz/Hpk34MKPpx7s8XxUqimfcQK6gGlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "repeating": "^2.0.0"
       },
@@ -6066,6 +6153,7 @@
       "integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
         "@inquirer/core": "^10.3.2",
@@ -6092,6 +6180,7 @@
       "resolved": "https://registry.npmjs.org/insight/-/insight-0.7.0.tgz",
       "integrity": "sha512-KQnkePMqhyZn73PTQ8zYGltNnoQilME9TLsXuykEw/cANuUocvp6lUZZkply7fz3f1QJV+MBFjuORPT2ArS9Bw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "async": "^1.4.2",
         "chalk": "^1.0.0",
@@ -6112,6 +6201,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6121,6 +6211,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6129,13 +6220,15 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/insight/node_modules/chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -6152,6 +6245,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "restore-cursor": "^1.0.1"
       },
@@ -6163,13 +6257,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
       "integrity": "sha512-eMU2akIeEIkCxGXUNmDnJq1KzOIiPnJ+rKqRe6hcxE3vIOPvpMrBYOn/Bl7zNlYJj/zQxXquAnozHUCf9Whnsg==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/insight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -6179,6 +6275,7 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.10.1.tgz",
       "integrity": "sha512-zhf9SY0IHHC4OrPGEeOgAwMptQGzgq8Z2xPlSinbb7Z1uxF+1ry3HFUpCPq4hPGwuYwdhwbFm++zry4LM/+NzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^1.1.0",
         "ansi-regex": "^2.0.0",
@@ -6199,6 +6296,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6208,6 +6306,7 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "exit-hook": "^1.0.0",
         "onetime": "^1.0.0"
@@ -6221,6 +6320,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha512-qOX+w+IxFgpUpJfkv2oGN0+ExPs68F4sZHfaRRx4dDexAQkG83atugKVEylyT5ARees3HBbfmuvnjbrd8j9Wjw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "once": "^1.3.0"
       }
@@ -6230,6 +6330,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -6242,6 +6343,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -6268,7 +6370,8 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -6288,6 +6391,7 @@
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -6303,6 +6407,7 @@
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-1.1.0.tgz",
       "integrity": "sha512-ZEpopPu+bLIb/x3IF9wXxRdAW74e/ity1XGRxpznAaABKhc8mmtRamRB2l71CSs1YMS8FQxDK/vPK10XlhzG2A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6321,6 +6426,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
       "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       },
@@ -6333,6 +6439,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -6370,6 +6477,7 @@
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
       "integrity": "sha512-9r39FIr3d+KD9SbX0sfMsHzb5PP3uimOiwr3YupUaUFG4W0l1U57Rx3utpttV7qz5U3jmrO5auUa04LU9pyHsg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6413,6 +6521,7 @@
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6422,6 +6531,7 @@
       "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
       "integrity": "sha512-1d50EJ7ipFxb9bIx213o6KPaJmHN8f+nR48UZWxWVzDx+NA3kpscxi02oQX3rGkEaLBi9m3ZayHngQc3+bBX9w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6444,6 +6554,7 @@
       "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
       "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6487,7 +6598,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -6511,7 +6623,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6714,7 +6827,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jschardet": {
       "version": "3.1.4",
@@ -6799,7 +6913,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6829,6 +6944,7 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -7093,6 +7209,7 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -7109,6 +7226,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "error-ex": "^1.2.0"
       },
@@ -7147,13 +7265,15 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.debounce": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
       "integrity": "sha512-lcmJwMpdPAtChA4hfiwxTtgFeNAaow701wWUgVUqeD0XJF7vMXIN+bu/2FJSGxT0NUbZy9g9VFrlOFfPjl+0Ew==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash._getnative": "^3.0.0"
       }
@@ -7175,19 +7295,22 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
       "integrity": "sha512-mvUHifnLqM+03YNzeTBS1/Gr6JRFjd3rRx88FHWUvamVaT9k2O/kXha3yBSOwB9/DTQrSTLJNHvLBBt2FdX7Mg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.padend": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.padstart": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha512-sW73O6S8+Tg66eY56DBk85aQzzUJDtpoXFBgELMd5P/SotAguo+1kYO6RuYgXxA4HJH3LFTFPASX6ET6bjfriw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/log-symbols": {
       "version": "7.0.1",
@@ -7211,6 +7334,7 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha512-RPNliZOFkqFumDhvYqOaNY4Uz9oJM2K9tC6JWsJJsNdhuONW4LQHRBpb0qf4pJApVffI5N39SwzWZJuEhfd7eQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
@@ -7223,7 +7347,8 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -7275,6 +7400,7 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7302,7 +7428,6 @@
       "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-4.1.2.tgz",
       "integrity": "sha512-CMwusHK+Kz0tu1qjgbd0rwcJxzgg76jlkPpqK+pDTv8Hth8JyM7JlgxNWaAFRKe969HATPTz/sp8T63QflyI+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=18",
         "@types/vinyl": "^2.0.8",
@@ -7372,6 +7497,7 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha512-TNdwZs0skRlpPpCUK25StC4VH+tP5GgeY1HQOOGP+lQ2xtdkN2VtT/5tiX9k3IWpkBPV9b3LsAWXn4GGi/PrSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "camelcase-keys": "^2.0.0",
         "decamelize": "^1.1.2",
@@ -7393,6 +7519,7 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7401,13 +7528,15 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/meow/node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -7460,6 +7589,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7469,6 +7599,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -7678,6 +7809,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -7857,6 +7989,7 @@
       "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -7988,6 +8121,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -8064,6 +8198,7 @@
       "resolved": "https://registry.npmjs.org/npm-keyword/-/npm-keyword-4.2.0.tgz",
       "integrity": "sha512-0ykY1vECznZrg9oZ6Bpn2ppcyQA5PW/HxK7PdQMRAfmANKG+f/GBxpMhkPilu7uNiEGTT+8RQ++T7VHt6tHCyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "got": "^5.0.0",
         "object-assign": "^4.0.1",
@@ -8079,6 +8214,7 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8091,6 +8227,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.6.0"
       }
@@ -8100,6 +8237,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -8118,6 +8256,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -8133,6 +8272,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -8148,6 +8288,7 @@
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -8173,6 +8314,7 @@
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -8186,6 +8328,7 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8195,6 +8338,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8207,6 +8351,7 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8219,6 +8364,7 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8228,6 +8374,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "rc": "^1.0.1"
       },
@@ -8240,6 +8387,7 @@
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -8379,6 +8527,7 @@
       "integrity": "sha512-iTK+HI68GceCoGOHAQiJ/ik1iDfI7S+cgyG8A+PP18IU3X83kRhQIRhAUNj4Bp2JMx6Zrt5kCiozYa9uGWTjhA==",
       "deprecated": "this package has been reintegrated into npm and is now out of date with respect to npm",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "config-chain": "~1.1.8",
         "inherits": "~2.0.0",
@@ -8396,13 +8545,15 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/npmconf/node_modules/once": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
       "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8413,6 +8564,7 @@
       "integrity": "sha512-DaL6RTb8Qh4tMe2ttPT1qWccETy2Vi5/8p+htMpLBeXJTr2CAqnF5WQtSP2eFpvaNbhLZ5uilDb98mRm4Q+lZQ==",
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ansi": "~0.3.1",
         "are-we-there-yet": "~1.1.2",
@@ -8424,6 +8576,7 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8691,6 +8844,7 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -8721,6 +8875,7 @@
       "resolved": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
       "integrity": "sha512-+8hwcz/JnQ9EpLIXzN0Rs7DLsBpJNT/xYehtB/jU93tHYr5BFEO8E+JGQNOSqE7opVzz5cGksKFHt7uUJVLSjQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8767,6 +8922,7 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha512-YKyQo/aDk+kLY/ChqYx3DMWW8cbxvZDh+7op1oU60TmLHGWFrn2gPaRWihzDhSwCarAESa9G8dNXzjTGfLx8FQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4.0.1"
       },
@@ -8797,6 +8953,7 @@
       "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "cli-cursor": "^5.0.0",
@@ -8821,6 +8978,7 @@
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8834,6 +8992,7 @@
       "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "is-unicode-supported": "^1.3.0"
@@ -8851,6 +9010,7 @@
       "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8864,6 +9024,7 @@
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -8879,6 +9040,7 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8888,6 +9050,7 @@
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
       "integrity": "sha512-f5estLO2KN8vgtTRaILIgEGBoBrMnZ3JQ7W9TMZCnOIGwHe8TRGSpcagnWDo+Dfhd/z08k9Xe75hvciJJ8Qaew==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "osx-release": "^1.0.0",
         "win-release": "^1.0.0"
@@ -8903,6 +9066,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
       "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
+      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -8912,6 +9076,7 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8922,6 +9087,7 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -8932,6 +9098,7 @@
       "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz",
       "integrity": "sha512-ixCMMwnVxyHFQLQnINhmIpWqXIfS2YOXchwQrk+OFzmo6nDjQ0E4KXAyyUh0T0MZgV4bUhkRrAbVqlE4yLVq4A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.1.0"
       },
@@ -9142,6 +9309,7 @@
       "resolved": "https://registry.npmjs.org/parse-help/-/parse-help-0.1.1.tgz",
       "integrity": "sha512-ny4sykC01dXzASUcjIPLJZDFn6O40+jCNcwqOIpsxQHIKl9JsA7kWt/s6kkwCkuafDnqkDSxdRiNY8DFXgneUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "execall": "^1.0.0"
       },
@@ -9231,7 +9399,8 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-scurry": {
       "version": "2.0.2",
@@ -9286,7 +9455,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9311,6 +9481,7 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9320,6 +9491,7 @@
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9329,6 +9501,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pinkie": "^2.0.0"
       },
@@ -9480,7 +9653,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process-on-spawn": {
       "version": "1.1.0",
@@ -9573,6 +9747,7 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -9635,7 +9810,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -9796,6 +9972,7 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -9809,6 +9986,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "path-exists": "^2.0.0",
         "pinkie-promise": "^2.0.0"
@@ -9821,13 +9999,15 @@
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/read-pkg-up/node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -9840,6 +10020,7 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pinkie-promise": "^2.0.0"
       },
@@ -9852,6 +10033,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -9866,6 +10048,7 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -9904,6 +10087,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -9918,7 +10102,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -9938,6 +10123,7 @@
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha512-8/td4MmwUB6PkZUbV25uKz7dfrmjYWxsW8DVfibWdlHRk/l/DfHKn4pU+dfcoGLFgWOdyGCzINRQD7jn+Bv+/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -9948,13 +10134,15 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "integrity": "sha512-EbrziT4s8cWPmzr47eYVW3wimS4HsvlnV5ri1xw1aR6JQo/OrJX5rkl32K/QQHdxeabJETtfeaROGhd8W7uBgg==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha512-qtW5hKzGQZqKoh6JNSD+4lfitfPKGz42e6QwiRmPM5mmKtR0N41AbJRYu0xJi7nhOJ4WDgRkKvAk6tw4WIwR4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
@@ -10014,6 +10202,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha512-ZqtSMuVybkISo2OWvqvm7iHSWngvdaW3IpsT9/uP8v4gMi591LY6h35wdOfvQdWCKFWZWm2Y1Opp4kV7vQKT6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-finite": "^1.0.0"
       },
@@ -10036,6 +10225,7 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -10068,6 +10258,7 @@
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -10102,13 +10293,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
@@ -10218,6 +10411,7 @@
       "resolved": "https://registry.npmjs.org/root-check/-/root-check-1.0.0.tgz",
       "integrity": "sha512-lt1ts72QmU7jh1DlOJqFN/le/aiRGAbchSSMhNpLQubDWPEOe0YKCcrhprkgyMxxFAcrEhyfTTUfc+Dj/bo4JA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "downgrade-root": "^1.0.0",
         "sudo-block": "^1.1.0"
@@ -10279,12 +10473,14 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "integrity": "sha512-CiaiuN6gapkdl+cZUr67W6I8jquN4lkak3vtIsIWCl4XIPP8ffsoyN6/+PuGXnQy8Cu8W2y9Xxh31Rq4M6wUug==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/rx-lite": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ=="
+      "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ==",
+      "peer": true
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -10430,6 +10626,7 @@
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha512-gL8F8L4ORwsS0+iQ34yCYv///jsOq0ZL7WP55d1HnJ32o7tyFYEFQZQA22mrLIacZdU6xecaBBZ+uEiffGNyXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^5.0.3"
       },
@@ -10442,6 +10639,7 @@
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
       "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -10454,6 +10652,7 @@
       "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
       "integrity": "sha512-V1fGg9i4CL3qesB6U0L6XAm4xOJiHmt4QAacazumuasc03BvtFGIMCduv01JWQ69Nv+JST9TqhSCiJoxoY031w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^5.3.0"
       },
@@ -10553,6 +10752,7 @@
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha512-Li5AOqrZWCVA2n5kryzEmqai6bKSIvpz5oUJHPVj6+dsbD3X1ixtsY5tEnsaNpH3pFAHmG8eIHUrtEtohrg+UQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10718,6 +10918,7 @@
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -10795,6 +10996,7 @@
       "resolved": "https://registry.npmjs.org/sort-on/-/sort-on-1.3.0.tgz",
       "integrity": "sha512-uJJV66QJROauiD0sxoe++eItWUwW+BRLn8PVRjWpg4L8kewOQRvhB4vwHTLZ8vqcu5cxhuQm4iI3ajXgBIqe0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "arrify": "^1.0.0",
         "dot-prop": "^2.0.0"
@@ -10830,6 +11032,7 @@
       "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "concat-stream": "^1.4.7",
         "os-shim": "^0.1.2"
@@ -10904,6 +11107,7 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
       "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -10952,6 +11156,7 @@
       "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -10975,6 +11180,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -10983,13 +11189,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
       "integrity": "sha512-MNCACnufWUf3pQ57O5WTBMkKhzYIaKEcUioO0XHrTMafrbBaNk4IyDOLHBv5xbXO0jLLdsYWeFjpjG2hVHRDtw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "strip-ansi": "^3.0.0"
       },
@@ -11002,6 +11210,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11011,6 +11220,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -11024,6 +11234,7 @@
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -11042,6 +11253,7 @@
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11055,6 +11267,7 @@
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -11082,6 +11295,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-utf8": "^0.2.0"
       },
@@ -11137,6 +11351,7 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha512-I5iQq6aFMM62fBEAIB/hXzwJD6EEZ0xEGCX2t7oXqaKPIRgt4WruAQ285BISgdkP+HLGWyeGmNJcpIwFeRYRUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-stdin": "^4.0.1"
       },
@@ -11164,6 +11379,7 @@
       "resolved": "https://registry.npmjs.org/sudo-block/-/sudo-block-1.2.0.tgz",
       "integrity": "sha512-RE3gka+wcmkvAMt7Ht/TORJ6uxIo+MBPCCibLLygj6xec817CtEYDG6IyICFyWwHZwO3c6d61XdWRrgffq7WJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^1.0.0",
         "is-docker": "^1.0.0",
@@ -11178,6 +11394,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11187,6 +11404,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11196,6 +11414,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -11212,6 +11431,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -11221,6 +11441,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -11233,6 +11454,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -11258,6 +11480,7 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11375,6 +11598,7 @@
       "resolved": "https://registry.npmjs.org/tabtab/-/tabtab-1.3.2.tgz",
       "integrity": "sha512-qHWOJ5g7lrpftZMyPv3ZaYZs7PuUTKWEP/TakZHfpq66bSwH25SQXn5616CCh6Hf/1iPcgQJQHGcJkzQuATabQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^2.2.0",
         "inquirer": "^1.0.2",
@@ -11392,6 +11616,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11401,6 +11626,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11410,6 +11636,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -11426,6 +11653,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "restore-cursor": "^1.0.1"
       },
@@ -11437,13 +11665,15 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/tabtab/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -11453,6 +11683,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -11462,6 +11693,7 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
       "integrity": "sha512-diSnpgfv/Ozq6QKuV2mUcwZ+D24b03J3W6EVxzvtkCWJTPrH2gKLsqgSW0vzRMZZFhFdhnvzka0RUJxIm7AOxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^1.1.0",
         "chalk": "^1.0.0",
@@ -11483,19 +11715,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tabtab/node_modules/mute-stream": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
       "integrity": "sha512-m0kBTDLF/0lgzCsPVmJSKM5xkLNX7ZAB0Q+n2DP37JMIRPVC2R4c3BdO6x++bXFKftbhvSfKgwxAexME+BRDRw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/tabtab/node_modules/onetime": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11505,6 +11740,7 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "exit-hook": "^1.0.0",
         "onetime": "^1.0.0"
@@ -11518,6 +11754,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -11527,6 +11764,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -11541,6 +11779,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -11553,6 +11792,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -11562,6 +11802,7 @@
       "resolved": "https://registry.npmjs.org/taketalk/-/taketalk-1.0.0.tgz",
       "integrity": "sha512-kS7E53It6HA8S1FVFBWP7HDwgTiJtkmYk7TsowGlizzVrivR1Mf9mgjXHY1k7rOfozRVMZSfwjB3bevO4QEqpg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-stdin": "^4.0.1",
         "minimist": "^1.1.0"
@@ -11664,13 +11905,15 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/through2": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
       "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "2 || 3"
@@ -11717,7 +11960,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11730,6 +11972,7 @@
       "resolved": "https://registry.npmjs.org/titleize/-/titleize-1.0.1.tgz",
       "integrity": "sha512-rUwGDruKq1gX+FFHbTl5qjI7teVO7eOe+C8IcQ7QT+1BK3eEUXJqbZcBOeaRP4FwSC/C1A5jDoIVta0nIQ9yew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11739,6 +11982,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
       "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.14"
       }
@@ -11769,6 +12013,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -11794,6 +12039,7 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-5.0.0.tgz",
       "integrity": "sha512-kstfs+hgwmdsOadN3KgA+C68wPJwnZq4DN6WMDCvZapDWEF34W2TyPKN2v2+BJnZgIz5QOfxFeldLyYvdgRAwg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -11828,6 +12074,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -11839,12 +12086,14 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/twig": {
       "version": "0.8.9",
       "resolved": "https://registry.npmjs.org/twig/-/twig-0.8.9.tgz",
       "integrity": "sha512-X/1wUorHWi3KsKVpToFnB4aXiuW0zS8s+Pmp+k/Ubl7Y3Us1FAXGbFcLVNOwBPcZ81m0F2TwjU4t4OD4HPqd4w==",
+      "peer": true,
       "dependencies": {
         "minimatch": "3.0.x",
         "walk": "2.3.x"
@@ -11861,6 +12110,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
       "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -11935,7 +12185,8 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -11953,6 +12204,7 @@
       "integrity": "sha512-ZiLtQrdrFvWVXW5wickjtHiyOkn+cG74B0r33DQ2vJuz12FsFO7dU2q0dumrrYk6ny4wl2Vjsodpxk0+Z10/rA==",
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -12012,6 +12264,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -12074,6 +12327,7 @@
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.6.3.tgz",
       "integrity": "sha512-Gjt2a7j+qL2wvazHPSkWZOay4NfZe7WpV63OtrKbK6Uxyta0U1aS7f++XSNpljIinKYLC8wrNfPHYkPmV5AhbQ==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "boxen": "^0.3.1",
         "chalk": "^1.0.0",
@@ -12091,6 +12345,7 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12103,6 +12358,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12112,6 +12368,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12121,6 +12378,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.6.0"
       }
@@ -12130,6 +12388,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -12148,6 +12407,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -12164,6 +12424,7 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
       "integrity": "sha512-BOCxwwxF5WPspp1OBq9j0JLyL5JgJOTssz9PdOHr8VWjFijaC3PpjU48vFEX3uxx8sTusnVQckLbNzBq6fmkGw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "dot-prop": "^3.0.0",
         "graceful-fs": "^4.1.2",
@@ -12184,6 +12445,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -12199,6 +12461,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -12208,6 +12471,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -12223,6 +12487,7 @@
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -12248,6 +12513,7 @@
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -12261,6 +12527,7 @@
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
       "integrity": "sha512-8925wFYLfWBciewimt0VmDyYw0GFCRcbFSTrZGt4JgQ7lh5jb/kodMlUt0uMaxXdRKVi+7F3ib30N7fTv83ikw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "package-json": "^2.0.0"
       },
@@ -12273,6 +12540,7 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12282,6 +12550,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12294,6 +12563,7 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12306,6 +12576,7 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12315,6 +12586,7 @@
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
       "integrity": "sha512-PRg65iXMTt/uK8Rfh5zvzkUbfAPitF17YaCY+IbHsYgksiLvtzWWTUildHth3mVaZ7871OJ7gtP4LBRBlmAdXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "got": "^5.0.0",
         "registry-auth-token": "^3.0.1",
@@ -12330,6 +12602,7 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
       "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "rc": "^1.1.6",
         "safe-buffer": "^5.0.1"
@@ -12340,6 +12613,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "rc": "^1.0.1"
       },
@@ -12352,6 +12626,7 @@
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -12364,6 +12639,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -12376,6 +12652,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -12394,6 +12671,7 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -12404,6 +12682,7 @@
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "os-homedir": "^1.0.0"
       },
@@ -12428,7 +12707,8 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
       "integrity": "sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -12467,6 +12747,7 @@
         "node >=0.6.0"
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -12477,7 +12758,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/version-range": {
       "version": "4.15.0",
@@ -12535,6 +12817,7 @@
       "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
       "integrity": "sha512-4eRTBZljBfIISK1Vnt69Gvr2w/wc3U6Vtrw7qiN5iqYJPH7LElcYh/iU4XWhdCy2dZqv1ToMyYlybDylfG/5Vg==",
       "license": "(MIT OR Apache-2.0)",
+      "peer": true,
       "dependencies": {
         "foreachasync": "^3.0.0"
       }
@@ -12692,6 +12975,7 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "integrity": "sha512-r5vvGtqsHUHn98V0jURY4Ts86xJf6+SzK9rpWdV8/73nURB3WFPIHd67aOvPw2fSuunIyHjAUqiJ2TY0x4E5gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-width": "^1.0.1"
       },
@@ -12704,6 +12988,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12713,6 +12998,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -12727,6 +13013,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -12739,6 +13026,7 @@
       "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
       "integrity": "sha512-iCRnKVvGxOQdsKhcQId2PXV1vV3J/sDPXKA4Oe9+Eti2nb2ESEsYHRYls/UjoUW3bIc5ZDO8dTH50A/5iVN+bw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^5.0.1"
       },
@@ -12829,6 +13117,7 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
       "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -12840,6 +13129,7 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
       "integrity": "sha512-NF1pPn594TaRSUO/HARoB4jK8I+rWgcpVlpQCK6/6o5PHyLUt2CSiDrpUZbQ6rROck+W2EwF8mBJcTs+W98J9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "os-homedir": "^1.0.0"
       },
@@ -12970,6 +13260,7 @@
       "resolved": "https://registry.npmjs.org/yeoman-character/-/yeoman-character-1.1.0.tgz",
       "integrity": "sha512-oxzeZugaEkVJC+IHwcb+DZDb8IdbZ3f4rHax4+wtJstCx+9BAaMX+Inmp3wmGmTWftJ7n5cPqQRbo1FaV/vNXQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "supports-color": "^3.1.2"
       },
@@ -12985,6 +13276,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12994,6 +13286,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
       "integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^1.0.0"
       },
@@ -13006,6 +13299,7 @@
       "resolved": "https://registry.npmjs.org/yeoman-doctor/-/yeoman-doctor-2.1.0.tgz",
       "integrity": "sha512-qlvpKZYZl7qeT1EUZPQDKcQL3vYhGcZTQ0GemzoAv/ydFOL1HFslU/Qnqq/w0kqzWPBilRfRloRwWBZiLOBtOg==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "bin-version-check": "^2.1.0",
         "chalk": "^1.0.0",
@@ -13028,6 +13322,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13037,6 +13332,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13046,6 +13342,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -13062,6 +13359,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -13071,6 +13369,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha512-mmPrW0Fh2fxOzdBbFv4g1m6pR72haFLPJ2G5SJEELf1y+iaQrDG6cWCPjy54RHYbZAt7X+ls690Kw62AdWXBzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^1.0.0"
       },
@@ -13083,6 +13382,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -13095,6 +13395,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -13506,7 +13807,6 @@
       "integrity": "sha512-4uttbNuZ/guMBRhf7R6TCfnLT6XY1HGpxsq6vpHRM3AVr5G6Qz7xXqxG2kdMzBGtIuH5CkXz0k/Byl27GsvIkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/core": "^11.1.5",
         "@inquirer/prompts": "^8.3.0",
@@ -13968,7 +14268,6 @@
       "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-7.5.1.tgz",
       "integrity": "sha512-MYncRvzSTd71BMwiUMAVhfX00sDD8DZDrmPzRxQkWuWQ0V1Qt4Rd0gS/Nee2QDTWvRjvCa+KBfiAVrtOySq+JA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@types/lodash-es": "^4.17.9",
         "@yeoman/namespace": "^1.0.0",
@@ -14051,6 +14350,7 @@
       "integrity": "sha512-npZ9vc25nOQbc5vYAbPUxDJx9eMd5oD+tljQwqzW7L2hjqD1dQKXc4sHu6dnF3/19N6FVAc2FeOgSZMUI/MZBg==",
       "hasInstallScript": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "async": "^1.0.0",
         "chalk": "^1.0.0",
@@ -14096,6 +14396,7 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14108,6 +14409,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14117,6 +14419,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14126,6 +14429,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-uniq": "^1.0.1"
       },
@@ -14137,13 +14441,15 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/yo/node_modules/cacheable-lookup": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.6.0"
       }
@@ -14153,6 +14459,7 @@
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -14171,6 +14478,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -14187,6 +14495,7 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha512-3Fo5wu8Ytle8q9iCzS4D2MWVL2X7JVWRiS1BnXbTFDhS9c/REkM9vd1AmabsoZoY5/dGi5TT9iKL8Kb6DeBRQg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14196,6 +14505,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "restore-cursor": "^1.0.1"
       },
@@ -14207,13 +14517,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz",
       "integrity": "sha512-eMU2akIeEIkCxGXUNmDnJq1KzOIiPnJ+rKqRe6hcxE3vIOPvpMrBYOn/Bl7zNlYJj/zQxXquAnozHUCf9Whnsg==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yo/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -14223,6 +14535,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -14238,6 +14551,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -14247,6 +14561,7 @@
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
       "integrity": "sha512-X8Z+b/0L4lToKYq+lwnKqi9X/Zek0NibLpsJgVsSxpoYq7JtiCtRb5HqKVEjEw/qAb/4AKKRLOwwKHlWNpm2Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.2"
       },
@@ -14259,6 +14574,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -14275,6 +14591,7 @@
       "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "inflight": "^1.0.4",
         "inherits": "2",
@@ -14291,6 +14608,7 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
       "integrity": "sha512-JPDtMSr0bt25W64q792rvlrSwIaZwqUAhqdYKSr57Wh/xBcQ5JDWLM85ndn+Q1WdBQXLb9YGCl0QN/T0HpqU0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-union": "^1.0.1",
         "arrify": "^1.0.0",
@@ -14308,6 +14626,7 @@
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -14333,6 +14652,7 @@
       "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
       "integrity": "sha512-AQxoopv/bBI2GsK8ZIMHgZA3lHZr7qlseQnSKahmQpgZ5x5aX7DeT9i4TOvo0ObFrfBH04IUDxzY1gW0nxm8hQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.2"
       }
@@ -14342,6 +14662,7 @@
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -14355,6 +14676,7 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.4.tgz",
       "integrity": "sha512-QR+2TW90jnKk9LUUtbcA3yQXKt2rDEKMh6+BAZQIeumtzHexnwVLdPakSslGijXYLJCzFv7GMXbFCn0pA00EUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^1.1.0",
         "ansi-regex": "^2.0.0",
@@ -14376,6 +14698,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha512-mmPrW0Fh2fxOzdBbFv4g1m6pR72haFLPJ2G5SJEELf1y+iaQrDG6cWCPjy54RHYbZAt7X+ls690Kw62AdWXBzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^1.0.0"
       },
@@ -14388,6 +14711,7 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -14397,6 +14721,7 @@
       "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.2.0.tgz",
       "integrity": "sha512-b8g0jWKdl8pM0LqAPdK9i8ERL7nYrzmJfRhxMiWH2uYdfYnb7uXnmwVb0ZGe7xyEl4lj+nLIU3yf4zPUT+XsVQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "through2": "^3.0.0",
         "vinyl": "^2.0.1",
@@ -14408,6 +14733,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14419,19 +14745,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/yo/node_modules/mute-stream": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
       "integrity": "sha512-m0kBTDLF/0lgzCsPVmJSKM5xkLNX7ZAB0Q+n2DP37JMIRPVC2R4c3BdO6x++bXFKftbhvSfKgwxAexME+BRDRw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yo/node_modules/normalize-url": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14444,6 +14773,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14453,6 +14783,7 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -14462,6 +14793,7 @@
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
       "integrity": "sha512-PRg65iXMTt/uK8Rfh5zvzkUbfAPitF17YaCY+IbHsYgksiLvtzWWTUildHth3mVaZ7871OJ7gtP4LBRBlmAdXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "got": "^5.0.0",
         "registry-auth-token": "^3.0.1",
@@ -14477,6 +14809,7 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
       "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "rc": "^1.1.6",
         "safe-buffer": "^5.0.1"
@@ -14487,6 +14820,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "rc": "^1.0.1"
       },
@@ -14499,6 +14833,7 @@
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
       "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -14508,6 +14843,7 @@
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -14520,6 +14856,7 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "exit-hook": "^1.0.0",
         "onetime": "^1.0.0"
@@ -14533,6 +14870,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha512-qOX+w+IxFgpUpJfkv2oGN0+ExPs68F4sZHfaRRx4dDexAQkG83atugKVEylyT5ARees3HBbfmuvnjbrd8j9Wjw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "once": "^1.3.0"
       }
@@ -14542,6 +14880,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -14556,6 +14895,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -14568,6 +14908,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
       "integrity": "sha512-1sUIL1jck0T1mhOLP2c696BIznzT525Lkub+n4jjMHjhjhoAQA6Ye659DxdlZBr0aLDMQoTxKIpnlqxgtwjsuQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-utf8": "^0.2.1"
       },
@@ -14580,6 +14921,7 @@
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
       "integrity": "sha512-yH0+mD8oahBZWnY43vxs4pSinn8SMKAdml/EOGBewoe1Y0Eitd0h2Mg3ZRiXruUW6L4P+lvZiEgbh0NgUGia1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "first-chunk-stream": "^2.0.0",
         "strip-bom": "^2.0.0"
@@ -14593,6 +14935,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -14602,6 +14945,7 @@
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha512-sJjbDp2GodvkB0FZZcn7k6afVisqX5BZD7Yq3xp4nN2O15BBK0cLm3Vwn2vQaF7UDS0UUsrQMkkplmDI5fskig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "os-homedir": "^1.0.0"
       },
@@ -14614,6 +14958,7 @@
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
       "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clone": "^2.1.1",
         "clone-buffer": "^1.0.0",
@@ -14631,6 +14976,7 @@
       "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-3.0.0.tgz",
       "integrity": "sha512-BoJDj+ca3D9xOuPEM6RWVtWQtvEPQiQYn82LvdxhLWplfQsBzBqtgK0yhCP0s1BNTi6dH9BO+dzybvyQIacifg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.3.0",
@@ -14647,6 +14993,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -14660,6 +15007,7 @@
       "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.6.6.tgz",
       "integrity": "sha512-Sg0mCm/MhMc7QBQb8KhQqQIdL8olccyNUCK0N2KFHI9PYmwEN/vS23xv2JZgr2C0zl0ZkrrXH2lPJOLvLycftg==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "chalk": "^1.0.0",
         "debug": "^2.0.0",
@@ -14679,13 +15027,15 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yo/node_modules/yeoman-environment/node_modules/inquirer": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
       "integrity": "sha512-diSnpgfv/Ozq6QKuV2mUcwZ+D24b03J3W6EVxzvtkCWJTPrH2gKLsqgSW0vzRMZZFhFdhnvzka0RUJxIm7AOxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-escapes": "^1.1.0",
         "chalk": "^1.0.0",
@@ -14708,6 +15058,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -14717,6 +15068,7 @@
       "resolved": "https://registry.npmjs.org/yosay/-/yosay-1.2.1.tgz",
       "integrity": "sha512-B7jGygVGUoOK7A7CfvpmRiKo7i8Ksmi5MHElSMZeI7CV7pehgPYZVzbyWSxc49YyRsyTewi3SpgHlvGF0h32vA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0",
         "ansi-styles": "^2.0.0",
@@ -14767,6 +15119,7 @@
       "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -14910,7 +15263,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "generator-ml-container-creator",
+  "name": "@aws/generator-ml-container-creator",
   "version": "1.0.0",
   "description": "Generator for SageMaker AI BYOC paradigm for predictive inference use-cases.",
   "type": "module",
@@ -29,10 +29,11 @@
     "security-fix": "npm audit fix",
     "lint": "eslint generators/**/*.js test/**/*.js",
     "lint:fix": "eslint generators/**/*.js test/**/*.js --fix",
-    "start": "yo ml-container-creator",
-    "dev": "npm link && yo ml-container-creator",
+    "start": "yo @aws/ml-container-creator",
+    "dev": "npm link && yo @aws/ml-container-creator",
     "clean": "rm -rf test-output-*",
     "validate": "npm run lint && npm run test:all",
+    "validate:namespaces": "node scripts/validate-namespaces.js",
     "docs:serve": "mkdocs serve",
     "docs:build": "mkdocs build",
     "docs:deploy": "mkdocs gh-deploy",
@@ -106,7 +107,6 @@
   },
   "author": "Dan Ferguson",
   "license": "Apache-2.0",
-  "private": true,
   "peerDependencies": {
     "yo": "^1.4.2"
   }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -391,7 +391,7 @@ test_your_new_feature() {
     mkdir -p "your-feature-test-$test_name"
     cd "your-feature-test-$test_name"
     
-    if yo ml-container-creator \
+    if yo @aws/ml-container-creator \
         --framework=sklearn \
         --your-new-option="$your_param" \
         --skip-prompts > "../your-feature-$test_name.log" 2>&1; then
@@ -493,8 +493,8 @@ cd "test-$framework-$server"
 cd ..
 
 # ❌ Avoid: Tests interfering with each other
-yo ml-container-creator --framework=sklearn  # Files created in current dir
-yo ml-container-creator --framework=xgboost  # Overwrites previous files
+yo @aws/ml-container-creator --framework=sklearn  # Files created in current dir
+yo @aws/ml-container-creator --framework=xgboost  # Overwrites previous files
 ```
 
 #### 2. Comprehensive Validation
@@ -527,7 +527,7 @@ test_your_feature() {
     mkdir -p "$test_dir"
     cd "$test_dir"
     
-    if yo ml-container-creator --your-option --skip-prompts > ../test.log 2>&1; then
+    if yo @aws/ml-container-creator --your-option --skip-prompts > ../test.log 2>&1; then
         # Validate success case
         validate_files ["expected-file.txt"] "your feature test"
         cd ..
@@ -548,7 +548,7 @@ test_your_feature() {
 test_your_feature() {
     mkdir -p "test-dir"
     cd "test-dir"
-    yo ml-container-creator --your-option --skip-prompts
+    yo @aws/ml-container-creator --your-option --skip-prompts
     # If this fails, we're stuck in test-dir
     validate_files ["expected-file.txt"] "test"
 }
@@ -558,7 +558,7 @@ test_your_feature() {
 ```bash
 # ✅ Good: Clear, informative output
 print_substep "Testing sklearn + Flask + pkl format"
-verbose_log "Running: yo ml-container-creator --framework=sklearn --model-server=flask --model-format=pkl --skip-prompts"
+verbose_log "Running: yo @aws/ml-container-creator --framework=sklearn --model-server=flask --model-format=pkl --skip-prompts"
 if validate_files ["Dockerfile", "requirements.txt"] "sklearn Flask generation"; then
     print_success "sklearn + Flask test passed"
 else
@@ -566,7 +566,7 @@ else
 fi
 
 # ❌ Avoid: Unclear or missing output
-yo ml-container-creator --framework=sklearn --model-server=flask --skip-prompts > /dev/null
+yo @aws/ml-container-creator --framework=sklearn --model-server=flask --skip-prompts > /dev/null
 if [[ -f "Dockerfile" ]]; then
     echo "OK"
 fi

--- a/scripts/test-generate-configs.sh
+++ b/scripts/test-generate-configs.sh
@@ -433,7 +433,7 @@ print_info "Testing basic framework configurations..."
 for config in basic-*.json; do
     if [[ -f "$config" ]]; then
         echo "Testing: $config"
-        if yo ml-container-creator --config="$config" --skip-prompts > "${config%.json}.log" 2>&1; then
+        if yo @aws/ml-container-creator --config="$config" --skip-prompts > "${config%.json}.log" 2>&1; then
             print_success "Config test passed: $config"
             ((TESTS_PASSED++))
         else
@@ -448,7 +448,7 @@ print_info "Testing edge case configurations..."
 for config in edge-*.json; do
     if [[ -f "$config" ]]; then
         echo "Testing: $config"
-        if yo ml-container-creator --config="$config" --skip-prompts > "${config%.json}.log" 2>&1; then
+        if yo @aws/ml-container-creator --config="$config" --skip-prompts > "${config%.json}.log" 2>&1; then
             print_success "Edge case test passed: $config"
             ((TESTS_PASSED++))
         else
@@ -463,7 +463,7 @@ print_info "Testing error configurations (should fail)..."
 for config in error-*.json; do
     if [[ -f "$config" ]]; then
         echo "Testing: $config (expecting failure)"
-        if yo ml-container-creator --config="$config" --skip-prompts > "${config%.json}.log" 2>&1; then
+        if yo @aws/ml-container-creator --config="$config" --skip-prompts > "${config%.json}.log" 2>&1; then
             print_error "Error test unexpectedly passed: $config"
             ((TESTS_FAILED++))
         else

--- a/scripts/test-generate-projects.sh
+++ b/scripts/test-generate-projects.sh
@@ -441,7 +441,7 @@ test_env_variables() {
     mkdir -p "$project_name"
     cd "$project_name"
     
-    if yo ml-container-creator \
+    if yo @aws/ml-container-creator \
         --framework=sklearn \
         --model-server=flask \
         --model-format=pkl \
@@ -506,7 +506,7 @@ test_config_file() {
     mkdir -p "config-test-$(basename "$config_file" .json)"
     cd "config-test-$(basename "$config_file" .json)"
     
-    if yo ml-container-creator --config="../$config_file" --skip-prompts > "../${config_file%.json}.log" 2>&1; then
+    if yo @aws/ml-container-creator --config="../$config_file" --skip-prompts > "../${config_file%.json}.log" 2>&1; then
         
         # Validate framework-specific files
         local validation_passed=true
@@ -561,7 +561,7 @@ test_precedence() {
     mkdir -p "$project_name"
     cd "$project_name"
     
-    if yo ml-container-creator \
+    if yo @aws/ml-container-creator \
         --framework=sklearn \
         --model-server=flask \
         --model-format=pkl \
@@ -597,7 +597,7 @@ test_error_handling() {
     mkdir -p "error-test-invalid-framework"
     cd "error-test-invalid-framework"
     
-    if yo ml-container-creator --framework=invalid --skip-prompts > ../invalid-framework.log 2>&1; then
+    if yo @aws/ml-container-creator --framework=invalid --skip-prompts > ../invalid-framework.log 2>&1; then
         if grep -q "Unsupported framework\|not implemented\|invalid" ../invalid-framework.log; then
             verbose_log "Invalid framework error handling works"
             ((error_tests_passed++))
@@ -614,7 +614,7 @@ test_error_handling() {
     mkdir -p "error-test-missing-params"
     cd "error-test-missing-params"
     
-    if yo ml-container-creator --skip-prompts > ../missing-params.log 2>&1; then
+    if yo @aws/ml-container-creator --skip-prompts > ../missing-params.log 2>&1; then
         # When no framework is specified, generator should use defaults (sklearn)
         if [[ -f "Dockerfile" && -f "requirements.txt" ]]; then
             verbose_log "Missing parameter handling works (uses defaults)"
@@ -632,7 +632,7 @@ test_error_handling() {
     mkdir -p "error-test-invalid-combo"
     cd "error-test-invalid-combo"
     
-    if yo ml-container-creator --framework=sklearn --model-server=vllm --skip-prompts > ../invalid-combo.log 2>&1; then
+    if yo @aws/ml-container-creator --framework=sklearn --model-server=vllm --skip-prompts > ../invalid-combo.log 2>&1; then
         if grep -q "invalid\|incompatible\|not supported\|Unsupported" ../invalid-combo.log; then
             verbose_log "Invalid combination error handling works"
             ((error_tests_passed++))
@@ -666,7 +666,7 @@ test_cli_commands() {
     mkdir -p "cli-test-help"
     cd "cli-test-help"
     
-    if yo ml-container-creator help > ../help-output.log 2>&1; then
+    if yo @aws/ml-container-creator help > ../help-output.log 2>&1; then
         if grep -q "CLI OPTIONS\|USAGE\|EXAMPLES" ../help-output.log; then
             verbose_log "Help command works correctly"
             ((cli_tests_passed++))
@@ -679,7 +679,7 @@ test_cli_commands() {
     mkdir -p "cli-test-config"
     cd "cli-test-config"
     
-    if echo "1" | yo ml-container-creator generate-empty-config > ../empty-config.log 2>&1; then
+    if echo "1" | yo @aws/ml-container-creator generate-empty-config > ../empty-config.log 2>&1; then
         if [[ -f "config/mcp.json" ]]; then
             verbose_log "Generate empty config works correctly"
             ((cli_tests_passed++))
@@ -751,7 +751,7 @@ main() {
     print_step "6" "Testing Package.json Configuration (6th Precedence)"
     
     # The package.json should be in the current directory for the generator to find it
-    if yo ml-container-creator --framework=sklearn --model-server=flask --model-format=pkl --skip-prompts > package-json-test.log 2>&1; then
+    if yo @aws/ml-container-creator --framework=sklearn --model-server=flask --model-format=pkl --skip-prompts > package-json-test.log 2>&1; then
         if validate_file_content "deploy/deploy.sh" "eu-central-1" "Package.json AWS region"; then
             print_success "Package.json configuration test passed"
             record_test_result "Package.json Configuration" "PASS"

--- a/scripts/validate-namespaces.js
+++ b/scripts/validate-namespaces.js
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// CI validation script for npm namespace policy enforcement.
+// Scans all package.json and manifest.json files to verify:
+// - Root package uses @aws/ scope
+// - Server packages use @amzn/ scope
+// - No packages use the legacy @ml-container-creator/ scope
+// - Publish safety (private field) is set correctly
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs'
+import { resolve, dirname, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const repoRoot = resolve(__dirname, '..')
+const serversRoot = resolve(repoRoot, 'servers')
+const rootPkgPath = resolve(repoRoot, 'package.json')
+
+/**
+ * Safely parse a JSON file, returning null on failure and pushing an error.
+ * @param {string} filePath - Absolute path to the JSON file
+ * @param {string[]} errors - Array to push parse errors into
+ * @returns {object|null}
+ */
+function safeParseJson(filePath, errors) {
+    try {
+        return JSON.parse(readFileSync(filePath, 'utf8'))
+    } catch (err) {
+        const rel = relative(repoRoot, filePath)
+        errors.push(`${rel}: not valid JSON: ${err.message}`)
+        return null
+    }
+}
+
+/**
+ * Validate that the root package.json name starts with @aws/.
+ * @param {string} pkgPath - Absolute path to root package.json
+ * @returns {string[]} Array of error strings (empty if valid)
+ */
+export function validateRootNamespace(pkgPath) {
+    const errors = []
+
+    if (!existsSync(pkgPath)) {
+        errors.push('Root package.json not found')
+        return errors
+    }
+
+    const pkg = safeParseJson(pkgPath, errors)
+    if (!pkg) return errors
+
+    if (!pkg.name) {
+        errors.push('Root package.json: missing "name" field')
+    } else if (!pkg.name.startsWith('@aws/')) {
+        errors.push(`Root package.json: name "${pkg.name}" does not start with @aws/`)
+    } else {
+        console.log('✓ Root package.json: name starts with @aws/')
+    }
+
+    return errors
+}
+
+/**
+ * Validate that every server pkg name starts with @amzn/.
+ * Also validates servers/lib.
+ * @param {string} serversDir - Absolute path to the servers/ directory
+ * @returns {string[]} Array of error strings (empty if valid)
+ */
+export function validateServerNamespaces(serversDir) {
+    const errors = []
+
+    if (!existsSync(serversDir)) {
+        errors.push('servers/ directory not found')
+        return errors
+    }
+
+    const entries = readdirSync(serversDir)
+    for (const entry of entries) {
+        const fullPath = resolve(serversDir, entry)
+        if (!statSync(fullPath).isDirectory()) continue
+
+        const pkgPath = resolve(fullPath, 'package.json')
+        if (!existsSync(pkgPath)) continue
+
+        const pkg = safeParseJson(pkgPath, errors)
+        if (!pkg) continue
+
+        const rel = `servers/${entry}/package.json`
+        if (!pkg.name) {
+            errors.push(`${rel}: missing "name" field`)
+        } else if (!pkg.name.startsWith('@amzn/')) {
+            errors.push(`${rel}: name "${pkg.name}" does not start with @amzn/`)
+        } else {
+            console.log(`✓ ${rel}: name starts with @amzn/`)
+        }
+    }
+
+    return errors
+}
+
+/**
+ * Validate that every server manifest name starts with @amzn/.
+ * @param {string} serversDir - Absolute path to the servers/ directory
+ * @returns {string[]} Array of error strings (empty if valid)
+ */
+export function validateManifestNamespaces(serversDir) {
+    const errors = []
+
+    if (!existsSync(serversDir)) {
+        errors.push('servers/ directory not found')
+        return errors
+    }
+
+    const entries = readdirSync(serversDir)
+    for (const entry of entries) {
+        const fullPath = resolve(serversDir, entry)
+        if (!statSync(fullPath).isDirectory()) continue
+
+        const manifestPath = resolve(fullPath, 'manifest.json')
+        if (!existsSync(manifestPath)) continue
+
+        const manifest = safeParseJson(manifestPath, errors)
+        if (!manifest) continue
+
+        const rel = `servers/${entry}/manifest.json`
+        if (!manifest.name) {
+            errors.push(`${rel}: missing "name" field`)
+        } else if (!manifest.name.startsWith('@amzn/')) {
+            errors.push(`${rel}: name "${manifest.name}" does not start with @amzn/`)
+        } else {
+            console.log(`✓ ${rel}: name starts with @amzn/`)
+        }
+    }
+
+    return errors
+}
+
+/**
+ * Validate that no pkg in the repo uses the legacy scope.
+ * Scans all package.json files recursively, skipping node_modules and .git.
+ * @param {string} root - Absolute path to the repository root
+ * @returns {string[]} Array of error strings (empty if valid)
+ */
+export function validateNoLegacyScope(root) {
+    const errors = []
+    const legacyScope = '@ml-container-creator/'
+
+    function scanDir(dir) {
+        let entries
+        try {
+            entries = readdirSync(dir)
+        } catch {
+            return
+        }
+
+        for (const entry of entries) {
+            if (entry === 'node_modules' || entry === '.git') continue
+
+            const fullPath = resolve(dir, entry)
+            let stat
+            try {
+                stat = statSync(fullPath)
+            } catch {
+                continue
+            }
+
+            if (stat.isDirectory()) {
+                scanDir(fullPath)
+            } else if (entry === 'package.json') {
+                const pkg = safeParseJson(fullPath, errors)
+                if (!pkg) continue
+
+                const rel = relative(root, fullPath)
+                if (pkg.name && pkg.name.startsWith(legacyScope)) {
+                    errors.push(`${rel}: name "${pkg.name}" uses legacy scope ${legacyScope}`)
+                }
+            }
+        }
+    }
+
+    scanDir(root)
+
+    if (errors.length === 0) {
+        console.log(`✓ No package.json uses legacy scope ${legacyScope}`)
+    }
+
+    return errors
+}
+
+/**
+ * Validate publish safety: server packages must be private, root must not be.
+ * @param {string} pkgPath - Absolute path to root package.json
+ * @param {string} serversDir - Absolute path to the servers/ directory
+ * @returns {string[]} Array of error strings (empty if valid)
+ */
+export function validatePublishSafety(pkgPath, serversDir) {
+    const errors = []
+
+    // Check root package is NOT private
+    if (!existsSync(pkgPath)) {
+        errors.push('Root package.json not found')
+    } else {
+        const rootPkg = safeParseJson(pkgPath, errors)
+        if (rootPkg) {
+            if (rootPkg.private === true) {
+                errors.push('Root package.json: must NOT have "private": true (it is published to npm)')
+            } else {
+                console.log('✓ Root package.json: not marked as private (publishable)')
+            }
+        }
+    }
+
+    // Check all server packages ARE private
+    if (!existsSync(serversDir)) {
+        errors.push('servers/ directory not found')
+        return errors
+    }
+
+    const entries = readdirSync(serversDir)
+    for (const entry of entries) {
+        const fullPath = resolve(serversDir, entry)
+        if (!statSync(fullPath).isDirectory()) continue
+
+        const serverPkgPath = resolve(fullPath, 'package.json')
+        if (!existsSync(serverPkgPath)) continue
+
+        const pkg = safeParseJson(serverPkgPath, errors)
+        if (!pkg) continue
+
+        const rel = `servers/${entry}/package.json`
+        if (pkg.private !== true) {
+            errors.push(`${rel}: missing "private": true (internal package must not be published)`)
+        } else {
+            console.log(`✓ ${rel}: marked as private`)
+        }
+    }
+
+    return errors
+}
+
+/**
+ * Run all namespace and publish safety validations.
+ * @returns {{ errors: string[], checkCount: number }}
+ */
+export function validateAll() {
+    const errors = []
+    let checkCount = 0
+
+    console.log('── Namespace validation ──')
+
+    console.log('\n  Root package:')
+    const rootErrors = validateRootNamespace(rootPkgPath)
+    errors.push(...rootErrors)
+    checkCount++
+
+    console.log('\n  Server packages:')
+    const serverErrors = validateServerNamespaces(serversRoot)
+    errors.push(...serverErrors)
+    checkCount++
+
+    console.log('\n  Server manifests:')
+    const manifestErrors = validateManifestNamespaces(serversRoot)
+    errors.push(...manifestErrors)
+    checkCount++
+
+    console.log('\n  Legacy scope scan:')
+    const legacyErrors = validateNoLegacyScope(repoRoot)
+    errors.push(...legacyErrors)
+    checkCount++
+
+    console.log('\n── Publish safety ──')
+    const publishErrors = validatePublishSafety(rootPkgPath, serversRoot)
+    errors.push(...publishErrors)
+    checkCount++
+
+    return { errors, checkCount }
+}
+
+// Run when executed directly
+const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(__filename)
+if (isMain) {
+    const { errors, checkCount } = validateAll()
+
+    if (errors.length > 0) {
+        console.log('')
+        for (const err of errors) {
+            console.error(`❌ ${err}`)
+        }
+        console.error(`\n${errors.length} validation error(s) found`)
+        process.exit(1)
+    } else {
+        console.log(`\n✅ All ${checkCount} namespace checks passed`)
+        process.exit(0)
+    }
+}

--- a/servers/README.md
+++ b/servers/README.md
@@ -80,10 +80,10 @@ Suggests AWS regions for SageMaker deployments based on a search term. Filters t
 
 ```bash
 # Add instance-recommender
-yo ml-container-creator mcp add instance-recommender --bundled
+yo @aws/ml-container-creator mcp add instance-recommender --bundled
 
 # Add region-picker with a search filter for European regions
-yo ml-container-creator mcp add region-picker --bundled -e REGION_SEARCH=europe
+yo @aws/ml-container-creator mcp add region-picker --bundled -e REGION_SEARCH=europe
 ```
 
 Dependencies are installed automatically on first use.
@@ -91,7 +91,7 @@ Dependencies are installed automatically on first use.
 ### Listing Bundled Servers
 
 ```bash
-yo ml-container-creator mcp list --bundled
+yo @aws/ml-container-creator mcp list --bundled
 ```
 
 ### Enabling Smart Mode
@@ -99,8 +99,8 @@ yo ml-container-creator mcp list --bundled
 Pass `BEDROCK_SMART=true` as an environment variable when adding the server:
 
 ```bash
-yo ml-container-creator mcp add instance-recommender --bundled -e BEDROCK_SMART=true
-yo ml-container-creator mcp add region-picker --bundled -e BEDROCK_SMART=true
+yo @aws/ml-container-creator mcp add instance-recommender --bundled -e BEDROCK_SMART=true
+yo @aws/ml-container-creator mcp add region-picker --bundled -e BEDROCK_SMART=true
 ```
 
 ## Environment Variables
@@ -164,12 +164,12 @@ Bedrock models must be explicitly enabled in your AWS account:
 
 ## How Servers Impact the Generator Flow
 
-When you run `yo ml-container-creator`, the generator queries any configured MCP servers during the configuration loading phase. Here's how the bundled servers influence the flow:
+When you run `yo @aws/ml-container-creator`, the generator queries any configured MCP servers during the configuration loading phase. Here's how the bundled servers influence the flow:
 
 ### Without MCP Servers
 
 ```
-$ yo ml-container-creator
+$ yo @aws/ml-container-creator
 
 ? AWS Region: (use arrow keys or type to search)
 ❯ us-east-1
@@ -187,8 +187,8 @@ The user sees a generic list of regions and must know which instance type to pic
 ### With instance-recommender (Static Mode)
 
 ```bash
-yo ml-container-creator mcp add instance-recommender --bundled
-yo ml-container-creator
+yo @aws/ml-container-creator mcp add instance-recommender --bundled
+yo @aws/ml-container-creator
 ```
 
 ```
@@ -206,8 +206,8 @@ The server detects the transformer framework from context and suggests GPU insta
 ### With region-picker (Static Mode)
 
 ```bash
-yo ml-container-creator mcp add region-picker --bundled -e REGION_SEARCH=europe
-yo ml-container-creator
+yo @aws/ml-container-creator mcp add region-picker --bundled -e REGION_SEARCH=europe
+yo @aws/ml-container-creator
 ```
 
 ```
@@ -227,9 +227,9 @@ The search term `"europe"` filters the region list to only show European regions
 ### With Smart Mode (Bedrock)
 
 ```bash
-yo ml-container-creator mcp add instance-recommender --bundled -e BEDROCK_SMART=true
-yo ml-container-creator mcp add region-picker --bundled -e BEDROCK_SMART=true
-yo ml-container-creator
+yo @aws/ml-container-creator mcp add instance-recommender --bundled -e BEDROCK_SMART=true
+yo @aws/ml-container-creator mcp add region-picker --bundled -e BEDROCK_SMART=true
+yo @aws/ml-container-creator
 ```
 
 ```
@@ -289,7 +289,7 @@ The Bedrock API didn't respond within 10 seconds. This usually means network con
 
 ### Server Not Returning Results
 
-1. Check the server is registered: `yo ml-container-creator mcp list`
+1. Check the server is registered: `yo @aws/ml-container-creator mcp list`
 2. Check stderr output — all diagnostic messages go to stderr
 3. Verify the tool is being called with the right parameters (e.g., `"awsRegion"` for region-picker, `"instanceType"` for instance-recommender)
 4. Try running the standalone tests to verify the server logic:
@@ -302,7 +302,7 @@ node servers/instance-recommender/test.js
 ### Smart Mode Not Activating
 
 Smart mode only activates when `BEDROCK_SMART` is exactly `"true"`. Check:
-- The env var is set in the server config: `yo ml-container-creator mcp get <server-name>`
+- The env var is set in the server config: `yo @aws/ml-container-creator mcp get <server-name>`
 - It's not `"True"`, `"TRUE"`, or `"1"` — only `"true"` works
 
 ## Testing
@@ -402,7 +402,7 @@ await server.connect(transport)
 Register it:
 
 ```bash
-yo ml-container-creator mcp add my-server -- node path/to/my-server.js
+yo @aws/ml-container-creator mcp add my-server -- node path/to/my-server.js
 ```
 
 ## License Compliance

--- a/servers/base-image-picker/catalogs/triton.json
+++ b/servers/base-image-picker/catalogs/triton.json
@@ -1,0 +1,38 @@
+[
+    {
+        "image": "nvcr.io/nvidia/tritonserver:24.08-py3",
+        "tag": "24.08-py3",
+        "architecture": "amd64",
+        "created": "2024-08-15T00:00:00Z",
+        "labels": { "cuda_version": "12.5", "python_version": "3.10", "triton_version": "24.08" },
+        "registry": "ngc",
+        "repository": "nvidia/tritonserver"
+    },
+    {
+        "image": "nvcr.io/nvidia/tritonserver:24.05-py3",
+        "tag": "24.05-py3",
+        "architecture": "amd64",
+        "created": "2024-05-15T00:00:00Z",
+        "labels": { "cuda_version": "12.4", "python_version": "3.10", "triton_version": "24.05" },
+        "registry": "ngc",
+        "repository": "nvidia/tritonserver"
+    },
+    {
+        "image": "nvcr.io/nvidia/tritonserver:24.01-py3",
+        "tag": "24.01-py3",
+        "architecture": "amd64",
+        "created": "2024-01-15T00:00:00Z",
+        "labels": { "cuda_version": "12.3", "python_version": "3.10", "triton_version": "24.01" },
+        "registry": "ngc",
+        "repository": "nvidia/tritonserver"
+    },
+    {
+        "image": "nvcr.io/nvidia/tritonserver:23.10-py3",
+        "tag": "23.10-py3",
+        "architecture": "amd64",
+        "created": "2023-10-15T00:00:00Z",
+        "labels": { "cuda_version": "12.2", "python_version": "3.10", "triton_version": "23.10" },
+        "registry": "ngc",
+        "repository": "nvidia/tritonserver"
+    }
+]

--- a/servers/base-image-picker/index.js
+++ b/servers/base-image-picker/index.js
@@ -101,10 +101,12 @@ class ImageResolver extends DynamicResolverBase {
 
 let TRANSFORMER_IMAGE_CATALOG
 let PYTHON_SLIM_CATALOG
+let TRITON_IMAGE_CATALOG
 
 try {
     TRANSFORMER_IMAGE_CATALOG = loadCatalog('./catalogs/model-servers.json')
     PYTHON_SLIM_CATALOG = loadCatalog('./catalogs/python-slim.json')
+    TRITON_IMAGE_CATALOG = loadCatalog('./catalogs/triton.json')
 } catch (err) {
     process.stderr.write(`[base-image-picker] Fatal: ${err.message}\n`)
     process.exit(1)
@@ -226,10 +228,11 @@ function mergeStaticAndDynamic(staticImages, dynamicImages, limit) {
  * No network calls, no auth, no external dependencies.
  */
 class StaticCatalogResolver extends ImageResolver {
-    constructor(transformerCatalog, pythonSlimCatalog) {
+    constructor(transformerCatalog, pythonSlimCatalog, tritonCatalog) {
         super()
         this._transformerCatalog = transformerCatalog
         this._pythonSlimCatalog = pythonSlimCatalog
+        this._tritonCatalog = tritonCatalog || []
     }
 
     async fetchImages(framework, options = {}) {
@@ -237,6 +240,10 @@ class StaticCatalogResolver extends ImageResolver {
 
         if (framework === 'python-slim') {
             return this._resolvePythonSlim(limit, searchCriteria)
+        }
+
+        if (framework === 'triton') {
+            return this._resolveTriton(limit, searchCriteria)
         }
 
         const catalog = this._transformerCatalog[framework] || []
@@ -250,7 +257,8 @@ class StaticCatalogResolver extends ImageResolver {
     supportedFrameworks() {
         return [
             ...Object.keys(this._transformerCatalog),
-            'python-slim'
+            'python-slim',
+            'triton'
         ]
     }
 
@@ -263,6 +271,26 @@ class StaticCatalogResolver extends ImageResolver {
                 entry.tag.toLowerCase().includes(query) ||
                 entry.image.toLowerCase().includes(query) ||
                 (entry.labels.python_version && entry.labels.python_version.toLowerCase().includes(query))
+            )
+        }
+
+        const sliced = catalog.slice(0, limit)
+        return {
+            images: sliced,
+            defaultImage: sliced[0]?.image || null
+        }
+    }
+
+    _resolveTriton(limit, searchCriteria) {
+        let catalog = [...this._tritonCatalog]
+
+        if (searchCriteria && searchCriteria.trim()) {
+            const query = searchCriteria.trim().toLowerCase()
+            catalog = catalog.filter(entry =>
+                entry.tag.toLowerCase().includes(query) ||
+                entry.image.toLowerCase().includes(query) ||
+                (entry.labels.triton_version && entry.labels.triton_version.toLowerCase().includes(query)) ||
+                (entry.labels.cuda_version && entry.labels.cuda_version.toLowerCase().includes(query))
             )
         }
 
@@ -318,7 +346,7 @@ class ResolverRegistry {
 
 // ── V1 wiring ────────────────────────────────────────────────────────────────
 
-const staticResolver = new StaticCatalogResolver(TRANSFORMER_IMAGE_CATALOG, PYTHON_SLIM_CATALOG)
+const staticResolver = new StaticCatalogResolver(TRANSFORMER_IMAGE_CATALOG, PYTHON_SLIM_CATALOG, TRITON_IMAGE_CATALOG)
 const registry = new ResolverRegistry()
 registry.register(staticResolver)
 registry.setDefault(staticResolver)
@@ -347,12 +375,17 @@ if (discoverMode) {
  * When discover mode is active, merges static and dynamic results.
  */
 async function resolveBaseImage(context, limit) {
-    const { framework, modelServer, searchCriteria } = context
+    const { framework, modelServer, searchCriteria, architecture } = context
 
     // Determine which framework identifier to resolve
-    const resolverKey = (framework === 'transformers' && modelServer)
-        ? modelServer
-        : 'python-slim'
+    let resolverKey
+    if (architecture === 'triton') {
+        resolverKey = 'triton'
+    } else if (framework === 'transformers' && modelServer) {
+        resolverKey = modelServer
+    } else {
+        resolverKey = 'python-slim'
+    }
 
     const resolver = registry.getResolver(resolverKey)
     if (!resolver) {
@@ -434,6 +467,7 @@ export {
     ResolverRegistry,
     TRANSFORMER_IMAGE_CATALOG,
     PYTHON_SLIM_CATALOG,
+    TRITON_IMAGE_CATALOG,
     resolveBaseImage,
     mergeStaticAndDynamic,
     registry,

--- a/servers/base-image-picker/manifest.json
+++ b/servers/base-image-picker/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "@ml-container-creator/base-image-picker",
+    "name": "@amzn/ml-container-creator-base-image-picker",
     "version": "1.0.0",
     "description": "MCP server that returns curated base container images for ML Container Creator.",
     "modes": {

--- a/servers/base-image-picker/package-lock.json
+++ b/servers/base-image-picker/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@ml-container-creator/base-image-picker",
+  "name": "@amzn/ml-container-creator-base-image-picker",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ml-container-creator/base-image-picker",
+      "name": "@amzn/ml-container-creator-base-image-picker",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/servers/base-image-picker/package.json
+++ b/servers/base-image-picker/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@ml-container-creator/base-image-picker",
+  "name": "@amzn/ml-container-creator-base-image-picker",
+  "private": true,
   "version": "1.0.0",
   "description": "MCP server that returns curated base container images for ML Container Creator. Supports transformer serving frameworks and Python slim images for traditional ML.",
   "type": "module",

--- a/servers/hyperpod-cluster-picker/manifest.json
+++ b/servers/hyperpod-cluster-picker/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "@ml-container-creator/hyperpod-cluster-picker",
+    "name": "@amzn/ml-container-creator-hyperpod-cluster-picker",
     "version": "1.0.0",
     "description": "MCP server that discovers available SageMaker HyperPod EKS clusters.",
     "modes": {

--- a/servers/hyperpod-cluster-picker/package-lock.json
+++ b/servers/hyperpod-cluster-picker/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@ml-container-creator/hyperpod-cluster-picker",
+  "name": "@amzn/ml-container-creator-hyperpod-cluster-picker",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ml-container-creator/hyperpod-cluster-picker",
+      "name": "@amzn/ml-container-creator-hyperpod-cluster-picker",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1675,7 +1675,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1914,7 +1913,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2497,7 +2495,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/servers/hyperpod-cluster-picker/package.json
+++ b/servers/hyperpod-cluster-picker/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@ml-container-creator/hyperpod-cluster-picker",
+  "name": "@amzn/ml-container-creator-hyperpod-cluster-picker",
+  "private": true,
   "version": "1.0.0",
   "description": "MCP server that discovers available SageMaker HyperPod EKS clusters for ML Container Creator deployment target selection.",
   "type": "module",

--- a/servers/instance-recommender/manifest.json
+++ b/servers/instance-recommender/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "@ml-container-creator/instance-recommender",
+    "name": "@amzn/ml-container-creator-instance-recommender",
     "version": "1.0.0",
     "description": "MCP server that recommends SageMaker instance types for ML Container Creator.",
     "modes": {

--- a/servers/instance-recommender/package-lock.json
+++ b/servers/instance-recommender/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@ml-container-creator/instance-recommender",
+  "name": "@amzn/ml-container-creator-instance-recommender",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ml-container-creator/instance-recommender",
+      "name": "@amzn/ml-container-creator-instance-recommender",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -369,7 +369,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -574,7 +573,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1124,7 +1122,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/servers/instance-recommender/package.json
+++ b/servers/instance-recommender/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@ml-container-creator/instance-recommender",
+  "name": "@amzn/ml-container-creator-instance-recommender",
+  "private": true,
   "version": "1.0.0",
   "description": "MCP server that recommends SageMaker instance types and IAM role ARNs based on ML framework and model configuration. Supports Bedrock-powered smart recommendations.",
   "type": "module",

--- a/servers/lib/package-lock.json
+++ b/servers/lib/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@ml-container-creator/lib",
+  "name": "@amzn/ml-container-creator-lib",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ml-container-creator/lib",
+      "name": "@amzn/ml-container-creator-lib",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/servers/lib/package.json
+++ b/servers/lib/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@ml-container-creator/lib",
+  "name": "@amzn/ml-container-creator-lib",
+  "private": true,
   "version": "1.0.0",
   "description": "Shared library for ML Container Creator bundled MCP servers. Provides a reusable Bedrock client for context-aware recommendations.",
   "type": "module",

--- a/servers/region-picker/manifest.json
+++ b/servers/region-picker/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "@ml-container-creator/region-picker",
+    "name": "@amzn/ml-container-creator-region-picker",
     "version": "1.0.0",
     "description": "MCP server that suggests AWS regions for SageMaker deployments.",
     "modes": {

--- a/servers/region-picker/package-lock.json
+++ b/servers/region-picker/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@ml-container-creator/region-picker",
+  "name": "@amzn/ml-container-creator-region-picker",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ml-container-creator/region-picker",
+      "name": "@amzn/ml-container-creator-region-picker",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -369,7 +369,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -574,7 +573,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1124,7 +1122,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/servers/region-picker/package.json
+++ b/servers/region-picker/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@ml-container-creator/region-picker",
+  "name": "@amzn/ml-container-creator-region-picker",
+  "private": true,
   "version": "1.0.0",
   "description": "MCP server that suggests AWS regions based on a search term for ML Container Creator. Supports Bedrock-powered smart recommendations.",
   "type": "module",

--- a/test/README.md
+++ b/test/README.md
@@ -473,7 +473,7 @@ npm run validate
 
 # Test generator functionality manually
 npm link
-yo ml-container-creator test-project --framework=sklearn --model-server=flask --model-format=pkl --skip-prompts
+yo @aws/ml-container-creator test-project --framework=sklearn --model-server=flask --model-format=pkl --skip-prompts
 
 # Verify generated project works
 cd test-project

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-describe('generator-ml-container-creator:app', () => {
+describe('@aws/generator-ml-container-creator:app', () => {
     // Note: With do-framework integration, ALL template files are now generated unconditionally.
     // Runtime scripts (in do/ directory) handle conditional logic based on deployment configuration.
     

--- a/test/input-parsing-and-generation/backward-compatibility-managed-inference.property.test.js
+++ b/test/input-parsing-and-generation/backward-compatibility-managed-inference.property.test.js
@@ -47,11 +47,11 @@ function renderTemplate(template, vars) {
 const managedInferenceConfigArb = fc.record({
     projectName: fc.stringMatching(/^[a-z][a-z0-9-]{2,20}$/),
     deploymentConfig: fc.constantFrom(
-        'sklearn-flask', 'sklearn-fastapi',
-        'xgboost-flask', 'xgboost-fastapi',
-        'tensorflow-flask', 'tensorflow-fastapi',
+        'http-flask', 'http-fastapi',
         'transformers-vllm', 'transformers-sglang'
     ),
+    architecture: fc.constantFrom('http', 'transformers'),
+    backend: fc.constantFrom('flask', 'fastapi', 'vllm', 'sglang'),
     framework: fc.constantFrom('sklearn', 'xgboost', 'tensorflow', 'transformers'),
     modelServer: fc.constantFrom('flask', 'fastapi', 'vllm', 'sglang'),
     awsRegion: fc.constantFrom('us-east-1', 'us-west-2', 'eu-west-1'),
@@ -394,8 +394,8 @@ describe('Property 14: Backward Compatibility for Managed Inference', () => {
 
         fc.assert(fc.property(
             fc.record({
-                framework: fc.constantFrom('sklearn', 'xgboost', 'tensorflow', 'transformers'),
-                modelServer: fc.constantFrom('flask', 'fastapi', 'vllm', 'sglang'),
+                architecture: fc.constantFrom('http', 'transformers'),
+                backend: fc.constantFrom('flask', 'fastapi', 'vllm', 'sglang'),
                 awsRegion: fc.constantFrom('us-east-1', 'us-west-2')
             }),
             (config) => {
@@ -429,8 +429,8 @@ describe('Property 14: Backward Compatibility for Managed Inference', () => {
 
         fc.assert(fc.property(
             fc.record({
-                framework: fc.constantFrom('sklearn', 'xgboost', 'tensorflow', 'transformers'),
-                modelServer: fc.constantFrom('flask', 'fastapi', 'vllm', 'sglang'),
+                architecture: fc.constantFrom('http', 'transformers'),
+                backend: fc.constantFrom('flask', 'fastapi', 'vllm', 'sglang'),
                 awsRegion: fc.constantFrom('us-east-1', 'us-west-2')
             }),
             (config) => {

--- a/test/input-parsing-and-generation/codebuild.test.js
+++ b/test/input-parsing-and-generation/codebuild.test.js
@@ -200,8 +200,10 @@ describe('CodeBuild Feature', () => {
             const configManager = new ConfigManager(mockGenerator);
             
             const validConfig = {
-                framework: 'sklearn',
-                modelServer: 'flask',
+                deploymentConfig: 'http-flask',
+                architecture: 'http',
+                backend: 'flask',
+                engine: 'sklearn',
                 modelFormat: 'pkl',
                 buildTarget: 'codebuild',
                 codebuildComputeType: 'BUILD_GENERAL1_MEDIUM',

--- a/test/input-parsing-and-generation/error-handling.test.js
+++ b/test/input-parsing-and-generation/error-handling.test.js
@@ -285,84 +285,71 @@ describe('Error Handling and Validation', () => {
     });
 
     describe('Parameter Validation', () => {
-        it('should validate framework parameter', () => {
-            console.log('\n  🧪 Testing framework parameter validation...');
+        it('should validate deployment-config parameter', () => {
+            console.log('\n  🧪 Testing deployment-config parameter validation...');
             
             const configManager = new ConfigManager(mockGenerator);
             
-            // Test valid frameworks
-            const validFrameworks = ['sklearn', 'xgboost', 'tensorflow', 'transformers'];
-            validFrameworks.forEach(framework => {
+            // Test valid deployment configs
+            const validConfigs = ['http-flask', 'http-fastapi', 'transformers-vllm', 'triton-fil'];
+            validConfigs.forEach(dc => {
                 try {
-                    configManager._validateParameterValue('framework', framework, {});
-                    console.log(`    ✅ Valid framework accepted: ${framework}`);
+                    configManager._validateParameterValue('deploymentConfig', dc, {});
+                    console.log(`    ✅ Valid deployment-config accepted: ${dc}`);
                 } catch (error) {
-                    throw new Error(`Valid framework rejected: ${framework} - ${error.message}`);
+                    throw new Error(`Valid deployment-config rejected: ${dc} - ${error.message}`);
                 }
             });
             
-            // Test invalid framework
+            // Test invalid deployment-config
             try {
-                configManager._validateParameterValue('framework', 'invalid-framework', {});
-                throw new Error('Invalid framework was accepted');
+                configManager._validateParameterValue('deploymentConfig', 'invalid-config', {});
+                throw new Error('Invalid deployment-config was accepted');
             } catch (error) {
                 if (error instanceof ValidationError) {
-                    console.log('    ✅ Invalid framework correctly rejected');
+                    console.log('    ✅ Invalid deployment-config correctly rejected');
                     console.log(`    📝 Error message: ${error.message}`);
                     
-                    if (!error.message.includes('Unsupported framework')) {
-                        throw new Error(`Error message should mention unsupported framework: ${error.message}`);
+                    if (!error.message.includes('Unsupported deployment-config')) {
+                        throw new Error(`Error message should mention unsupported deployment-config: ${error.message}`);
                     }
                 } else {
                     throw new Error(`Expected ValidationError, got: ${error.constructor.name}`);
                 }
             }
             
-            console.log('    ✅ Framework parameter validation working correctly');
+            console.log('    ✅ Deployment-config parameter validation working correctly');
         });
 
-        it('should validate model server compatibility with framework', () => {
-            console.log('\n  🧪 Testing model server compatibility validation...');
+        it('should validate old-format deployment-config with migration message', () => {
+            console.log('\n  🧪 Testing old-format deployment-config migration validation...');
             
             const configManager = new ConfigManager(mockGenerator);
             
-            // Test valid combinations
-            const validCombinations = [
-                { framework: 'sklearn', modelServer: 'flask' },
-                { framework: 'sklearn', modelServer: 'fastapi' },
-                { framework: 'transformers', modelServer: 'vllm' },
-                { framework: 'transformers', modelServer: 'sglang' },
-                { framework: 'transformers', modelServer: 'lmi' },
-                { framework: 'transformers', modelServer: 'djl' }
+            // Test old-format configs get migration messages
+            const oldFormats = [
+                { old: 'sklearn-flask', expected: 'Use --deployment-config=http-flask --engine=sklearn instead' },
+                { old: 'xgboost-fastapi', expected: 'Use --deployment-config=http-fastapi --engine=xgboost instead' },
+                { old: 'tensorflow-flask', expected: 'Use --deployment-config=http-flask --engine=tensorflow instead' }
             ];
             
-            validCombinations.forEach(({ framework, modelServer }) => {
+            oldFormats.forEach(({ old, expected }) => {
                 try {
-                    configManager._validateParameterValue('modelServer', modelServer, { framework });
-                    console.log(`    ✅ Valid combination accepted: ${framework} + ${modelServer}`);
+                    configManager._validateParameterValue('deploymentConfig', old, {});
+                    throw new Error(`Old-format deployment-config was accepted: ${old}`);
                 } catch (error) {
-                    throw new Error(`Valid combination rejected: ${framework} + ${modelServer} - ${error.message}`);
+                    if (error instanceof ValidationError) {
+                        console.log(`    ✅ Old-format correctly rejected: ${old}`);
+                        if (!error.message.includes(expected)) {
+                            throw new Error(`Error message should include migration guidance: ${error.message}`);
+                        }
+                    } else {
+                        throw new Error(`Expected ValidationError, got: ${error.constructor.name}`);
+                    }
                 }
             });
             
-            // Test invalid combination
-            try {
-                configManager._validateParameterValue('modelServer', 'vllm', { framework: 'sklearn' });
-                throw new Error('Invalid framework/server combination was accepted');
-            } catch (error) {
-                if (error instanceof ValidationError) {
-                    console.log('    ✅ Invalid combination correctly rejected: sklearn + vllm');
-                    console.log(`    📝 Error message: ${error.message}`);
-                    
-                    if (!error.message.includes('not compatible with framework')) {
-                        throw new Error(`Error message should mention compatibility: ${error.message}`);
-                    }
-                } else {
-                    throw new Error(`Expected ValidationError, got: ${error.constructor.name}`);
-                }
-            }
-            
-            console.log('    ✅ Model server compatibility validation working correctly');
+            console.log('    ✅ Old-format deployment-config migration validation working correctly');
         });
 
         it('should validate instance type requirements for transformers', () => {
@@ -372,7 +359,7 @@ describe('Error Handling and Validation', () => {
             
             // Test valid instance type for transformers
             try {
-                configManager._validateParameterValue('instanceType', 'ml.g5.xlarge', { framework: 'transformers' });
+                configManager._validateParameterValue('instanceType', 'ml.g5.xlarge', { architecture: 'transformers' });
                 console.log('    ✅ GPU instance accepted for transformers');
             } catch (error) {
                 throw new Error(`Valid instance type rejected for transformers: ${error.message}`);
@@ -389,7 +376,7 @@ describe('Error Handling and Validation', () => {
                     originalWarn(...args);
                 };
                 
-                configManager._validateParameterValue('instanceType', 'ml.m5.large', { framework: 'transformers' });
+                configManager._validateParameterValue('instanceType', 'ml.m5.large', { architecture: 'transformers' });
                 
                 console.warn = originalWarn;
                 
@@ -414,8 +401,10 @@ describe('Error Handling and Validation', () => {
             
             // Test configuration missing required parameters
             const incompleteConfig = {
-                framework: 'sklearn'
-                // Missing modelServer, modelFormat, etc.
+                deploymentConfig: 'http-flask',
+                architecture: 'http',
+                backend: 'flask'
+                // Missing engine, modelFormat, etc.
             };
             
             const errors = configManager.validateRequiredParameters(incompleteConfig);
@@ -438,8 +427,10 @@ describe('Error Handling and Validation', () => {
             
             // Test complete configuration
             const completeConfig = {
-                framework: 'sklearn',
-                modelServer: 'flask',
+                deploymentConfig: 'http-flask',
+                architecture: 'http',
+                backend: 'flask',
+                engine: 'sklearn',
                 modelFormat: 'pkl',
                 includeSampleModel: false,
                 includeTesting: true,
@@ -468,8 +459,7 @@ describe('Error Handling and Validation', () => {
             await helpers.default.run(getGeneratorPath())
                 .withOptions({
                     'skip-prompts': true,
-                    'framework': 'invalid-framework',
-                    'model-server': 'flask'
+                    'deployment-config': 'invalid-config'
                 });
             
             // Check that no files were generated due to validation failure

--- a/test/input-parsing-and-generation/property-test-utils.js
+++ b/test/input-parsing-and-generation/property-test-utils.js
@@ -12,26 +12,48 @@ import fc from 'fast-check';
 
 // Parameter Matrix Configuration (matches design document)
 export const PARAMETER_MATRIX = {
-    framework: {
-        cliOption: 'framework',
+    deploymentConfig: {
+        cliOption: 'deployment-config',
         envVar: null,
         configFile: true,
         packageJson: false,
         promptable: true,
         required: true,
         default: null,
-        values: ['sklearn', 'xgboost', 'tensorflow', 'transformers']
+        values: ['http-flask', 'http-fastapi', 'transformers-vllm', 'transformers-sglang', 'transformers-tensorrt-llm', 'transformers-lmi', 'transformers-djl', 'triton-fil', 'triton-onnxruntime', 'triton-tensorflow', 'triton-pytorch', 'triton-vllm', 'triton-tensorrtllm', 'triton-python']
     },
-    
-    modelServer: {
-        cliOption: 'model-server',
+
+    architecture: {
+        cliOption: null,
+        envVar: null,
+        configFile: false,
+        packageJson: false,
+        promptable: false,
+        required: false,
+        default: null,
+        values: ['http', 'transformers', 'triton']
+    },
+
+    backend: {
+        cliOption: null,
+        envVar: null,
+        configFile: false,
+        packageJson: false,
+        promptable: false,
+        required: false,
+        default: null,
+        values: ['flask', 'fastapi', 'vllm', 'sglang', 'tensorrt-llm', 'lmi', 'djl', 'fil', 'onnxruntime', 'tensorflow', 'pytorch', 'tensorrtllm', 'python']
+    },
+
+    engine: {
+        cliOption: 'engine',
         envVar: null,
         configFile: true,
         packageJson: false,
         promptable: true,
-        required: true,
+        required: false,
         default: null,
-        values: ['flask', 'fastapi', 'vllm', 'sglang', 'tensorrt-llm']
+        values: ['sklearn', 'xgboost', 'tensorflow']
     },
     
     modelFormat: {
@@ -218,8 +240,8 @@ export const generateFilePath = () =>
 
 // Generate configuration objects
 export const generateConfiguration = () => fc.record({
-    framework: fc.constantFrom(...PARAMETER_MATRIX.framework.values),
-    modelServer: fc.constantFrom(...PARAMETER_MATRIX.modelServer.values),
+    deploymentConfig: fc.constantFrom(...PARAMETER_MATRIX.deploymentConfig.values),
+    engine: fc.option(fc.constantFrom(...PARAMETER_MATRIX.engine.values)),
     modelFormat: fc.constantFrom(...PARAMETER_MATRIX.modelFormat.values),
     buildTarget: fc.constantFrom(...PARAMETER_MATRIX.buildTarget.values),
     codebuildComputeType: fc.option(fc.constantFrom(...PARAMETER_MATRIX.codebuildComputeType.values)),
@@ -235,8 +257,8 @@ export const generateConfiguration = () => fc.record({
 
 // Generate CLI options object
 export const generateCliOptions = () => fc.record({
-    'framework': fc.option(fc.constantFrom(...PARAMETER_MATRIX.framework.values)),
-    'model-server': fc.option(fc.constantFrom(...PARAMETER_MATRIX.modelServer.values)),
+    'deployment-config': fc.option(fc.constantFrom(...PARAMETER_MATRIX.deploymentConfig.values)),
+    'engine': fc.option(fc.constantFrom(...PARAMETER_MATRIX.engine.values)),
     'model-format': fc.option(fc.constantFrom(...PARAMETER_MATRIX.modelFormat.values)),
     'build-target': fc.option(fc.constantFrom(...PARAMETER_MATRIX.buildTarget.values)),
     'codebuild-compute-type': fc.option(fc.constantFrom(...PARAMETER_MATRIX.codebuildComputeType.values)),
@@ -273,8 +295,8 @@ export const generatePackageJsonConfig = () => fc.record({
     awsRoleArn: fc.option(generateValidArn()),
     destinationDir: fc.option(fc.constantFrom(...PARAMETER_MATRIX.destinationDir.values)),
     // Include some unsupported parameters that should be ignored
-    framework: fc.option(fc.constantFrom(...PARAMETER_MATRIX.framework.values)),
-    modelServer: fc.option(fc.constantFrom(...PARAMETER_MATRIX.modelServer.values)),
+    deploymentConfig: fc.option(fc.constantFrom(...PARAMETER_MATRIX.deploymentConfig.values)),
+    engine: fc.option(fc.constantFrom(...PARAMETER_MATRIX.engine.values)),
     includeSampleModel: fc.option(fc.boolean()),
     includeTesting: fc.option(fc.boolean())
 });
@@ -282,8 +304,8 @@ export const generatePackageJsonConfig = () => fc.record({
 // Generate config file content (all parameters supported)
 export const generateConfigFileContent = () => fc.record({
     projectName: fc.option(generateProjectName()),
-    framework: fc.option(fc.constantFrom(...PARAMETER_MATRIX.framework.values)),
-    modelServer: fc.option(fc.constantFrom(...PARAMETER_MATRIX.modelServer.values)),
+    deploymentConfig: fc.option(fc.constantFrom(...PARAMETER_MATRIX.deploymentConfig.values)),
+    engine: fc.option(fc.constantFrom(...PARAMETER_MATRIX.engine.values)),
     modelFormat: fc.option(fc.constantFrom(...PARAMETER_MATRIX.modelFormat.values)),
     buildTarget: fc.option(fc.constantFrom(...PARAMETER_MATRIX.buildTarget.values)),
     codebuildComputeType: fc.option(fc.constantFrom(...PARAMETER_MATRIX.codebuildComputeType.values)),
@@ -349,36 +371,19 @@ export function getDefaultValue(parameter) {
     return paramConfig ? paramConfig.default : null;
 }
 
-// Validate framework/server compatibility
-export function isValidFrameworkServerCombination(framework, modelServer) {
-    const validCombinations = {
-        sklearn: ['flask', 'fastapi'],
-        xgboost: ['flask', 'fastapi'],
-        tensorflow: ['flask', 'fastapi'],
-        transformers: ['vllm', 'sglang', 'tensorrt-llm']
-    };
-    
-    return validCombinations[framework]?.includes(modelServer) || false;
-}
-
-// Validate framework/format compatibility
-export function isValidFrameworkFormatCombination(framework, modelFormat) {
-    const validCombinations = {
-        sklearn: ['pkl', 'joblib'],
-        xgboost: ['json', 'model', 'ubj'],
-        tensorflow: ['keras', 'h5', 'SavedModel'],
-        transformers: [] // No format needed for transformers
-    };
-    
-    return validCombinations[framework]?.includes(modelFormat) || 
-           (framework === 'transformers' && !modelFormat);
+// Validate deployment-config validity
+export function isValidDeploymentConfig(deploymentConfig) {
+    const validConfigs = PARAMETER_MATRIX.deploymentConfig.values;
+    return validConfigs.includes(deploymentConfig);
 }
 
 // Create a minimal valid configuration for testing
 export function createMinimalValidConfig() {
     return {
-        framework: 'sklearn',
-        modelServer: 'flask',
+        deploymentConfig: 'http-flask',
+        architecture: 'http',
+        backend: 'flask',
+        engine: 'sklearn',
         modelFormat: 'pkl',
         buildTarget: 'codebuild',
         includeSampleModel: false,
@@ -393,8 +398,10 @@ export function createMinimalValidConfig() {
 // Create a minimal valid CodeBuild configuration for testing
 export function createMinimalValidCodeBuildConfig() {
     return {
-        framework: 'sklearn',
-        modelServer: 'flask',
+        deploymentConfig: 'http-flask',
+        architecture: 'http',
+        backend: 'flask',
+        engine: 'sklearn',
         modelFormat: 'pkl',
         buildTarget: 'codebuild',
         codebuildComputeType: 'BUILD_GENERAL1_MEDIUM',

--- a/test/property/config-manager.property.test.js
+++ b/test/property/config-manager.property.test.js
@@ -156,8 +156,8 @@ describe('ConfigManager Property-Based Tests (Refactored)', () => {
             
             await fc.assert(fc.asyncProperty(
                 fc.record({
-                    'framework': fc.option(fc.constantFrom('sklearn', 'xgboost', 'tensorflow', 'transformers')),
-                    'model-server': fc.option(fc.constantFrom('flask', 'fastapi', 'vllm', 'sglang')),
+                    'deployment-config': fc.option(fc.constantFrom('http-flask', 'http-fastapi', 'transformers-vllm', 'transformers-sglang')),
+                    'engine': fc.option(fc.constantFrom('sklearn', 'xgboost', 'tensorflow')),
                     'model-format': fc.option(fc.constantFrom('pkl', 'json', 'keras')),
                     'instance-type': fc.option(fc.constantFrom('ml.m5.large', 'ml.g5.xlarge')),
                     'region': fc.option(fc.constantFrom('us-east-1', 'us-west-2', 'eu-west-1')),
@@ -179,11 +179,11 @@ describe('ConfigManager Property-Based Tests (Refactored)', () => {
                     const config = await configManager.loadConfiguration();
                     
                     // Verify CLI options were mapped correctly
-                    if (cleanOptions.framework) {
-                        assert.strictEqual(config.framework, cleanOptions.framework);
+                    if (cleanOptions['deployment-config']) {
+                        assert.strictEqual(config.deploymentConfig, cleanOptions['deployment-config']);
                     }
-                    if (cleanOptions['model-server']) {
-                        assert.strictEqual(config.modelServer, cleanOptions['model-server']);
+                    if (cleanOptions['engine']) {
+                        assert.strictEqual(config.engine, cleanOptions['engine']);
                     }
                     if (cleanOptions['model-format']) {
                         assert.strictEqual(config.modelFormat, cleanOptions['model-format']);

--- a/test/property/deployment-config-resolver.property.test.js
+++ b/test/property/deployment-config-resolver.property.test.js
@@ -1,0 +1,219 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * DeploymentConfigResolver Property-Based Tests
+ *
+ * Verifies universal correctness properties of the DeploymentConfigResolver
+ * component: round-trip identity, architecture consistency, isValid correctness,
+ * old format rejection, and getConfigsForArchitecture consistency.
+ *
+ * Feature: triton-integration
+ */
+
+import fc from 'fast-check';
+import { describe, it, before } from 'mocha';
+import assert from 'assert';
+import DeploymentConfigResolver from '../../generators/app/lib/deployment-config-resolver.js';
+
+const FAST_PROPERTY_CONFIG = {
+    numRuns: 100,
+    timeout: 30000,
+    verbose: false
+};
+
+describe('DeploymentConfigResolver Property-Based Tests', () => {
+
+    let resolver;
+    let allConfigs;
+    let tritonConfigs;
+    let validArchitectures;
+
+    before(() => {
+        resolver = new DeploymentConfigResolver();
+        allConfigs = resolver.getAllConfigs();
+        tritonConfigs = allConfigs.filter(dc => dc.startsWith('triton-'));
+        validArchitectures = ['http', 'transformers', 'triton'];
+
+        console.log('\n🚀 Starting DeploymentConfigResolver Property Tests');
+        console.log('📋 Testing: Universal correctness properties for deployment-config resolution');
+        console.log(`🔧 Configuration: ${FAST_PROPERTY_CONFIG.numRuns} iterations per property`);
+        console.log(`📦 Total configs: ${allConfigs.length} (${tritonConfigs.length} triton)\n`);
+    });
+
+    /**
+     * Property 1: Decompose/Compose Round-Trip Identity
+     *
+     * Validates: Requirements 1.3, 1.1, 1.2
+     *
+     * For all 14 valid deployment-config strings,
+     * compose(decompose(dc)) === dc
+     */
+    describe('Property 1: Decompose/Compose Round-Trip Identity', () => {
+        it('compose(decompose(dc)) === dc for all valid deployment-config strings', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(...allConfigs),
+                (dc) => {
+                    const parts = resolver.decompose(dc);
+                    const roundTripped = resolver.compose(parts);
+
+                    assert.strictEqual(
+                        roundTripped,
+                        dc,
+                        `Round-trip failed for '${dc}': compose(decompose('${dc}')) === '${roundTripped}'`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+    });
+
+    /**
+     * Property 2: Architecture Consistency for Triton Configs
+     *
+     * Validates: Requirements 2.2, 1.1
+     *
+     * For all 7 triton-* configs, decompose(dc).architecture === 'triton'
+     */
+    describe('Property 2: Architecture Consistency for Triton Configs', () => {
+        it('decompose(dc).architecture === "triton" for all triton-* configs', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(...tritonConfigs),
+                (dc) => {
+                    const parts = resolver.decompose(dc);
+
+                    assert.strictEqual(
+                        parts.architecture,
+                        'triton',
+                        `Architecture mismatch for '${dc}': expected 'triton', got '${parts.architecture}'`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+    });
+
+    /**
+     * Property 3: isValid Correctness
+     *
+     * Validates: Requirements 1.6, 1.7, 2.4
+     *
+     * isValid(s) returns true iff s is one of the 14 valid configs;
+     * false for everything else including old-format strings.
+     */
+    describe('Property 3: isValid Correctness', () => {
+        it('isValid returns true for all 14 valid configs', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(...allConfigs),
+                (dc) => {
+                    assert.strictEqual(
+                        resolver.isValid(dc),
+                        true,
+                        `Expected isValid('${dc}') to be true`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        it('isValid returns false for arbitrary non-canonical strings', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            const validSet = new Set(allConfigs);
+
+            fc.assert(fc.property(
+                fc.string({ minLength: 0, maxLength: 50 }),
+                (s) => {
+                    if (validSet.has(s)) {
+                        // If fast-check happens to generate a valid config, isValid should be true
+                        assert.strictEqual(resolver.isValid(s), true);
+                    } else {
+                        assert.strictEqual(
+                            resolver.isValid(s),
+                            false,
+                            `Expected isValid('${s}') to be false for non-canonical string`
+                        );
+                    }
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+    });
+
+    /**
+     * Property 4: Old Format Rejection
+     *
+     * Validates: Requirement 1.7
+     *
+     * For all 6 old-format strings, isValid(dc) returns false.
+     */
+    describe('Property 4: Old Format Rejection', () => {
+        it('isValid returns false for all old-format deployment-config strings', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            const oldFormatConfigs = [
+                'sklearn-flask',
+                'sklearn-fastapi',
+                'xgboost-flask',
+                'xgboost-fastapi',
+                'tensorflow-flask',
+                'tensorflow-fastapi'
+            ];
+
+            fc.assert(fc.property(
+                fc.constantFrom(...oldFormatConfigs),
+                (dc) => {
+                    assert.strictEqual(
+                        resolver.isValid(dc),
+                        false,
+                        `Expected isValid('${dc}') to be false for old-format config`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+    });
+
+    /**
+     * Property 5: getConfigsForArchitecture Consistency
+     *
+     * Validates: Requirement 1.5
+     *
+     * For any valid architecture a and any config dc returned by
+     * getConfigsForArchitecture(a), decompose(dc).architecture === a
+     */
+    describe('Property 5: getConfigsForArchitecture Consistency', () => {
+        it('every config returned by getConfigsForArchitecture(a) decomposes to architecture a', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(...validArchitectures),
+                (architecture) => {
+                    const configs = resolver.getConfigsForArchitecture(architecture);
+
+                    for (const dc of configs) {
+                        const parts = resolver.decompose(dc);
+                        assert.strictEqual(
+                            parts.architecture,
+                            architecture,
+                            `getConfigsForArchitecture('${architecture}') returned '${dc}' but decompose gives architecture '${parts.architecture}'`
+                        );
+                    }
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+    });
+});

--- a/test/property/namespace-repo-properties.property.test.js
+++ b/test/property/namespace-repo-properties.property.test.js
@@ -1,0 +1,914 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Repository-Level Namespace Property-Based Tests
+ *
+ * Property-based tests verifying repository-level correctness properties
+ * for the npm namespace rename feature.
+ *
+ * Feature: npm-namespace-rename, Property 1: Server package naming convention
+ */
+
+import fc from 'fast-check';
+import { describe, it, afterEach } from 'mocha';
+import assert from 'assert';
+import { readdirSync, readFileSync, existsSync, mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const SERVERS_DIR = join(REPO_ROOT, 'servers');
+
+const EXPECTED_PREFIX = '@amzn/ml-container-creator-';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const tempDirs = [];
+
+function createTempDir() {
+    const dir = mkdtempSync(join(tmpdir(), 'ns-repo-test-'));
+    tempDirs.push(dir);
+    return dir;
+}
+
+function writeJSON(filePath, data) {
+    writeFileSync(filePath, JSON.stringify(data, null, 4), 'utf8');
+}
+
+function ensureDir(dir) {
+    mkdirSync(dir, { recursive: true });
+}
+
+function readJSON(filePath) {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+/**
+ * Get all server directories (directories under servers/ that contain a package.json).
+ */
+function getServerDirs(serversDir) {
+    if (!existsSync(serversDir)) return [];
+    return readdirSync(serversDir, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .filter(d => existsSync(join(serversDir, d.name, 'package.json')))
+        .map(d => d.name);
+}
+
+// ── Generators ───────────────────────────────────────────────────────────────
+
+/**
+ * Generate a valid server directory name (lowercase, alphanumeric with hyphens).
+ */
+const arbServerDirName = fc.stringMatching(/^[a-z][a-z0-9-]{2,15}$/)
+    .filter(s => s.length >= 3 && !s.endsWith('-'));
+
+/**
+ * Generate a random package name that does NOT follow the convention.
+ */
+const arbNonConventionName = fc.oneof(
+    fc.constant('@aws/some-package'),
+    fc.constant('@foo/bar-baz'),
+    fc.constant('no-scope-package'),
+    fc.constant('@amzn/wrong-prefix-name'),
+    fc.constant('@ml-container-creator/old-style'),
+    arbServerDirName.map(s => `@amzn/other-project-${s}`)
+);
+
+// ── Property tests ───────────────────────────────────────────────────────────
+
+describe('Repository-Level Namespace Property Tests', () => {
+
+    afterEach(() => {
+        for (const dir of tempDirs) {
+            try {
+                rmSync(dir, { recursive: true, force: true });
+            } catch {
+                // ignore cleanup errors
+            }
+        }
+        tempDirs.length = 0;
+    });
+
+    // Feature: npm-namespace-rename, Property 1: Server package naming convention
+    describe('Property 1: Server package naming convention', () => {
+
+        /**
+         * Validates: Requirements 2.1, 2.2, 2.3, 2.4, 2.5, 4.1, 4.2, 4.3, 4.4
+         */
+
+        // ── Real repo verification ───────────────────────────────────────
+
+        it('every real server package.json name equals @amzn/ml-container-creator-{dirname}', function () {
+            this.timeout(10000);
+
+            const serverDirs = getServerDirs(SERVERS_DIR);
+            assert.ok(serverDirs.length > 0, 'Expected at least one server directory');
+
+            for (const dirName of serverDirs) {
+                const pkgPath = join(SERVERS_DIR, dirName, 'package.json');
+                const pkg = readJSON(pkgPath);
+                const expectedName = `${EXPECTED_PREFIX}${dirName}`;
+
+                assert.strictEqual(
+                    pkg.name,
+                    expectedName,
+                    `servers/${dirName}/package.json name should be "${expectedName}" but got "${pkg.name}"`
+                );
+            }
+        });
+
+        it('every real server manifest.json name matches its package.json name', function () {
+            this.timeout(10000);
+
+            const serverDirs = getServerDirs(SERVERS_DIR);
+
+            for (const dirName of serverDirs) {
+                const manifestPath = join(SERVERS_DIR, dirName, 'manifest.json');
+                if (!existsSync(manifestPath)) continue;
+
+                const pkgPath = join(SERVERS_DIR, dirName, 'package.json');
+                const pkg = readJSON(pkgPath);
+                const manifest = readJSON(manifestPath);
+
+                assert.strictEqual(
+                    manifest.name,
+                    pkg.name,
+                    `servers/${dirName}/manifest.json name "${manifest.name}" should match package.json name "${pkg.name}"`
+                );
+            }
+        });
+
+        // ── Property: naming convention holds for generated structures ────
+
+        it('for any server dir, package.json name must equal @amzn/ml-container-creator-{dirname}', function () {
+            this.timeout(30000);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                (dirName) => {
+                    const root = createTempDir();
+                    const serversDir = join(root, 'servers');
+                    const serverDir = join(serversDir, dirName);
+                    ensureDir(serverDir);
+
+                    const expectedName = `${EXPECTED_PREFIX}${dirName}`;
+                    writeJSON(join(serverDir, 'package.json'), {
+                        name: expectedName,
+                        version: '1.0.0'
+                    });
+
+                    // Verify the convention: read back and check
+                    const dirs = getServerDirs(serversDir);
+                    assert.ok(dirs.includes(dirName), `Directory ${dirName} should be found`);
+
+                    const pkg = readJSON(join(serversDir, dirName, 'package.json'));
+                    assert.strictEqual(
+                        pkg.name,
+                        `${EXPECTED_PREFIX}${dirName}`,
+                        `Name should follow convention: ${EXPECTED_PREFIX}${dirName}`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: 100 });
+        });
+
+        it('detects naming violations when package.json name does not follow convention', function () {
+            this.timeout(30000);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                arbNonConventionName,
+                (dirName, badName) => {
+                    const root = createTempDir();
+                    const serversDir = join(root, 'servers');
+                    const serverDir = join(serversDir, dirName);
+                    ensureDir(serverDir);
+
+                    writeJSON(join(serverDir, 'package.json'), {
+                        name: badName,
+                        version: '1.0.0'
+                    });
+
+                    const pkg = readJSON(join(serverDir, 'package.json'));
+                    const expectedName = `${EXPECTED_PREFIX}${dirName}`;
+
+                    // The name should NOT match the convention
+                    assert.notStrictEqual(
+                        pkg.name,
+                        expectedName,
+                        `Name "${badName}" should not match convention "${expectedName}"`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: 100 });
+        });
+
+        // ── Property: manifest.json name matches package.json name ───────
+
+        it('if manifest.json exists, its name must match the package.json name', function () {
+            this.timeout(30000);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                fc.boolean(),
+                (dirName, includeManifest) => {
+                    const root = createTempDir();
+                    const serversDir = join(root, 'servers');
+                    const serverDir = join(serversDir, dirName);
+                    ensureDir(serverDir);
+
+                    const expectedName = `${EXPECTED_PREFIX}${dirName}`;
+                    writeJSON(join(serverDir, 'package.json'), {
+                        name: expectedName,
+                        version: '1.0.0'
+                    });
+
+                    if (includeManifest) {
+                        writeJSON(join(serverDir, 'manifest.json'), {
+                            name: expectedName,
+                            version: '1.0.0'
+                        });
+
+                        const pkg = readJSON(join(serverDir, 'package.json'));
+                        const manifest = readJSON(join(serverDir, 'manifest.json'));
+
+                        assert.strictEqual(
+                            manifest.name,
+                            pkg.name,
+                            `manifest.json name "${manifest.name}" must match package.json name "${pkg.name}"`
+                        );
+                    }
+
+                    return true;
+                }
+            ), { numRuns: 100 });
+        });
+
+        it('detects manifest name mismatch with package.json', function () {
+            this.timeout(30000);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                arbNonConventionName,
+                (dirName, mismatchedName) => {
+                    const root = createTempDir();
+                    const serversDir = join(root, 'servers');
+                    const serverDir = join(serversDir, dirName);
+                    ensureDir(serverDir);
+
+                    const expectedName = `${EXPECTED_PREFIX}${dirName}`;
+                    writeJSON(join(serverDir, 'package.json'), {
+                        name: expectedName,
+                        version: '1.0.0'
+                    });
+
+                    // Write manifest with a different name
+                    writeJSON(join(serverDir, 'manifest.json'), {
+                        name: mismatchedName,
+                        version: '1.0.0'
+                    });
+
+                    const pkg = readJSON(join(serverDir, 'package.json'));
+                    const manifest = readJSON(join(serverDir, 'manifest.json'));
+
+                    // The names should NOT match
+                    assert.notStrictEqual(
+                        manifest.name,
+                        pkg.name,
+                        `Mismatched manifest name "${mismatchedName}" should differ from package name "${expectedName}"`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: 100 });
+        });
+    });
+
+    // Feature: npm-namespace-rename, Property 2: Lock file name consistency
+    describe('Property 2: Lock file name consistency', () => {
+
+        /**
+         * Validates: Requirements 1.3, 2.6
+         */
+
+        // ── Real repo verification ───────────────────────────────────────
+
+        it('every real directory with both package.json and package-lock.json has matching name fields', function () {
+            this.timeout(10000);
+
+            // Collect all directories that have both files
+            const dirsToCheck = [];
+
+            // Root directory
+            if (existsSync(join(REPO_ROOT, 'package.json')) && existsSync(join(REPO_ROOT, 'package-lock.json'))) {
+                dirsToCheck.push(REPO_ROOT);
+            }
+
+            // Server directories
+            if (existsSync(SERVERS_DIR)) {
+                const serverDirs = readdirSync(SERVERS_DIR, { withFileTypes: true })
+                    .filter(d => d.isDirectory());
+                for (const d of serverDirs) {
+                    const dir = join(SERVERS_DIR, d.name);
+                    if (existsSync(join(dir, 'package.json')) && existsSync(join(dir, 'package-lock.json'))) {
+                        dirsToCheck.push(dir);
+                    }
+                }
+            }
+
+            assert.ok(dirsToCheck.length > 0, 'Expected at least one directory with both package.json and package-lock.json');
+
+            for (const dir of dirsToCheck) {
+                const pkg = readJSON(join(dir, 'package.json'));
+                const lock = readJSON(join(dir, 'package-lock.json'));
+
+                assert.strictEqual(
+                    lock.name,
+                    pkg.name,
+                    `In ${dir}, package-lock.json name "${lock.name}" should match package.json name "${pkg.name}"`
+                );
+            }
+        });
+
+        it('root package.json and package-lock.json names match', function () {
+            this.timeout(10000);
+
+            const pkgPath = join(REPO_ROOT, 'package.json');
+            const lockPath = join(REPO_ROOT, 'package-lock.json');
+
+            assert.ok(existsSync(pkgPath), 'Root package.json must exist');
+            assert.ok(existsSync(lockPath), 'Root package-lock.json must exist');
+
+            const pkg = readJSON(pkgPath);
+            const lock = readJSON(lockPath);
+
+            assert.strictEqual(
+                lock.name,
+                pkg.name,
+                `Root package-lock.json name "${lock.name}" should match package.json name "${pkg.name}"`
+            );
+        });
+
+        // ── Property: matching names are detected as consistent ──────────
+
+        it('for any directory with matching package.json and package-lock.json names, consistency holds', function () {
+            this.timeout(30000);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                fc.constantFrom(
+                    '@aws/generator-ml-container-creator',
+                    '@amzn/ml-container-creator-test-server',
+                    '@amzn/ml-container-creator-lib',
+                    'some-random-package'
+                ),
+                (dirName, pkgName) => {
+                    const root = createTempDir();
+                    const dir = join(root, dirName);
+                    ensureDir(dir);
+
+                    writeJSON(join(dir, 'package.json'), {
+                        name: pkgName,
+                        version: '1.0.0'
+                    });
+
+                    writeJSON(join(dir, 'package-lock.json'), {
+                        name: pkgName,
+                        version: '1.0.0',
+                        lockfileVersion: 3,
+                        requires: true,
+                        packages: {}
+                    });
+
+                    const pkg = readJSON(join(dir, 'package.json'));
+                    const lock = readJSON(join(dir, 'package-lock.json'));
+
+                    // Names must match
+                    assert.strictEqual(
+                        lock.name,
+                        pkg.name,
+                        `Lock file name "${lock.name}" should match package name "${pkg.name}"`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: 100 });
+        });
+
+        // ── Property: mismatching names are detected as inconsistent ─────
+
+        it('for any directory with mismatching package.json and package-lock.json names, inconsistency is detected', function () {
+            this.timeout(30000);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                fc.constantFrom(
+                    '@aws/generator-ml-container-creator',
+                    '@amzn/ml-container-creator-test-server',
+                    '@amzn/ml-container-creator-lib'
+                ),
+                arbNonConventionName,
+                (dirName, pkgName, lockName) => {
+                    // Ensure the names are actually different
+                    fc.pre(pkgName !== lockName);
+
+                    const root = createTempDir();
+                    const dir = join(root, dirName);
+                    ensureDir(dir);
+
+                    writeJSON(join(dir, 'package.json'), {
+                        name: pkgName,
+                        version: '1.0.0'
+                    });
+
+                    writeJSON(join(dir, 'package-lock.json'), {
+                        name: lockName,
+                        version: '1.0.0',
+                        lockfileVersion: 3,
+                        requires: true,
+                        packages: {}
+                    });
+
+                    const pkg = readJSON(join(dir, 'package.json'));
+                    const lock = readJSON(join(dir, 'package-lock.json'));
+
+                    // Names must NOT match
+                    assert.notStrictEqual(
+                        lock.name,
+                        pkg.name,
+                        `Lock file name "${lock.name}" should differ from package name "${pkg.name}"`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: 100 });
+        });
+    });
+
+    // Feature: npm-namespace-rename, Property 3: No legacy scope or invocation in repository
+    describe('Property 3: No legacy scope or invocation in repository', () => {
+
+        /**
+         * Validates: Requirements 5.1, 5.2, 6.1, 6.2, 6.3, 6.4, 8.5
+         */
+
+        const LEGACY_SCOPE = '@ml-container-creator/';
+        // Matches "yo ml-container-creator" NOT preceded by "@aws/"
+        const BARE_YO_REGEX = /(?<!@aws\/)yo ml-container-creator/;
+
+        // Binary file extensions to skip
+        const BINARY_EXTENSIONS = new Set([
+            '.png', '.jpg', '.jpeg', '.gif', '.ico', '.svg',
+            '.woff', '.woff2', '.ttf', '.eot',
+            '.zip', '.tar', '.gz', '.bz2',
+            '.pdf', '.exe', '.dll', '.so', '.dylib',
+            '.lock'
+        ]);
+
+        /**
+         * Check if a file path should be excluded from scanning.
+         * Excludes: node_modules (any depth), .git, .kiro/specs, .kiro/rationale,
+         * .kiro/steering, package-lock.json, site/ (build output), test-dir/ (test output),
+         * the validation script itself, and property test files (they reference legacy
+         * strings as test data).
+         */
+        function isExcluded(relPath) {
+            if (relPath.startsWith('node_modules/') || relPath.startsWith('.git/')) return true;
+            if (relPath.includes('/node_modules/')) return true;
+            if (relPath.startsWith('.kiro/specs/')) return true;
+            if (relPath.startsWith('.kiro/rationale/')) return true;
+            if (relPath.startsWith('.kiro/steering/')) return true;
+            if (relPath === 'package-lock.json') return true;
+            if (relPath.includes('/package-lock.json')) return true;
+            if (relPath.startsWith('site/')) return true;
+            if (relPath.startsWith('test-dir/')) return true;
+            if (relPath === 'scripts/validate-namespaces.js') return true;
+            if (relPath.startsWith('test/property/')) return true;
+            return false;
+        }
+
+        /**
+         * Check if a file is likely binary by extension.
+         */
+        function isBinaryExtension(filePath) {
+            const ext = filePath.slice(filePath.lastIndexOf('.')).toLowerCase();
+            return BINARY_EXTENSIONS.has(ext);
+        }
+
+        /**
+         * Recursively walk a directory and return relative paths of text files.
+         */
+        function walkTextFiles(rootDir, dir, results = []) {
+            let entries;
+            try {
+                entries = readdirSync(dir, { withFileTypes: true });
+            } catch {
+                return results;
+            }
+
+            for (const entry of entries) {
+                const fullPath = join(dir, entry.name);
+                const relPath = fullPath.slice(rootDir.length + 1).replace(/\\/g, '/');
+
+                if (isExcluded(relPath)) continue;
+
+                if (entry.isDirectory()) {
+                    walkTextFiles(rootDir, fullPath, results);
+                } else if (entry.isFile() && !isBinaryExtension(entry.name)) {
+                    results.push({ fullPath, relPath });
+                }
+            }
+            return results;
+        }
+
+        /**
+         * Scan content for legacy scope string.
+         * Returns true if legacy scope is found.
+         */
+        function hasLegacyScope(content) {
+            return content.includes(LEGACY_SCOPE);
+        }
+
+        /**
+         * Scan content for bare "yo ml-container-creator" (without @aws/ prefix).
+         * Returns true if bare invocation is found.
+         */
+        function hasBareYoInvocation(content) {
+            return BARE_YO_REGEX.test(content);
+        }
+
+        // ── Real repo scan: no legacy scope ──────────────────────────────
+
+        it('no file in the real repo contains @ml-container-creator/', function () {
+            this.timeout(30000);
+
+            const files = walkTextFiles(REPO_ROOT, REPO_ROOT);
+            const violations = [];
+
+            for (const { fullPath, relPath } of files) {
+                let content;
+                try {
+                    content = readFileSync(fullPath, 'utf8');
+                } catch {
+                    continue;
+                }
+                // Skip files with null bytes (binary)
+                if (content.includes('\0')) continue;
+
+                if (hasLegacyScope(content)) {
+                    violations.push(relPath);
+                }
+            }
+
+            assert.deepStrictEqual(
+                violations,
+                [],
+                `Files containing legacy scope "${LEGACY_SCOPE}": ${violations.join(', ')}`
+            );
+        });
+
+        // ── Real repo scan: no bare yo invocation ────────────────────────
+
+        it('no file in the real repo contains bare "yo ml-container-creator" without @aws/ prefix', function () {
+            this.timeout(30000);
+
+            const files = walkTextFiles(REPO_ROOT, REPO_ROOT);
+            const violations = [];
+
+            for (const { fullPath, relPath } of files) {
+                let content;
+                try {
+                    content = readFileSync(fullPath, 'utf8');
+                } catch {
+                    continue;
+                }
+                // Skip files with null bytes (binary)
+                if (content.includes('\0')) continue;
+
+                if (hasBareYoInvocation(content)) {
+                    violations.push(relPath);
+                }
+            }
+
+            assert.deepStrictEqual(
+                violations,
+                [],
+                `Files containing bare "yo ml-container-creator": ${violations.join(', ')}`
+            );
+        });
+
+        // ── Property: scanner detects legacy scope in generated content ──
+
+        it('scanner detects @ml-container-creator/ in any generated file content', function () {
+            this.timeout(30000);
+
+            fc.assert(fc.property(
+                fc.tuple(
+                    fc.string({ minLength: 0, maxLength: 50 }),
+                    fc.string({ minLength: 0, maxLength: 50 })
+                ),
+                ([prefix, suffix]) => {
+                    const content = `${prefix}@ml-container-creator/${suffix}`;
+                    assert.ok(
+                        hasLegacyScope(content),
+                        `Scanner should detect legacy scope in: "${content}"`
+                    );
+                    return true;
+                }
+            ), { numRuns: 100 });
+        });
+
+        // ── Property: scanner detects bare yo invocation in generated content ──
+
+        it('scanner detects bare "yo ml-container-creator" in any generated file content', function () {
+            this.timeout(30000);
+
+            fc.assert(fc.property(
+                fc.tuple(
+                    // Prefix that does NOT end with "@aws/"
+                    fc.string({ minLength: 0, maxLength: 50 })
+                        .filter(s => !s.endsWith('@aws/')),
+                    fc.string({ minLength: 0, maxLength: 50 })
+                ),
+                ([prefix, suffix]) => {
+                    const content = `${prefix}yo ml-container-creator${suffix}`;
+                    assert.ok(
+                        hasBareYoInvocation(content),
+                        `Scanner should detect bare yo invocation in: "${content}"`
+                    );
+                    return true;
+                }
+            ), { numRuns: 100 });
+        });
+
+        // ── Property: scanner finds nothing in clean content ─────────────
+
+        it('scanner finds no legacy strings in content without them', function () {
+            this.timeout(30000);
+
+            fc.assert(fc.property(
+                fc.string({ minLength: 0, maxLength: 200 })
+                    .filter(s => !s.includes('@ml-container-creator/') && !BARE_YO_REGEX.test(s)),
+                (content) => {
+                    assert.ok(
+                        !hasLegacyScope(content),
+                        'Scanner should not detect legacy scope in clean content'
+                    );
+                    assert.ok(
+                        !hasBareYoInvocation(content),
+                        'Scanner should not detect bare yo invocation in clean content'
+                    );
+                    return true;
+                }
+            ), { numRuns: 100 });
+        });
+    });
+
+    // Feature: npm-namespace-rename, Property 6: Server resolution is path-based
+    describe('Property 6: Server resolution is path-based', () => {
+
+        /**
+         * Validates: Requirements 10.1, 10.2, 10.3
+         */
+
+        /**
+         * Mirror of McpCommandHandler._getAvailableBundledServers() logic.
+         * Scans a serversDir for directories containing a package.json with
+         * @modelcontextprotocol/sdk as a dependency. Returns server entries
+         * keyed by directory name, NOT by the package name field.
+         */
+        function getAvailableBundledServers(serversDir) {
+            if (!existsSync(serversDir)) return [];
+
+            const entries = readdirSync(serversDir, { withFileTypes: true });
+            const servers = [];
+
+            for (const entry of entries) {
+                if (!entry.isDirectory()) continue;
+
+                const pkgPath = join(serversDir, entry.name, 'package.json');
+                if (!existsSync(pkgPath)) continue;
+
+                try {
+                    const pkg = readJSON(pkgPath);
+                    const deps = pkg.dependencies || {};
+                    if (!deps['@modelcontextprotocol/sdk']) continue;
+
+                    servers.push({
+                        name: entry.name,
+                        description: pkg.description || '(no description)'
+                    });
+                } catch (_) {
+                    servers.push({
+                        name: entry.name,
+                        description: '(unable to read package.json)'
+                    });
+                }
+            }
+
+            return servers;
+        }
+
+        /**
+         * Generate a random package name (any arbitrary string).
+         */
+        const arbRandomPkgName = fc.oneof(
+            fc.constant('@aws/some-random-thing'),
+            fc.constant('@amzn/ml-container-creator-base-image-picker'),
+            fc.constant('@totally/different-name'),
+            fc.constant('no-scope-at-all'),
+            fc.constant('@ml-container-creator/old-name'),
+            arbServerDirName.map(s => `@random/${s}`),
+            arbNonConventionName
+        );
+
+        // ── Real repo: servers discovered by directory, not name ──────────
+
+        it('real servers are discovered by directory presence and @modelcontextprotocol/sdk dependency', function () {
+            this.timeout(10000);
+
+            const servers = getAvailableBundledServers(SERVERS_DIR);
+
+            // Must find at least one server
+            assert.ok(servers.length > 0, 'Expected at least one bundled server');
+
+            // Each returned server name must be a directory name, not a package name
+            for (const server of servers) {
+                // The name should be a simple directory name (no @ scope)
+                assert.ok(
+                    !server.name.includes('/'),
+                    `Server name "${server.name}" should be a directory name, not a scoped package name`
+                );
+
+                // The directory must exist
+                const serverDir = join(SERVERS_DIR, server.name);
+                assert.ok(
+                    existsSync(serverDir),
+                    `Directory servers/${server.name}/ must exist`
+                );
+
+                // The package.json must have @modelcontextprotocol/sdk
+                const pkg = readJSON(join(serverDir, 'package.json'));
+                const deps = pkg.dependencies || {};
+                assert.ok(
+                    deps['@modelcontextprotocol/sdk'],
+                    `servers/${server.name}/package.json must have @modelcontextprotocol/sdk dependency`
+                );
+            }
+        });
+
+        it('real lib directory is excluded because it lacks @modelcontextprotocol/sdk', function () {
+            this.timeout(10000);
+
+            const servers = getAvailableBundledServers(SERVERS_DIR);
+            const serverNames = servers.map(s => s.name);
+
+            assert.ok(
+                !serverNames.includes('lib'),
+                'lib directory should not be listed as a bundled server (no @modelcontextprotocol/sdk dependency)'
+            );
+        });
+
+        // ── Property: name field does not affect server discovery ─────────
+
+        it('for any server dir with @modelcontextprotocol/sdk, discovery uses directory name regardless of package name', function () {
+            this.timeout(30000);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                arbRandomPkgName,
+                (dirName, pkgName) => {
+                    const root = createTempDir();
+                    const serversDir = join(root, 'servers');
+                    const serverDir = join(serversDir, dirName);
+                    ensureDir(serverDir);
+
+                    // Write package.json with arbitrary name but with the SDK dependency
+                    writeJSON(join(serverDir, 'package.json'), {
+                        name: pkgName,
+                        version: '1.0.0',
+                        dependencies: {
+                            '@modelcontextprotocol/sdk': '^1.0.0'
+                        }
+                    });
+
+                    const servers = getAvailableBundledServers(serversDir);
+
+                    // Server must be discovered
+                    assert.strictEqual(servers.length, 1, 'Exactly one server should be discovered');
+
+                    // The returned name must be the directory name, not the package name
+                    assert.strictEqual(
+                        servers[0].name,
+                        dirName,
+                        `Server should be identified as "${dirName}" (dir name), not "${pkgName}" (package name)`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: 100 });
+        });
+
+        // ── Property: directories without SDK dependency are excluded ─────
+
+        it('for any server dir without @modelcontextprotocol/sdk, directory is not discovered', function () {
+            this.timeout(30000);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                arbRandomPkgName,
+                (dirName, pkgName) => {
+                    const root = createTempDir();
+                    const serversDir = join(root, 'servers');
+                    const serverDir = join(serversDir, dirName);
+                    ensureDir(serverDir);
+
+                    // Write package.json WITHOUT @modelcontextprotocol/sdk
+                    writeJSON(join(serverDir, 'package.json'), {
+                        name: pkgName,
+                        version: '1.0.0',
+                        dependencies: {
+                            'some-other-dep': '^1.0.0'
+                        }
+                    });
+
+                    const servers = getAvailableBundledServers(serversDir);
+
+                    // Server must NOT be discovered
+                    assert.strictEqual(
+                        servers.length,
+                        0,
+                        `Directory "${dirName}" without @modelcontextprotocol/sdk should not be discovered`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: 100 });
+        });
+
+        // ── Property: multiple servers with varying names all resolve by directory ──
+
+        it('multiple servers with different package names are all resolved by directory name', function () {
+            this.timeout(30000);
+
+            fc.assert(fc.property(
+                fc.array(
+                    fc.tuple(arbServerDirName, arbRandomPkgName),
+                    { minLength: 1, maxLength: 5 }
+                ),
+                (serverSpecs) => {
+                    // Deduplicate directory names
+                    const seen = new Set();
+                    const uniqueSpecs = serverSpecs.filter(([dirName]) => {
+                        if (seen.has(dirName)) return false;
+                        seen.add(dirName);
+                        return true;
+                    });
+
+                    fc.pre(uniqueSpecs.length >= 1);
+
+                    const root = createTempDir();
+                    const serversDir = join(root, 'servers');
+
+                    for (const [dirName, pkgName] of uniqueSpecs) {
+                        const serverDir = join(serversDir, dirName);
+                        ensureDir(serverDir);
+
+                        writeJSON(join(serverDir, 'package.json'), {
+                            name: pkgName,
+                            version: '1.0.0',
+                            dependencies: {
+                                '@modelcontextprotocol/sdk': '^1.0.0'
+                            }
+                        });
+                    }
+
+                    const servers = getAvailableBundledServers(serversDir);
+                    const discoveredNames = servers.map(s => s.name).sort();
+                    const expectedNames = uniqueSpecs.map(([dirName]) => dirName).sort();
+
+                    assert.deepStrictEqual(
+                        discoveredNames,
+                        expectedNames,
+                        `Discovered servers ${JSON.stringify(discoveredNames)} should match directory names ${JSON.stringify(expectedNames)}`
+                    );
+
+                    // None of the returned names should be a package name
+                    for (const server of servers) {
+                        assert.ok(
+                            !server.name.includes('/'),
+                            `Returned name "${server.name}" should be a directory name, not a scoped package name`
+                        );
+                    }
+
+                    return true;
+                }
+            ), { numRuns: 100 });
+        });
+    });
+});

--- a/test/property/namespace-validation.property.test.js
+++ b/test/property/namespace-validation.property.test.js
@@ -1,0 +1,597 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Namespace Validation Property-Based Tests
+ *
+ * Property-based tests verifying that the namespace validation script
+ * (scripts/validate-namespaces.js) correctly detects namespace violations
+ * in package.json and manifest.json files.
+ *
+ * Feature: npm-namespace-rename, Property 4: Validator detects namespace violations
+ */
+
+import fc from 'fast-check';
+import { describe, it, afterEach } from 'mocha';
+import assert from 'assert';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+    validateRootNamespace,
+    validateServerNamespaces,
+    validateManifestNamespaces,
+    validatePublishSafety
+} from '../../scripts/validate-namespaces.js';
+
+const FAST_PROPERTY_CONFIG = {
+    numRuns: 100,
+    timeout: 30000,
+    verbose: false
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const tempDirs = [];
+
+function createTempDir() {
+    const dir = mkdtempSync(join(tmpdir(), 'ns-val-test-'));
+    tempDirs.push(dir);
+    return dir;
+}
+
+function writeJSON(filePath, data) {
+    writeFileSync(filePath, JSON.stringify(data, null, 4), 'utf8');
+}
+
+function ensureDir(dir) {
+    mkdirSync(dir, { recursive: true });
+}
+
+// ── Generators ───────────────────────────────────────────────────────────────
+
+/**
+ * Generate a random npm scope that is NOT @aws/ — these are invalid for root.
+ */
+const arbInvalidRootPrefix = fc.oneof(
+    fc.constant('@amzn/'),
+    fc.constant('@ml-container-creator/'),
+    fc.constant('@foo/'),
+    fc.constant('@bar/'),
+    fc.constant(''),
+    fc.constant('no-scope-')
+);
+
+/**
+ * Generate a random npm scope that is NOT @amzn/ — these are invalid for servers.
+ */
+const arbInvalidServerPrefix = fc.oneof(
+    fc.constant('@aws/'),
+    fc.constant('@ml-container-creator/'),
+    fc.constant('@foo/'),
+    fc.constant('@bar/'),
+    fc.constant(''),
+    fc.constant('no-scope-')
+);
+
+/**
+ * Generate a random package name suffix.
+ */
+const arbNameSuffix = fc.stringMatching(/^[a-z][a-z0-9-]{2,20}$/)
+    .filter(s => s.length >= 3);
+
+/**
+ * Generate a random server directory name.
+ */
+const arbServerDirName = fc.stringMatching(/^[a-z][a-z0-9-]{2,15}$/)
+    .filter(s => s.length >= 3);
+
+// ── Property tests ───────────────────────────────────────────────────────────
+
+describe('Namespace Validation Property-Based Tests', () => {
+
+    afterEach(() => {
+        for (const dir of tempDirs) {
+            try {
+                rmSync(dir, { recursive: true, force: true });
+            } catch {
+                // ignore cleanup errors
+            }
+        }
+        tempDirs.length = 0;
+    });
+
+    // Feature: npm-namespace-rename, Property 4: Validator detects namespace violations
+    describe('Property 4: Validator detects namespace violations', () => {
+
+        /**
+         * Validates: Requirements 8.1, 8.2, 8.3, 8.4, 8.6
+         */
+
+        // ── Test 1: Root package with invalid prefix is rejected ─────────
+
+        it('rejects root package.json names not starting with @aws/', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                arbInvalidRootPrefix,
+                arbNameSuffix,
+                (prefix, suffix) => {
+                    const dir = createTempDir();
+                    const pkgPath = join(dir, 'package.json');
+                    const name = `${prefix}${suffix}`;
+
+                    writeJSON(pkgPath, { name, version: '1.0.0' });
+
+                    const errors = validateRootNamespace(pkgPath);
+
+                    assert.ok(
+                        errors.length > 0,
+                        `Should reject root name "${name}" (does not start with @aws/) but got no errors`
+                    );
+
+                    // Error message must contain the current name (Req 8.6)
+                    const mentionsName = errors.some(e => e.includes(name));
+                    assert.ok(
+                        mentionsName,
+                        `Error should mention the violating name "${name}". Errors: ${JSON.stringify(errors)}`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        // ── Test 2: Root package with valid @aws/ prefix passes ──────────
+
+        it('accepts root package.json names starting with @aws/', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                arbNameSuffix,
+                (suffix) => {
+                    const dir = createTempDir();
+                    const pkgPath = join(dir, 'package.json');
+                    const name = `@aws/${suffix}`;
+
+                    writeJSON(pkgPath, { name, version: '1.0.0' });
+
+                    const errors = validateRootNamespace(pkgPath);
+
+                    assert.deepStrictEqual(
+                        errors,
+                        [],
+                        `Should accept root name "${name}" but got errors: ${JSON.stringify(errors)}`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        // ── Test 3: Server package with invalid prefix is rejected ───────
+
+        it('rejects server package.json names not starting with @amzn/', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                arbInvalidServerPrefix,
+                arbNameSuffix,
+                (dirName, prefix, suffix) => {
+                    const dir = createTempDir();
+                    const serverDir = join(dir, dirName);
+                    ensureDir(serverDir);
+
+                    const name = `${prefix}${suffix}`;
+                    writeJSON(join(serverDir, 'package.json'), { name, version: '1.0.0' });
+
+                    const errors = validateServerNamespaces(dir);
+
+                    assert.ok(
+                        errors.length > 0,
+                        `Should reject server name "${name}" in ${dirName}/ (does not start with @amzn/) but got no errors`
+                    );
+
+                    // Error message must contain the file path (Req 8.6)
+                    const mentionsPath = errors.some(e => e.includes(dirName));
+                    assert.ok(
+                        mentionsPath,
+                        `Error should mention the server directory "${dirName}". Errors: ${JSON.stringify(errors)}`
+                    );
+
+                    // Error message must contain the current name (Req 8.6)
+                    const mentionsName = errors.some(e => e.includes(name));
+                    assert.ok(
+                        mentionsName,
+                        `Error should mention the violating name "${name}". Errors: ${JSON.stringify(errors)}`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        // ── Test 4: Server package with valid @amzn/ prefix passes ───────
+
+        it('accepts server package.json names starting with @amzn/', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                arbNameSuffix,
+                (dirName, suffix) => {
+                    const dir = createTempDir();
+                    const serverDir = join(dir, dirName);
+                    ensureDir(serverDir);
+
+                    const name = `@amzn/${suffix}`;
+                    writeJSON(join(serverDir, 'package.json'), { name, version: '1.0.0' });
+
+                    const errors = validateServerNamespaces(dir);
+
+                    assert.deepStrictEqual(
+                        errors,
+                        [],
+                        `Should accept server name "${name}" but got errors: ${JSON.stringify(errors)}`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        // ── Test 5: Manifest with invalid prefix is rejected ─────────────
+
+        it('rejects server manifest.json names not starting with @amzn/', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                arbInvalidServerPrefix,
+                arbNameSuffix,
+                (dirName, prefix, suffix) => {
+                    const dir = createTempDir();
+                    const serverDir = join(dir, dirName);
+                    ensureDir(serverDir);
+
+                    const name = `${prefix}${suffix}`;
+                    writeJSON(join(serverDir, 'manifest.json'), { name, version: '1.0.0' });
+
+                    const errors = validateManifestNamespaces(dir);
+
+                    assert.ok(
+                        errors.length > 0,
+                        `Should reject manifest name "${name}" in ${dirName}/ (does not start with @amzn/) but got no errors`
+                    );
+
+                    // Error message must contain the file path (Req 8.6)
+                    const mentionsPath = errors.some(e => e.includes(dirName));
+                    assert.ok(
+                        mentionsPath,
+                        `Error should mention the server directory "${dirName}". Errors: ${JSON.stringify(errors)}`
+                    );
+
+                    // Error message must contain the current name (Req 8.6)
+                    const mentionsName = errors.some(e => e.includes(name));
+                    assert.ok(
+                        mentionsName,
+                        `Error should mention the violating name "${name}". Errors: ${JSON.stringify(errors)}`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        // ── Test 6: Manifest with valid @amzn/ prefix passes ─────────────
+
+        it('accepts server manifest.json names starting with @amzn/', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                arbNameSuffix,
+                (dirName, suffix) => {
+                    const dir = createTempDir();
+                    const serverDir = join(dir, dirName);
+                    ensureDir(serverDir);
+
+                    const name = `@amzn/${suffix}`;
+                    writeJSON(join(serverDir, 'manifest.json'), { name, version: '1.0.0' });
+
+                    const errors = validateManifestNamespaces(dir);
+
+                    assert.deepStrictEqual(
+                        errors,
+                        [],
+                        `Should accept manifest name "${name}" but got errors: ${JSON.stringify(errors)}`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        // ── Test 7: Missing name field is rejected ───────────────────────
+
+        it('rejects package.json or manifest.json with missing name field', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                fc.constantFrom('package.json', 'manifest.json'),
+                (dirName, fileType) => {
+                    const dir = createTempDir();
+
+                    if (fileType === 'package.json') {
+                        // Test root package.json missing name
+                        const pkgPath = join(dir, 'package.json');
+                        writeJSON(pkgPath, { version: '1.0.0' });
+                        const rootErrors = validateRootNamespace(pkgPath);
+                        assert.ok(
+                            rootErrors.length > 0,
+                            'Should reject root package.json with missing name'
+                        );
+
+                        // Test server package.json missing name
+                        const serverDir = join(dir, 'servers', dirName);
+                        ensureDir(serverDir);
+                        writeJSON(join(serverDir, 'package.json'), { version: '1.0.0' });
+                        const serverErrors = validateServerNamespaces(join(dir, 'servers'));
+                        assert.ok(
+                            serverErrors.length > 0,
+                            'Should reject server package.json with missing name'
+                        );
+                    } else {
+                        // Test manifest.json missing name
+                        const serverDir = join(dir, dirName);
+                        ensureDir(serverDir);
+                        writeJSON(join(serverDir, 'manifest.json'), { version: '1.0.0' });
+                        const manifestErrors = validateManifestNamespaces(dir);
+                        assert.ok(
+                            manifestErrors.length > 0,
+                            'Should reject manifest.json with missing name'
+                        );
+                    }
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+    });
+
+    // Feature: npm-namespace-rename, Property 5: Validator detects publish safety violations
+    describe('Property 5: Validator detects publish safety violations', () => {
+
+        /**
+         * Validates: Requirements 9.1, 9.2, 9.3, 9.4
+         */
+
+        /**
+         * Generator for the `private` field value: true, false, or undefined (missing).
+         */
+        const arbPrivateField = fc.constantFrom(true, false, undefined);
+
+        // ── Test 1: Server packages without "private": true produce errors ──
+
+        it('rejects server packages missing "private": true', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                fc.constantFrom(false, undefined),
+                (dirName, privateValue) => {
+                    const dir = createTempDir();
+                    const serversDir = join(dir, 'servers');
+                    const serverDir = join(serversDir, dirName);
+                    ensureDir(serverDir);
+
+                    // Root package.json (valid — not private)
+                    const rootPkgPath = join(dir, 'package.json');
+                    writeJSON(rootPkgPath, { name: '@aws/test-pkg', version: '1.0.0' });
+
+                    // Server package.json with invalid private field
+                    const serverPkg = { name: `@amzn/ml-container-creator-${dirName}`, version: '1.0.0' };
+                    if (privateValue !== undefined) {
+                        serverPkg.private = privateValue;
+                    }
+                    writeJSON(join(serverDir, 'package.json'), serverPkg);
+
+                    const errors = validatePublishSafety(rootPkgPath, serversDir);
+
+                    assert.ok(
+                        errors.length > 0,
+                        `Should reject server package with private=${JSON.stringify(privateValue)} but got no errors`
+                    );
+
+                    // Error message must contain the violating file path (Req 9.4)
+                    const mentionsPath = errors.some(e => e.includes(dirName));
+                    assert.ok(
+                        mentionsPath,
+                        `Error should mention the server directory "${dirName}". Errors: ${JSON.stringify(errors)}`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        // ── Test 2: Server packages with "private": true don't produce errors ──
+
+        it('accepts server packages with "private": true', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                (dirName) => {
+                    const dir = createTempDir();
+                    const serversDir = join(dir, 'servers');
+                    const serverDir = join(serversDir, dirName);
+                    ensureDir(serverDir);
+
+                    // Root package.json (valid — not private)
+                    const rootPkgPath = join(dir, 'package.json');
+                    writeJSON(rootPkgPath, { name: '@aws/test-pkg', version: '1.0.0' });
+
+                    // Server package.json with private: true
+                    writeJSON(join(serverDir, 'package.json'), {
+                        name: `@amzn/ml-container-creator-${dirName}`,
+                        version: '1.0.0',
+                        private: true
+                    });
+
+                    const errors = validatePublishSafety(rootPkgPath, serversDir);
+
+                    assert.deepStrictEqual(
+                        errors,
+                        [],
+                        `Should accept server package with private=true but got errors: ${JSON.stringify(errors)}`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        // ── Test 3: Root package with "private": true produces errors ────────
+
+        it('rejects root package with "private": true', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                arbServerDirName,
+                (_dirName) => {
+                    const dir = createTempDir();
+                    const serversDir = join(dir, 'servers');
+                    ensureDir(serversDir);
+
+                    // Root package.json with private: true (violation)
+                    const rootPkgPath = join(dir, 'package.json');
+                    writeJSON(rootPkgPath, {
+                        name: '@aws/test-pkg',
+                        version: '1.0.0',
+                        private: true
+                    });
+
+                    const errors = validatePublishSafety(rootPkgPath, serversDir);
+
+                    assert.ok(
+                        errors.length > 0,
+                        'Should reject root package with private=true but got no errors'
+                    );
+
+                    // Error message must mention root (Req 9.4)
+                    const mentionsRoot = errors.some(e =>
+                        e.toLowerCase().includes('root') || e.includes('package.json')
+                    );
+                    assert.ok(
+                        mentionsRoot,
+                        `Error should mention root package. Errors: ${JSON.stringify(errors)}`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        // ── Test 4: Root package without "private": true doesn't produce errors ─
+
+        it('accepts root package without "private": true', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(false, undefined),
+                (privateValue) => {
+                    const dir = createTempDir();
+                    const serversDir = join(dir, 'servers');
+                    ensureDir(serversDir);
+
+                    // Root package.json without private: true (valid)
+                    const rootPkg = { name: '@aws/test-pkg', version: '1.0.0' };
+                    if (privateValue !== undefined) {
+                        rootPkg.private = privateValue;
+                    }
+                    const rootPkgPath = join(dir, 'package.json');
+                    writeJSON(rootPkgPath, rootPkg);
+
+                    const errors = validatePublishSafety(rootPkgPath, serversDir);
+
+                    assert.deepStrictEqual(
+                        errors,
+                        [],
+                        `Should accept root package with private=${JSON.stringify(privateValue)} but got errors: ${JSON.stringify(errors)}`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        // ── Test 5: Combined — random private values across root and servers ─
+
+        it('correctly identifies all publish safety violations with random private values', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                arbPrivateField,
+                arbServerDirName,
+                arbPrivateField,
+                (rootPrivate, serverDirName, serverPrivate) => {
+                    const dir = createTempDir();
+                    const serversDir = join(dir, 'servers');
+                    const serverDir = join(serversDir, serverDirName);
+                    ensureDir(serverDir);
+
+                    // Root package.json
+                    const rootPkg = { name: '@aws/test-pkg', version: '1.0.0' };
+                    if (rootPrivate !== undefined) {
+                        rootPkg.private = rootPrivate;
+                    }
+                    const rootPkgPath = join(dir, 'package.json');
+                    writeJSON(rootPkgPath, rootPkg);
+
+                    // Server package.json
+                    const serverPkg = { name: `@amzn/ml-container-creator-${serverDirName}`, version: '1.0.0' };
+                    if (serverPrivate !== undefined) {
+                        serverPkg.private = serverPrivate;
+                    }
+                    writeJSON(join(serverDir, 'package.json'), serverPkg);
+
+                    const errors = validatePublishSafety(rootPkgPath, serversDir);
+
+                    const rootShouldFail = rootPrivate === true;
+                    const serverShouldFail = serverPrivate !== true;
+
+                    if (rootShouldFail) {
+                        const hasRootError = errors.some(e =>
+                            e.toLowerCase().includes('root') || e.includes('must NOT')
+                        );
+                        assert.ok(
+                            hasRootError,
+                            `Root with private=true should produce error. Errors: ${JSON.stringify(errors)}`
+                        );
+                    }
+
+                    if (serverShouldFail) {
+                        const hasServerError = errors.some(e => e.includes(serverDirName));
+                        assert.ok(
+                            hasServerError,
+                            `Server "${serverDirName}" with private=${JSON.stringify(serverPrivate)} should produce error. Errors: ${JSON.stringify(errors)}`
+                        );
+                    }
+
+                    if (!rootShouldFail && !serverShouldFail) {
+                        assert.deepStrictEqual(
+                            errors,
+                            [],
+                            `No violations expected but got errors: ${JSON.stringify(errors)}`
+                        );
+                    }
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+    });
+});

--- a/test/property/template-manager-hyperpod-validation.property.test.js
+++ b/test/property/template-manager-hyperpod-validation.property.test.js
@@ -28,7 +28,7 @@ const FAST_PROPERTY_CONFIG = {
 
 /** Base answers that are always valid (non-HyperPod fields) */
 const baseValidAnswers = {
-    deploymentConfig: 'sklearn-flask',
+    deploymentConfig: 'http-flask',
     awsRegion: 'us-east-1'
 };
 

--- a/test/property/template-manager-triton.property.test.js
+++ b/test/property/template-manager-triton.property.test.js
@@ -1,0 +1,133 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Template Manager Triton Validation Property-Based Tests
+ *
+ * Property 6: TemplateManager Accepts All Valid Configs
+ * Validates: Requirements 7.3, 2.1, 7.1
+ *
+ * Property 7: GPU Backend Validation Rejects CPU Instances
+ * Validates: Requirements 7.2, 11.2
+ *
+ * Feature: triton-integration
+ */
+
+import fc from 'fast-check';
+import { describe, it, before } from 'mocha';
+import assert from 'assert';
+import TemplateManager from '../../generators/app/lib/template-manager.js';
+
+const FAST_PROPERTY_CONFIG = {
+    numRuns: 100,
+    timeout: 30000,
+    verbose: false
+};
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/** All 14 valid deployment-config strings */
+const ALL_VALID_CONFIGS = [
+    'http-flask', 'http-fastapi',
+    'transformers-vllm', 'transformers-sglang',
+    'transformers-tensorrt-llm', 'transformers-lmi', 'transformers-djl',
+    'triton-fil', 'triton-onnxruntime', 'triton-tensorflow',
+    'triton-pytorch', 'triton-vllm', 'triton-tensorrtllm', 'triton-python'
+];
+
+/** GPU-requiring backends */
+const GPU_REQUIRING_BACKENDS = ['triton-vllm', 'triton-tensorrtllm'];
+
+/** CPU-only instance types for testing GPU rejection */
+const CPU_ONLY_INSTANCES = ['ml.m5.xlarge', 'ml.c5.xlarge', 'ml.t3.large', 'ml.r5.xlarge'];
+
+/** Base answers that satisfy all non-deploymentConfig validation */
+const baseValidAnswers = {
+    buildTarget: 'codebuild',
+    deploymentTarget: 'managed-inference',
+    awsRegion: 'us-east-1',
+    awsRoleArn: ''
+};
+
+// ── Property 6: TemplateManager Accepts All Valid Configs ────────────────────
+
+describe('TemplateManager Triton Validation Property-Based Tests', () => {
+
+    before(() => {
+        console.log('\n🚀 Starting TemplateManager Triton Property Tests');
+        console.log('📋 Testing: Valid config acceptance and GPU backend rejection');
+        console.log(`🔧 Configuration: ${FAST_PROPERTY_CONFIG.numRuns} iterations per property`);
+        console.log(`📦 Total configs: ${ALL_VALID_CONFIGS.length} (${GPU_REQUIRING_BACKENDS.length} GPU-requiring)\n`);
+    });
+
+    /**
+     * Property 6: TemplateManager Accepts All Valid Configs
+     *
+     * **Validates: Requirements 7.3, 2.1, 7.1**
+     *
+     * For all 14 valid deployment-config strings (with GPU instance
+     * for GPU-requiring backends), validate() does not throw.
+     */
+    describe('Property 6: TemplateManager Accepts All Valid Configs', () => {
+        it('validate() does not throw for any valid deployment-config with appropriate instance type', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(...ALL_VALID_CONFIGS),
+                (deploymentConfig) => {
+                    const instanceType = GPU_REQUIRING_BACKENDS.includes(deploymentConfig)
+                        ? 'ml.g5.xlarge'
+                        : 'ml.m5.large';
+
+                    const answers = {
+                        ...baseValidAnswers,
+                        deploymentConfig,
+                        instanceType
+                    };
+
+                    const manager = new TemplateManager(answers);
+                    manager.validate();
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+    });
+
+    // ── Property 7: GPU Backend Validation Rejects CPU Instances ─────────────
+
+    /**
+     * Property 7: GPU Backend Validation Rejects CPU Instances
+     *
+     * **Validates: Requirements 7.2, 11.2**
+     *
+     * For triton-vllm and triton-tensorrtllm with CPU-only instance
+     * types, validate() throws.
+     */
+    describe('Property 7: GPU Backend Validation Rejects CPU Instances', () => {
+        it('validate() throws for GPU-requiring backends with CPU-only instance types', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(...GPU_REQUIRING_BACKENDS),
+                fc.constantFrom(...CPU_ONLY_INSTANCES),
+                (deploymentConfig, instanceType) => {
+                    const answers = {
+                        ...baseValidAnswers,
+                        deploymentConfig,
+                        instanceType
+                    };
+
+                    const manager = new TemplateManager(answers);
+                    assert.throws(
+                        () => manager.validate(),
+                        /requires a GPU instance type/,
+                        `Expected validate() to throw for ${deploymentConfig} with ${instanceType}`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+    });
+});

--- a/test/property/triton-registry.property.test.js
+++ b/test/property/triton-registry.property.test.js
@@ -1,0 +1,191 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Triton Registry Property-Based Tests
+ *
+ * Property 9: Triton Registry Base Images
+ * Validates: Requirements 8.2, 8.3
+ *
+ * Property 10: Triton Backend Metadata Completeness
+ * Validates: Requirement 11.1
+ *
+ * Feature: triton-integration
+ */
+
+import fc from 'fast-check';
+import { describe, it, before } from 'mocha';
+import assert from 'assert';
+import frameworkRegistry from '../../generators/app/config/registries/frameworks.js';
+import tritonBackends from '../../generators/app/config/registries/triton-backends.js';
+
+const FAST_PROPERTY_CONFIG = {
+    numRuns: 100,
+    timeout: 30000,
+    verbose: false
+};
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/** All 7 Triton backend keys in the framework registry */
+const TRITON_REGISTRY_KEYS = [
+    'triton-fil',
+    'triton-onnxruntime',
+    'triton-tensorflow',
+    'triton-pytorch',
+    'triton-vllm',
+    'triton-tensorrtllm',
+    'triton-python'
+];
+
+/** Required fields for every framework registry entry */
+const REQUIRED_REGISTRY_FIELDS = [
+    'accelerator',
+    'envVars',
+    'inferenceAmiVersion',
+    'recommendedInstanceTypes',
+    'validationLevel'
+];
+
+/** All 7 Triton backend names in the backend metadata registry */
+const TRITON_BACKEND_NAMES = [
+    'fil',
+    'onnxruntime',
+    'tensorflow',
+    'pytorch',
+    'vllm',
+    'tensorrtllm',
+    'python'
+];
+
+/** Required fields for every backend metadata entry */
+const REQUIRED_METADATA_FIELDS = [
+    'requiresGpu',
+    'modelFormats',
+    'modelArtifactName',
+    'requiresModelName',
+    'supportsSampleModel'
+];
+
+// ── Property 9: Triton Registry Base Images ─────────────────────────────────
+
+describe('Triton Registry Property-Based Tests', () => {
+
+    before(() => {
+        console.log('\n🚀 Starting Triton Registry Property Tests');
+        console.log('📋 Testing: Registry base images and backend metadata completeness');
+        console.log(`🔧 Configuration: ${FAST_PROPERTY_CONFIG.numRuns} iterations per property`);
+        console.log(`📦 Triton registry keys: ${TRITON_REGISTRY_KEYS.length}, backend names: ${TRITON_BACKEND_NAMES.length}\n`);
+    });
+
+    /**
+     * Property 9: Triton Registry Base Images
+     *
+     * **Validates: Requirements 8.2, 8.3**
+     *
+     * For all Triton backend entries in frameworks.js, baseImage starts
+     * with 'nvcr.io/nvidia/tritonserver' and entry contains required
+     * fields (accelerator, envVars, inferenceAmiVersion,
+     * recommendedInstanceTypes, validationLevel).
+     */
+    describe('Property 9: Triton Registry Base Images', () => {
+        it('all Triton backend entries have baseImage starting with nvcr.io/nvidia/tritonserver and contain required fields', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(...TRITON_REGISTRY_KEYS),
+                (registryKey) => {
+                    const entry = frameworkRegistry[registryKey];
+                    assert.ok(entry, `Framework registry missing entry for '${registryKey}'`);
+
+                    // Get the first (and typically only) version entry
+                    const versions = Object.keys(entry);
+                    assert.ok(versions.length > 0, `No version entries for '${registryKey}'`);
+
+                    for (const version of versions) {
+                        const versionEntry = entry[version];
+
+                        // baseImage must start with nvcr.io/nvidia/tritonserver
+                        assert.ok(
+                            versionEntry.baseImage && versionEntry.baseImage.startsWith('nvcr.io/nvidia/tritonserver'),
+                            `baseImage for '${registryKey}' v${version} must start with 'nvcr.io/nvidia/tritonserver', got '${versionEntry.baseImage}'`
+                        );
+
+                        // All required fields must be present
+                        for (const field of REQUIRED_REGISTRY_FIELDS) {
+                            assert.ok(
+                                versionEntry[field] !== undefined && versionEntry[field] !== null,
+                                `Missing required field '${field}' in '${registryKey}' v${version}`
+                            );
+                        }
+                    }
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+    });
+
+    // ── Property 10: Triton Backend Metadata Completeness ───────────────────
+
+    /**
+     * Property 10: Triton Backend Metadata Completeness
+     *
+     * **Validates: Requirement 11.1**
+     *
+     * For all 7 Triton backends, metadata specifies requiresGpu,
+     * modelFormats, modelArtifactName, requiresModelName,
+     * supportsSampleModel.
+     */
+    describe('Property 10: Triton Backend Metadata Completeness', () => {
+        it('all 7 Triton backends have complete metadata with all required fields', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(...TRITON_BACKEND_NAMES),
+                (backendName) => {
+                    const metadata = tritonBackends[backendName];
+                    assert.ok(metadata, `Backend metadata missing for '${backendName}'`);
+
+                    for (const field of REQUIRED_METADATA_FIELDS) {
+                        assert.ok(
+                            field in metadata,
+                            `Missing required field '${field}' in backend metadata for '${backendName}'`
+                        );
+                    }
+
+                    // Type checks for boolean fields
+                    assert.strictEqual(
+                        typeof metadata.requiresGpu,
+                        'boolean',
+                        `requiresGpu must be boolean for '${backendName}'`
+                    );
+                    assert.strictEqual(
+                        typeof metadata.requiresModelName,
+                        'boolean',
+                        `requiresModelName must be boolean for '${backendName}'`
+                    );
+                    assert.strictEqual(
+                        typeof metadata.supportsSampleModel,
+                        'boolean',
+                        `supportsSampleModel must be boolean for '${backendName}'`
+                    );
+
+                    // modelFormats must be array or null
+                    assert.ok(
+                        metadata.modelFormats === null || Array.isArray(metadata.modelFormats),
+                        `modelFormats must be array or null for '${backendName}'`
+                    );
+
+                    // modelArtifactName must be string or null
+                    assert.ok(
+                        metadata.modelArtifactName === null || typeof metadata.modelArtifactName === 'string',
+                        `modelArtifactName must be string or null for '${backendName}'`
+                    );
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+    });
+});

--- a/test/property/triton-template-generation.property.test.js
+++ b/test/property/triton-template-generation.property.test.js
@@ -1,0 +1,179 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Triton Template Generation Property-Based Tests
+ *
+ * Property 8: Triton Projects Contain Model Repository Structure
+ * Validates: Requirements 4.4, 5.2
+ *
+ * Feature: triton-integration
+ */
+
+import fc from 'fast-check';
+import { describe, it, before } from 'mocha';
+import assert from 'assert';
+import DeploymentConfigResolver from '../../generators/app/lib/deployment-config-resolver.js';
+import tritonBackends from '../../generators/app/config/registries/triton-backends.js';
+
+const FAST_PROPERTY_CONFIG = {
+    numRuns: 100,
+    timeout: 30000,
+    verbose: false
+};
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const resolver = new DeploymentConfigResolver();
+
+/** All 7 Triton deployment-config strings */
+const TRITON_CONFIGS = resolver.getConfigsForArchitecture('triton');
+
+/** Sample model names for testing */
+const SAMPLE_MODEL_NAMES = [
+    'my-model', 'abalone', 'classifier', 'xgb-model',
+    'bert-base', 'resnet50', 'custom-model'
+];
+
+// ── Property 8: Triton Projects Contain Model Repository Structure ───────────
+
+describe('Triton Template Generation Property-Based Tests', () => {
+
+    before(() => {
+        console.log('\n🚀 Starting Triton Template Generation Property Tests');
+        console.log('📋 Testing: Model repository structure for Triton configs');
+        console.log(`🔧 Configuration: ${FAST_PROPERTY_CONFIG.numRuns} iterations per property`);
+        console.log(`📦 Triton configs: ${TRITON_CONFIGS.length}\n`);
+    });
+
+    /**
+     * Property 8: Triton Projects Contain Model Repository Structure
+     *
+     * **Validates: Requirements 4.4, 5.2**
+     *
+     * For any Triton deployment-config, the generated project should contain
+     * model_repository/<model-name>/config.pbtxt and
+     * model_repository/<model-name>/1/ directory, and the config.pbtxt
+     * should reference the correct Triton backend name.
+     */
+    describe('Property 8: Triton Projects Contain Model Repository Structure', () => {
+
+        it('all Triton configs decompose to triton architecture', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(...TRITON_CONFIGS),
+                (deploymentConfig) => {
+                    const parts = resolver.decompose(deploymentConfig);
+                    assert.strictEqual(parts.architecture, 'triton',
+                        `Expected architecture 'triton' for ${deploymentConfig}, got '${parts.architecture}'`);
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        it('expected model repository paths are generated for any Triton config and model name', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(...TRITON_CONFIGS),
+                fc.constantFrom(...SAMPLE_MODEL_NAMES),
+                (deploymentConfig, modelName) => {
+                    const parts = resolver.decompose(deploymentConfig);
+                    const backend = parts.backend;
+
+                    // Verify expected file paths for model repository structure
+                    const expectedConfigPath = `model_repository/${modelName}/config.pbtxt`;
+                    const expectedVersionDir = `model_repository/${modelName}/1/`;
+
+                    // Verify the paths are well-formed
+                    assert.ok(expectedConfigPath.includes('config.pbtxt'),
+                        'config.pbtxt path should be in model_repository');
+                    assert.ok(expectedVersionDir.endsWith('1/'),
+                        'Version directory should end with 1/');
+                    assert.ok(expectedConfigPath.startsWith('model_repository/'),
+                        'config.pbtxt should be under model_repository/');
+                    assert.ok(expectedVersionDir.startsWith('model_repository/'),
+                        'Version dir should be under model_repository/');
+
+                    // Verify the backend from decomposition matches a known Triton backend
+                    assert.ok(backend in tritonBackends,
+                        `Backend '${backend}' from ${deploymentConfig} should exist in triton-backends registry`);
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        it('config.pbtxt references the correct backend for any Triton config', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(...TRITON_CONFIGS),
+                (deploymentConfig) => {
+                    const parts = resolver.decompose(deploymentConfig);
+                    const backend = parts.backend;
+
+                    // The config.pbtxt template uses `backend` variable directly
+                    // Verify the backend name is valid for Triton
+                    const validTritonBackends = Object.keys(tritonBackends);
+                    assert.ok(validTritonBackends.includes(backend),
+                        `Backend '${backend}' should be a valid Triton backend. Valid: ${validTritonBackends.join(', ')}`);
+
+                    // Verify the backend metadata exists and has required fields
+                    const meta = tritonBackends[backend];
+                    assert.ok(meta !== undefined,
+                        `Backend metadata should exist for '${backend}'`);
+                    assert.ok(typeof meta.requiresGpu === 'boolean',
+                        `Backend '${backend}' should have requiresGpu boolean`);
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        it('triton-python backend requires model.py in version directory', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            fc.assert(fc.property(
+                fc.constantFrom(...SAMPLE_MODEL_NAMES),
+                (modelName) => {
+                    const parts = resolver.decompose('triton-python');
+                    assert.strictEqual(parts.backend, 'python');
+
+                    // For python backend, model.py should go in version directory
+                    const expectedModelPyPath = `model_repository/${modelName}/1/model.py`;
+                    assert.ok(expectedModelPyPath.includes('1/model.py'),
+                        'Python backend should have model.py in version directory');
+
+                    // Python backend metadata should indicate it doesn't require model name (HF)
+                    const meta = tritonBackends['python'];
+                    assert.strictEqual(meta.requiresModelName, false,
+                        'Python backend should not require HuggingFace model name');
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+
+        it('non-python Triton backends do not include model.py in expected output', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+            const nonPythonTritonConfigs = TRITON_CONFIGS.filter(dc => dc !== 'triton-python');
+
+            fc.assert(fc.property(
+                fc.constantFrom(...nonPythonTritonConfigs),
+                (deploymentConfig) => {
+                    const parts = resolver.decompose(deploymentConfig);
+
+                    // Non-python backends should not have model.py as their artifact
+                    // (model.py is specific to the python backend)
+                    assert.notStrictEqual(parts.backend, 'python',
+                        `${deploymentConfig} should not be python backend`);
+
+                    return true;
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+        });
+    });
+});

--- a/test/template-manager.test.js
+++ b/test/template-manager.test.js
@@ -14,9 +14,9 @@ describe('TemplateManager', () => {
     // conditional logic based on deployment configuration.
 
     describe('validate', () => {
-        it('should pass validation for supported deployment configurations', () => {
+        it('should pass validation for http deployment configurations', () => {
             const answers = {
-                deploymentConfig: 'sklearn-flask',
+                deploymentConfig: 'http-flask',
                 buildTarget: 'codebuild',
                 deploymentTarget: 'managed-inference',
                 instanceType: 'ml.m5.large',
@@ -24,11 +24,11 @@ describe('TemplateManager', () => {
                 awsRoleArn: '',
                 includeTesting: true,
                 testTypes: ['local-model-cli']
-            };
+            }
             
-            const manager = new TemplateManager(answers);
-            assert.doesNotThrow(() => manager.validate());
-        });
+            const manager = new TemplateManager(answers)
+            assert.doesNotThrow(() => manager.validate())
+        })
 
         it('should pass validation for transformers deployment configurations', () => {
             const answers = {
@@ -40,11 +40,27 @@ describe('TemplateManager', () => {
                 awsRoleArn: '',
                 includeTesting: true,
                 testTypes: ['local-model-cli']
-            };
+            }
             
-            const manager = new TemplateManager(answers);
-            assert.doesNotThrow(() => manager.validate());
-        });
+            const manager = new TemplateManager(answers)
+            assert.doesNotThrow(() => manager.validate())
+        })
+
+        it('should pass validation for triton deployment configurations', () => {
+            const answers = {
+                deploymentConfig: 'triton-fil',
+                buildTarget: 'codebuild',
+                deploymentTarget: 'managed-inference',
+                instanceType: 'ml.g5.xlarge',
+                awsRegion: 'us-east-1',
+                awsRoleArn: '',
+                includeTesting: true,
+                testTypes: ['local-model-cli']
+            }
+            
+            const manager = new TemplateManager(answers)
+            assert.doesNotThrow(() => manager.validate())
+        })
 
         it('should throw error for unsupported deployment configuration', () => {
             const answers = {
@@ -53,68 +69,123 @@ describe('TemplateManager', () => {
                 instanceType: 'ml.m5.large',
                 awsRegion: 'us-east-1',
                 awsRoleArn: ''
-            };
+            }
             
-            const manager = new TemplateManager(answers);
-            assert.throws(() => manager.validate(), /pytorch-torchserve not implemented yet/);
-        });
+            const manager = new TemplateManager(answers)
+            assert.throws(() => manager.validate(), /pytorch-torchserve not implemented yet/)
+        })
 
-        it('should support backward compatibility with separate framework and modelServer', () => {
+        it('should reject old-format deployment configs', () => {
             const answers = {
-                framework: 'sklearn',
-                modelServer: 'flask',
+                deploymentConfig: 'sklearn-flask',
+                buildTarget: 'codebuild',
+                instanceType: 'ml.m5.large',
+                awsRegion: 'us-east-1',
+                awsRoleArn: ''
+            }
+            
+            const manager = new TemplateManager(answers)
+            assert.throws(() => manager.validate(), /sklearn-flask not implemented yet/)
+        })
+
+        it('should support fallback validation with separate architecture and backend', () => {
+            const answers = {
+                architecture: 'http',
+                backend: 'flask',
                 buildTarget: 'codebuild',
                 instanceType: 'ml.m5.large',
                 awsRegion: 'us-east-1',
                 awsRoleArn: '',
                 includeTesting: true,
                 testTypes: ['local-model-cli']
-            };
+            }
             
-            const manager = new TemplateManager(answers);
-            assert.doesNotThrow(() => manager.validate());
-        });
+            const manager = new TemplateManager(answers)
+            assert.doesNotThrow(() => manager.validate())
+        })
 
-        it('should throw error for unsupported framework in backward compatibility mode', () => {
+        it('should throw error for unsupported architecture in fallback mode', () => {
             const answers = {
-                framework: 'pytorch',
-                modelServer: 'flask',
+                architecture: 'custom',
+                backend: 'flask',
                 buildTarget: 'codebuild',
                 instanceType: 'ml.m5.large',
                 awsRegion: 'us-east-1',
                 awsRoleArn: ''
-            };
+            }
             
-            const manager = new TemplateManager(answers);
-            assert.throws(() => manager.validate(), /pytorch not implemented yet/);
-        });
+            const manager = new TemplateManager(answers)
+            assert.throws(() => manager.validate(), /custom not implemented yet/)
+        })
 
-        it('should throw error for unsupported model server in backward compatibility mode', () => {
+        it('should throw error for unsupported backend in fallback mode', () => {
             const answers = {
-                framework: 'sklearn',
-                modelServer: 'torchserve',
+                architecture: 'http',
+                backend: 'torchserve',
                 buildTarget: 'codebuild',
                 instanceType: 'ml.m5.large',
                 awsRegion: 'us-east-1',
                 awsRoleArn: ''
-            };
+            }
             
-            const manager = new TemplateManager(answers);
-            assert.throws(() => manager.validate(), /torchserve not implemented yet/);
-        });
+            const manager = new TemplateManager(answers)
+            assert.throws(() => manager.validate(), /torchserve not implemented yet/)
+        })
 
-        it('should throw error for tensorrt-llm with non-transformers framework', () => {
+        it('should throw error for tensorrt-llm with non-transformers architecture', () => {
             const answers = {
-                framework: 'sklearn',
-                modelServer: 'tensorrt-llm',
+                architecture: 'http',
+                backend: 'tensorrt-llm',
                 buildTarget: 'codebuild',
                 instanceType: 'ml.g5.xlarge',
                 awsRegion: 'us-east-1',
                 awsRoleArn: ''
-            };
+            }
             
-            const manager = new TemplateManager(answers);
-            assert.throws(() => manager.validate(), /TensorRT-LLM is only supported with the transformers framework/);
-        });
-    });
+            const manager = new TemplateManager(answers)
+            assert.throws(() => manager.validate(), /TensorRT-LLM is only supported with the transformers architecture/)
+        })
+
+        it('should reject triton-vllm with CPU-only instance type', () => {
+            const answers = {
+                deploymentConfig: 'triton-vllm',
+                buildTarget: 'codebuild',
+                deploymentTarget: 'managed-inference',
+                instanceType: 'ml.m5.xlarge',
+                awsRegion: 'us-east-1',
+                awsRoleArn: ''
+            }
+            
+            const manager = new TemplateManager(answers)
+            assert.throws(() => manager.validate(), /triton-vllm requires a GPU instance type/)
+        })
+
+        it('should reject triton-tensorrtllm with CPU-only instance type', () => {
+            const answers = {
+                deploymentConfig: 'triton-tensorrtllm',
+                buildTarget: 'codebuild',
+                deploymentTarget: 'managed-inference',
+                instanceType: 'ml.c5.xlarge',
+                awsRegion: 'us-east-1',
+                awsRoleArn: ''
+            }
+            
+            const manager = new TemplateManager(answers)
+            assert.throws(() => manager.validate(), /triton-tensorrtllm requires a GPU instance type/)
+        })
+
+        it('should accept triton-vllm with GPU instance type', () => {
+            const answers = {
+                deploymentConfig: 'triton-vllm',
+                buildTarget: 'codebuild',
+                deploymentTarget: 'managed-inference',
+                instanceType: 'ml.g5.xlarge',
+                awsRegion: 'us-east-1',
+                awsRoleArn: ''
+            }
+            
+            const manager = new TemplateManager(answers)
+            assert.doesNotThrow(() => manager.validate())
+        })
+    })
 });

--- a/test/test_endpoint.sh
+++ b/test/test_endpoint.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Exit on any error
+set -e
+
+
+
+# Check if endpoint name is provided
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <endpoint-name>"
+    echo "Example: $0 triton-endpoint-1234567890"
+    exit 1
+fi
+
+ENDPOINT_NAME=$1
+AWS_REGION="us-east-1"
+
+
+
+echo "Testing SageMaker endpoint: ${ENDPOINT_NAME}"
+
+echo "Checking endpoint status..."
+aws sagemaker describe-endpoint --endpoint-name ${ENDPOINT_NAME} --region ${AWS_REGION} --query 'EndpointStatus' --output text
+
+echo "Testing inference endpoint..."
+
+
+echo '{"instances": [[1, 0.455, 0.365, 0.095, 0.514, 0.2245, 0.101, 0.15]]}' > input.json
+
+
+aws sagemaker-runtime invoke-endpoint \
+    --endpoint-name ${ENDPOINT_NAME} \
+    --region ${AWS_REGION} \
+    --content-type 'application/json' \
+    --body fileb://input.json \
+    response.json
+
+echo "Response:"
+if command -v jq &> /dev/null; then
+    # Decode base64 if response is encoded
+    jq -r '.Body // .' response.json 2>/dev/null || cat response.json
+else
+    cat response.json
+fi
+echo
+
+echo "Cleaning up files..."
+rm -f response.json input.json
+
+echo "Test complete!"

--- a/test/test_local_image.sh
+++ b/test/test_local_image.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+# Exit on any error
+set -e
+
+IMAGE_NAME="quick-inference-container"
+CONTAINER_NAME="triton-test"
+PORT=8080
+
+echo "Building Docker image..."
+docker build -t ${IMAGE_NAME} .
+
+echo "Stopping any existing container..."
+docker stop ${CONTAINER_NAME} 2>/dev/null || true
+docker rm ${CONTAINER_NAME} 2>/dev/null || true
+
+echo "Starting container on port ${PORT}..."
+docker run -d --name ${CONTAINER_NAME} -p ${PORT}:8080 ${IMAGE_NAME}
+
+echo "Waiting for container to start..."
+sleep 10
+
+echo "Testing health check endpoint..."
+curl -f http://localhost:${PORT}/ping || echo "Health check failed"
+
+echo -e "\nTesting inference endpoint..."
+curl -X POST http://localhost:${PORT}/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"instances": [[1, 0.455, 0.365, 0.095, 0.514, 0.2245, 0.101, 0.15]]}' || echo "Inference failed"
+
+echo -e "\nContainer logs:"
+docker logs ${CONTAINER_NAME}
+
+echo -e "\nCleaning up..."
+docker stop ${CONTAINER_NAME}
+docker rm ${CONTAINER_NAME}
+
+echo "Test complete!"

--- a/test/test_model_handler.py
+++ b/test/test_model_handler.py
@@ -1,0 +1,86 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+#!/usr/bin/env python3
+"""
+Local testing script for triton models
+
+This script allows you to test your model locally before containerizing.
+Unlike serve.py (which runs a production HTTP server), this is a CLI tool
+for development and debugging.
+
+Usage examples:
+  # Test with array input
+  python test_model_handler.py --input-data '[[1,2,3,4]]'
+  
+  # Test with SageMaker format
+  python test_model_handler.py --input-data '{"instances": [[1, 0.455, 0.365, 0.095, 0.514, 0.2245, 0.101, 0.15]]}'
+  
+  # Custom model path
+  python test_model_handler.py --model-path ./ --input-data '[[1, 0.455, 0.365, 0.095, 0.514, 0.2245, 0.101, 0.15]]'
+
+This is NOT used in production - serve.py handles containerized inference.
+"""
+import json
+import argparse
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'code'))
+from model_handler import ModelHandler
+
+def usage():
+    """Print usage examples and exit"""
+    print("\nTRITON Model Handler Test Tool")
+    print("=" * 40)
+    print("\nUsage examples:")
+    print("  # Basic test with array input:")
+    print("  python test_model_handler.py --input-data '[[1, 0.455, 0.365, 0.095, 0.514, 0.2245, 0.101, 0.15]]'")
+    print("\n  # SageMaker format:")
+    print("  python test_model_handler.py --input-data '{\"instances\": [[1, 0.455, 0.365, 0.095, 0.514, 0.2245, 0.101, 0.15]]}'")
+    print("\n  # Custom model path:")
+    print("  python test_model_handler.py --model-path ../sample_model --input-data '[[1, 0.455, 0.365, 0.095, 0.514, 0.2245, 0.101, 0.15]]'")
+    print("\n  # Show this help:")
+    print("  python test_model_handler.py --help")
+    print("\nNote: This is for local testing only. Production uses serve.py in containers.\n")
+    sys.exit(0)
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Local CLI tool for testing triton model inference',
+        epilog='Use --usage for detailed examples'
+    )
+    parser.add_argument('--model-path', type=str, default='sample_model',
+                        help='Path to model directory (default: sample_model)')
+    parser.add_argument('--input-data', type=str,
+                        help='Input data as application/json string')
+    parser.add_argument('--usage', action='store_true',
+                        help='Show detailed usage examples')
+
+    args = parser.parse_args()
+
+    if args.usage:
+        usage()
+
+    if not args.input_data:
+        print("Error: --input-data is required")
+        print("Use --usage for examples or --help for options")
+        sys.exit(1)
+
+    print(f"Loading model from: {args.model_path}")
+    handler = ModelHandler(args.model_path)
+    handler.load_model()
+
+    try:
+        input_data = json.loads(args.input_data)
+    except json.JSONDecodeError:
+        input_data = args.input_data
+
+    print("Running inference...")
+    result = handler.predict(input_data)
+    print("\nResult:")
+    print(json.dumps(result, indent=2))
+
+if __name__ == '__main__':
+    main()
+

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import assert from 'assert';
-import TemplateManager from '../generators/app/lib/template-manager.js';
+import assert from 'assert'
+import TemplateManager from '../generators/app/lib/template-manager.js'
 
 describe('Unit Tests', () => {
     describe('TemplateManager', () => {
@@ -10,18 +10,18 @@ describe('Unit Tests', () => {
         // All template files are now generated unconditionally, and runtime scripts handle
         // conditional logic based on deployment configuration.
 
-        it('should validate supported deployment configurations', () => {
+        it('should validate http deployment configurations', () => {
             const answers = {
-                deploymentConfig: 'sklearn-flask',
+                deploymentConfig: 'http-flask',
                 buildTarget: 'codebuild',
                 instanceType: 'ml.m5.large',
                 awsRegion: 'us-east-1',
                 awsRoleArn: ''
-            };
+            }
             
-            const manager = new TemplateManager(answers);
-            assert.doesNotThrow(() => manager.validate());
-        });
+            const manager = new TemplateManager(answers)
+            assert.doesNotThrow(() => manager.validate())
+        })
 
         it('should validate transformers deployment configurations', () => {
             const answers = {
@@ -30,39 +30,52 @@ describe('Unit Tests', () => {
                 instanceType: 'ml.g5.xlarge',
                 awsRegion: 'us-east-1',
                 awsRoleArn: ''
-            };
+            }
             
-            const manager = new TemplateManager(answers);
-            assert.doesNotThrow(() => manager.validate());
-        });
+            const manager = new TemplateManager(answers)
+            assert.doesNotThrow(() => manager.validate())
+        })
 
-        it('should support backward compatibility with separate framework and modelServer', () => {
+        it('should validate triton deployment configurations', () => {
             const answers = {
-                framework: 'sklearn',
-                modelServer: 'flask',
+                deploymentConfig: 'triton-fil',
+                buildTarget: 'codebuild',
+                instanceType: 'ml.g5.xlarge',
+                awsRegion: 'us-east-1',
+                awsRoleArn: ''
+            }
+            
+            const manager = new TemplateManager(answers)
+            assert.doesNotThrow(() => manager.validate())
+        })
+
+        it('should support fallback validation with separate architecture and backend', () => {
+            const answers = {
+                architecture: 'http',
+                backend: 'flask',
                 buildTarget: 'codebuild',
                 instanceType: 'ml.m5.large',
                 awsRegion: 'us-east-1',
                 awsRoleArn: ''
-            };
+            }
             
-            const manager = new TemplateManager(answers);
-            assert.doesNotThrow(() => manager.validate());
-        });
+            const manager = new TemplateManager(answers)
+            assert.doesNotThrow(() => manager.validate())
+        })
 
-        it('should throw error for unsupported framework in backward compatibility mode', () => {
+        it('should throw error for unsupported architecture in fallback mode', () => {
             const answers = {
-                framework: 'pytorch',
-                modelServer: 'flask',
+                architecture: 'pytorch',
+                backend: 'flask',
                 buildTarget: 'codebuild',
                 instanceType: 'ml.m5.large',
                 awsRegion: 'us-east-1',
                 awsRoleArn: ''
-            };
+            }
             
-            const manager = new TemplateManager(answers);
-            assert.throws(() => manager.validate(), /pytorch not implemented yet/);
-        });
+            const manager = new TemplateManager(answers)
+            assert.throws(() => manager.validate(), /pytorch not implemented yet/)
+        })
 
         it('should throw error for unsupported deployment configuration', () => {
             const answers = {
@@ -71,10 +84,23 @@ describe('Unit Tests', () => {
                 instanceType: 'ml.m5.large',
                 awsRegion: 'us-east-1',
                 awsRoleArn: ''
-            };
+            }
             
-            const manager = new TemplateManager(answers);
-            assert.throws(() => manager.validate(), /pytorch-torchserve not implemented yet/);
-        });
-    });
-});
+            const manager = new TemplateManager(answers)
+            assert.throws(() => manager.validate(), /pytorch-torchserve not implemented yet/)
+        })
+
+        it('should reject old-format deployment configs', () => {
+            const answers = {
+                deploymentConfig: 'sklearn-flask',
+                buildTarget: 'codebuild',
+                instanceType: 'ml.m5.large',
+                awsRegion: 'us-east-1',
+                awsRoleArn: ''
+            }
+            
+            const manager = new TemplateManager(answers)
+            assert.throws(() => manager.validate(), /sklearn-flask not implemented yet/)
+        })
+    })
+})

--- a/test/unit/config-manager-unit.test.js
+++ b/test/unit/config-manager-unit.test.js
@@ -31,28 +31,28 @@ describe('ConfigManager Unit Tests', () => {
 
     describe('loadConfiguration()', () => {
         describe('CLI Options (Highest Priority)', () => {
-            it('should load framework from CLI option', async () => {
-                mockGenerator = createMockGeneratorWithOptions({ framework: 'xgboost' });
+            it('should load deployment-config from CLI option', async () => {
+                mockGenerator = createMockGeneratorWithOptions({ 'deployment-config': 'http-flask' });
                 configManager = new ConfigManager(mockGenerator);
                 
                 const config = await configManager.loadConfiguration();
                 
-                assert.strictEqual(config.framework, 'xgboost');
+                assert.strictEqual(config.deploymentConfig, 'http-flask');
             });
 
-            it('should load model-server from CLI option', async () => {
-                mockGenerator = createMockGeneratorWithOptions({ 'model-server': 'fastapi' });
+            it('should load engine from CLI option', async () => {
+                mockGenerator = createMockGeneratorWithOptions({ engine: 'sklearn' });
                 configManager = new ConfigManager(mockGenerator);
                 
                 const config = await configManager.loadConfiguration();
                 
-                assert.strictEqual(config.modelServer, 'fastapi');
+                assert.strictEqual(config.engine, 'sklearn');
             });
 
             it('should load multiple CLI options', async () => {
                 mockGenerator = createMockGeneratorWithOptions({
-                    framework: 'sklearn',
-                    'model-server': 'flask',
+                    'deployment-config': 'http-flask',
+                    engine: 'sklearn',
                     'model-format': 'pkl',
                     'include-sample': true,
                     'include-testing': false
@@ -61,8 +61,8 @@ describe('ConfigManager Unit Tests', () => {
                 
                 const config = await configManager.loadConfiguration();
                 
-                assert.strictEqual(config.framework, 'sklearn');
-                assert.strictEqual(config.modelServer, 'flask');
+                assert.strictEqual(config.deploymentConfig, 'http-flask');
+                assert.strictEqual(config.engine, 'sklearn');
                 assert.strictEqual(config.modelFormat, 'pkl');
                 assert.strictEqual(config.includeSampleModel, true);
                 assert.strictEqual(config.includeTesting, false);
@@ -170,8 +170,9 @@ describe('ConfigManager Unit Tests', () => {
                 
                 const config = await configManager.loadConfiguration();
                 
-                assert.strictEqual(config.framework, null);
-                assert.strictEqual(config.modelServer, null);
+                // These env vars are not mapped to any parameter
+                assert.strictEqual(config.architecture, null);
+                assert.strictEqual(config.backend, null);
             });
         });
 
@@ -220,10 +221,10 @@ describe('ConfigManager Unit Tests', () => {
             configManager = new ConfigManager(mockGenerator);
         });
 
-        describe('Framework Validation', () => {
-            it('should accept valid frameworks', async () => {
+        describe('Deployment Config Validation', () => {
+            it('should accept valid deployment configs', async () => {
                 await configManager.loadConfiguration();
-                configManager.config.framework = 'sklearn';
+                configManager.config.deploymentConfig = 'http-flask';
                 
                 const errors = configManager.validateConfiguration();
                 
@@ -231,65 +232,115 @@ describe('ConfigManager Unit Tests', () => {
                 assert.strictEqual(errors.length, 0);
             });
 
-            it('should reject invalid frameworks', async () => {
+            it('should reject invalid deployment configs', async () => {
                 await configManager.loadConfiguration();
-                configManager.config.framework = 'pytorch';
+                configManager.config.deploymentConfig = 'invalid-config';
                 
                 const errors = configManager.validateConfiguration();
                 
                 assert.strictEqual(errors.length, 1);
-                assert.ok(errors[0].includes('Unsupported framework: pytorch'));
+                assert.ok(errors[0].includes('Unsupported deployment-config: invalid-config'));
+            });
+        });
+
+        describe('Old Format Migration', () => {
+            it('should reject old-format sklearn-flask with migration message', async () => {
+                await configManager.loadConfiguration();
+                configManager.config.deploymentConfig = 'sklearn-flask';
+                
+                const errors = configManager.validateConfiguration();
+                
+                assert.strictEqual(errors.length, 1);
+                assert.ok(errors[0].includes('Use --deployment-config=http-flask --engine=sklearn instead'));
+            });
+
+            it('should reject old-format xgboost-fastapi with migration message', async () => {
+                await configManager.loadConfiguration();
+                configManager.config.deploymentConfig = 'xgboost-fastapi';
+                
+                const errors = configManager.validateConfiguration();
+                
+                assert.strictEqual(errors.length, 1);
+                assert.ok(errors[0].includes('Use --deployment-config=http-fastapi --engine=xgboost instead'));
+            });
+
+            it('should reject old-format tensorflow-flask with migration message', async () => {
+                await configManager.loadConfiguration();
+                configManager.config.deploymentConfig = 'tensorflow-flask';
+                
+                const errors = configManager.validateConfiguration();
+                
+                assert.strictEqual(errors.length, 1);
+                assert.ok(errors[0].includes('Use --deployment-config=http-flask --engine=tensorflow instead'));
+            });
+        });
+
+        describe('Engine Validation', () => {
+            it('should accept valid engines', async () => {
+                await configManager.loadConfiguration();
+                configManager.config.engine = 'sklearn';
+                
+                const errors = configManager.validateConfiguration();
+                
+                assert.strictEqual(errors.length, 0);
+            });
+
+            it('should reject invalid engines', async () => {
+                await configManager.loadConfiguration();
+                configManager.config.engine = 'pytorch';
+                
+                const errors = configManager.validateConfiguration();
+                
+                assert.strictEqual(errors.length, 1);
+                assert.ok(errors[0].includes('Unsupported engine: pytorch'));
             });
         });
 
         describe('Model Server Validation', () => {
-            it('should accept valid sklearn + flask combination', async () => {
+            it('should accept valid http-flask deployment config', async () => {
                 await configManager.loadConfiguration();
-                configManager.config.framework = 'sklearn';
-                configManager.config.modelServer = 'flask';
+                configManager.config.deploymentConfig = 'http-flask';
                 
                 const errors = configManager.validateConfiguration();
                 
                 assert.strictEqual(errors.length, 0);
             });
 
-            it('should accept valid transformers + vllm combination', async () => {
+            it('should accept valid transformers-vllm deployment config', async () => {
                 await configManager.loadConfiguration();
-                configManager.config.framework = 'transformers';
-                configManager.config.modelServer = 'vllm';
+                configManager.config.deploymentConfig = 'transformers-vllm';
                 
                 const errors = configManager.validateConfiguration();
                 
                 assert.strictEqual(errors.length, 0);
             });
 
-            it('should reject invalid sklearn + vllm combination', async () => {
+            it('should reject invalid sklearn + vllm combination (old format)', async () => {
                 await configManager.loadConfiguration();
-                configManager.config.framework = 'sklearn';
-                configManager.config.modelServer = 'vllm';
+                configManager.config.deploymentConfig = 'sklearn-vllm';
                 
                 const errors = configManager.validateConfiguration();
                 
                 assert.strictEqual(errors.length, 1);
-                assert.ok(errors[0].includes('Unsupported model server'));
+                assert.ok(errors[0].includes('Unsupported deployment-config'));
             });
 
-            it('should provide special error for tensorrt-llm with non-transformers', async () => {
+            it('should reject unsupported triton backend', async () => {
                 await configManager.loadConfiguration();
-                configManager.config.framework = 'sklearn';
-                configManager.config.modelServer = 'tensorrt-llm';
+                configManager.config.deploymentConfig = 'triton-openvino';
                 
                 const errors = configManager.validateConfiguration();
                 
                 assert.strictEqual(errors.length, 1);
-                assert.ok(errors[0].includes('TensorRT-LLM is only supported with the transformers framework'));
+                assert.ok(errors[0].includes('Unsupported deployment-config'));
             });
         });
 
         describe('Model Format Validation', () => {
             it('should accept valid sklearn + pkl combination', async () => {
                 await configManager.loadConfiguration();
-                configManager.config.framework = 'sklearn';
+                configManager.config.deploymentConfig = 'http-flask';
+                configManager.config.engine = 'sklearn';
                 configManager.config.modelFormat = 'pkl';
                 
                 const errors = configManager.validateConfiguration();
@@ -299,7 +350,8 @@ describe('ConfigManager Unit Tests', () => {
 
             it('should reject invalid sklearn + keras combination', async () => {
                 await configManager.loadConfiguration();
-                configManager.config.framework = 'sklearn';
+                configManager.config.deploymentConfig = 'http-flask';
+                configManager.config.engine = 'sklearn';
                 configManager.config.modelFormat = 'keras';
                 
                 const errors = configManager.validateConfiguration();
@@ -379,17 +431,17 @@ describe('ConfigManager Unit Tests', () => {
 
         it('should merge prompt answers with explicit configuration', async () => {
             await configManager.loadConfiguration();
-            configManager.explicitConfig = { framework: 'sklearn' };
+            configManager.explicitConfig = { deploymentConfig: 'http-flask' };
             
             const promptAnswers = {
-                framework: 'xgboost', // Should be overridden
-                modelServer: 'flask'
+                deploymentConfig: 'http-fastapi', // Should be overridden
+                engine: 'sklearn'
             };
             
             const finalConfig = configManager.getFinalConfiguration(promptAnswers);
             
-            assert.strictEqual(finalConfig.framework, 'sklearn'); // Explicit config wins
-            assert.strictEqual(finalConfig.modelServer, 'flask'); // From prompts
+            assert.strictEqual(finalConfig.deploymentConfig, 'http-flask'); // Explicit config wins
+            assert.strictEqual(finalConfig.engine, 'sklearn'); // From prompts
         });
 
         it('should fill in missing values with defaults', async () => {
@@ -402,11 +454,11 @@ describe('ConfigManager Unit Tests', () => {
             assert.strictEqual(finalConfig.includeTesting, true);
         });
 
-        it('should disable sample models for transformers framework', async () => {
+        it('should disable sample models for transformers architecture', async () => {
             await configManager.loadConfiguration();
             
             const promptAnswers = {
-                framework: 'transformers',
+                deploymentConfig: 'transformers-vllm',
                 includeSampleModel: true
             };
             
@@ -420,7 +472,8 @@ describe('ConfigManager Unit Tests', () => {
             
             const promptAnswers = {
                 projectName: 'my-project',
-                framework: 'sklearn',
+                deploymentConfig: 'http-flask',
+                engine: 'sklearn',
                 buildTarget: 'codebuild'
             };
             
@@ -428,7 +481,7 @@ describe('ConfigManager Unit Tests', () => {
             
             assert.ok(typeof finalConfig.codebuildProjectName === 'string');
             assert.ok(finalConfig.codebuildProjectName.includes('my-project'));
-            assert.ok(finalConfig.codebuildProjectName.includes('sklearn'));
+            assert.ok(finalConfig.codebuildProjectName.includes('http'));
         });
 
         it('should add build timestamp', async () => {
@@ -476,8 +529,8 @@ describe('ConfigManager Unit Tests', () => {
 
         it('should return true when all required parameters are provided', async () => {
             mockGenerator = createMockGeneratorWithOptions({
-                framework: 'sklearn',
-                'model-server': 'flask',
+                'deployment-config': 'http-flask',
+                engine: 'sklearn',
                 'model-format': 'pkl',
                 'instance-type': 'ml.m5.large',
                 'project-name': 'test-project'
@@ -491,7 +544,7 @@ describe('ConfigManager Unit Tests', () => {
 
         it('should return false when required parameters are missing', async () => {
             mockGenerator = createMockGeneratorWithOptions({
-                framework: 'sklearn'
+                'deployment-config': 'http-flask'
                 // Missing other required parameters
             });
             configManager = new ConfigManager(mockGenerator);
@@ -512,8 +565,10 @@ describe('ConfigManager Unit Tests', () => {
             await configManager.loadConfiguration();
             
             const finalConfig = {
-                framework: 'sklearn',
-                modelServer: 'flask',
+                deploymentConfig: 'http-flask',
+                architecture: 'http',
+                backend: 'flask',
+                engine: 'sklearn',
                 modelFormat: 'pkl',
                 instanceType: 'ml.m5.large',
                 projectName: 'test-project',
@@ -533,24 +588,25 @@ describe('ConfigManager Unit Tests', () => {
             await configManager.loadConfiguration();
             
             const finalConfig = {
-                framework: 'sklearn',
-                // Missing modelServer
-                modelFormat: 'pkl',
+                deploymentConfig: 'http-flask',
+                architecture: 'http',
+                backend: 'flask',
+                // Missing engine, modelFormat, etc.
                 instanceType: 'ml.m5.large'
             };
             
             const errors = configManager.validateRequiredParameters(finalConfig);
             
             assert.ok(errors.length > 0);
-            assert.ok(errors.some(e => e.includes('modelServer')));
         });
 
         it('should not require modelFormat for transformers', async () => {
             await configManager.loadConfiguration();
             
             const finalConfig = {
-                framework: 'transformers',
-                modelServer: 'vllm',
+                deploymentConfig: 'transformers-vllm',
+                architecture: 'transformers',
+                backend: 'vllm',
                 // No modelFormat - should be OK for transformers
                 instanceType: 'ml.g5.xlarge',
                 projectName: 'test-project',
@@ -570,16 +626,16 @@ describe('ConfigManager Unit Tests', () => {
     describe('getExplicitConfiguration()', () => {
         it('should return only explicitly set configuration', async () => {
             mockGenerator = createMockGeneratorWithOptions({
-                framework: 'sklearn',
-                'model-server': 'flask'
+                'deployment-config': 'http-flask',
+                engine: 'sklearn'
             });
             configManager = new ConfigManager(mockGenerator);
             
             await configManager.loadConfiguration();
             const explicitConfig = configManager.getExplicitConfiguration();
             
-            assert.strictEqual(explicitConfig.framework, 'sklearn');
-            assert.strictEqual(explicitConfig.modelServer, 'flask');
+            assert.strictEqual(explicitConfig.deploymentConfig, 'http-flask');
+            assert.strictEqual(explicitConfig.engine, 'sklearn');
             // Defaults should not be in explicit config
             assert.strictEqual(explicitConfig.awsRegion, undefined);
         });
@@ -620,14 +676,14 @@ describe('ConfigManager Unit Tests', () => {
         });
 
         describe('_generateProjectName()', () => {
-            it('should generate project name for sklearn', () => {
-                const projectName = configManager._generateProjectName('sklearn');
+            it('should generate project name for http architecture', () => {
+                const projectName = configManager._generateProjectName('http');
                 
                 assert.ok(typeof projectName === 'string');
                 assert.ok(/^[a-z]+-[a-z]+-[a-z]+$/.test(projectName));
             });
 
-            it('should generate project name for transformers', () => {
+            it('should generate project name for transformers architecture', () => {
                 const projectName = configManager._generateProjectName('transformers');
                 
                 assert.ok(typeof projectName === 'string');
@@ -637,16 +693,16 @@ describe('ConfigManager Unit Tests', () => {
 
         describe('_generateCodeBuildProjectName()', () => {
             it('should generate valid CodeBuild project name', () => {
-                const buildName = configManager._generateCodeBuildProjectName('my-project', 'sklearn');
+                const buildName = configManager._generateCodeBuildProjectName('my-project', 'http');
                 
                 assert.ok(typeof buildName === 'string');
                 assert.ok(buildName.includes('my-project'));
-                assert.ok(buildName.includes('sklearn'));
+                assert.ok(buildName.includes('http'));
                 assert.ok(/^[a-z0-9][a-z0-9\-_]+$/.test(buildName));
             });
 
             it('should sanitize invalid characters', () => {
-                const buildName = configManager._generateCodeBuildProjectName('my@project!', 'sklearn');
+                const buildName = configManager._generateCodeBuildProjectName('my@project!', 'http');
                 
                 assert.ok(!buildName.includes('@'));
                 assert.ok(!buildName.includes('!'));
@@ -700,14 +756,312 @@ describe('ConfigManager Unit Tests', () => {
 
         describe('_canAutoGenerate()', () => {
             it('should return true for auto-generatable parameters', () => {
-                assert.strictEqual(configManager._canAutoGenerate('framework'), true);
-                assert.strictEqual(configManager._canAutoGenerate('modelServer'), true);
+                assert.strictEqual(configManager._canAutoGenerate('modelFormat'), true);
+                assert.strictEqual(configManager._canAutoGenerate('includeSampleModel'), true);
                 assert.strictEqual(configManager._canAutoGenerate('instanceType'), true);
             });
 
             it('should return false for non-auto-generatable parameters', () => {
                 assert.strictEqual(configManager._canAutoGenerate('projectName'), false);
                 assert.strictEqual(configManager._canAutoGenerate('awsRoleArn'), false);
+            });
+        });
+    });
+
+    /**
+     * DeploymentConfigResolver Integration Tests
+     *
+     * Validates that ConfigManager correctly uses DeploymentConfigResolver
+     * to populate architecture/backend/engine and rejects old-format configs.
+     *
+     * Validates: Requirements 6.1, 6.2, 6.3, 6.4
+     */
+    describe('DeploymentConfigResolver Integration', () => {
+        let configManager;
+        let mockGenerator;
+
+        beforeEach(() => {
+            mockGenerator = createMockGenerator();
+            configManager = new ConfigManager(mockGenerator);
+        });
+
+        describe('getFinalConfiguration() populates architecture, backend, engine (Req 6.1)', () => {
+            it('should derive architecture, backend, engine for http-flask', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'http-flask',
+                    engine: 'sklearn'
+                });
+
+                assert.strictEqual(finalConfig.architecture, 'http');
+                assert.strictEqual(finalConfig.backend, 'flask');
+                assert.strictEqual(finalConfig.engine, 'sklearn');
+            });
+
+            it('should derive architecture, backend, engine for http-fastapi', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'http-fastapi',
+                    engine: 'xgboost'
+                });
+
+                assert.strictEqual(finalConfig.architecture, 'http');
+                assert.strictEqual(finalConfig.backend, 'fastapi');
+                assert.strictEqual(finalConfig.engine, 'xgboost');
+            });
+
+            it('should derive architecture, backend, engine for transformers-vllm', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'transformers-vllm'
+                });
+
+                assert.strictEqual(finalConfig.architecture, 'transformers');
+                assert.strictEqual(finalConfig.backend, 'vllm');
+                assert.strictEqual(finalConfig.engine, null);
+            });
+
+            it('should derive architecture, backend, engine for triton-fil', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'triton-fil'
+                });
+
+                assert.strictEqual(finalConfig.architecture, 'triton');
+                assert.strictEqual(finalConfig.backend, 'fil');
+                assert.strictEqual(finalConfig.engine, null);
+            });
+
+            it('should derive architecture, backend, engine for triton-vllm', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'triton-vllm'
+                });
+
+                assert.strictEqual(finalConfig.architecture, 'triton');
+                assert.strictEqual(finalConfig.backend, 'vllm');
+                assert.strictEqual(finalConfig.engine, null);
+            });
+
+            it('should derive architecture, backend, engine for triton-tensorrtllm', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'triton-tensorrtllm'
+                });
+
+                assert.strictEqual(finalConfig.architecture, 'triton');
+                assert.strictEqual(finalConfig.backend, 'tensorrtllm');
+                assert.strictEqual(finalConfig.engine, null);
+            });
+
+            it('should derive architecture, backend, engine for triton-python', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'triton-python'
+                });
+
+                assert.strictEqual(finalConfig.architecture, 'triton');
+                assert.strictEqual(finalConfig.backend, 'python');
+                assert.strictEqual(finalConfig.engine, null);
+            });
+        });
+
+        describe('framework and modelServer are no longer populated (Req 6.2)', () => {
+            it('should not populate framework for http-flask config', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'http-flask',
+                    engine: 'sklearn'
+                });
+
+                assert.strictEqual(finalConfig.framework, undefined);
+                assert.strictEqual(finalConfig.modelServer, undefined);
+            });
+
+            it('should not populate framework for transformers-vllm config', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'transformers-vllm'
+                });
+
+                assert.strictEqual(finalConfig.framework, undefined);
+                assert.strictEqual(finalConfig.modelServer, undefined);
+            });
+
+            it('should not populate framework for triton-fil config', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'triton-fil'
+                });
+
+                assert.strictEqual(finalConfig.framework, undefined);
+                assert.strictEqual(finalConfig.modelServer, undefined);
+            });
+        });
+
+        describe('parameter matrix includes architecture, backend, engine (Req 6.3)', () => {
+            it('should include architecture in parameter matrix', () => {
+                const matrix = configManager.parameterMatrix;
+                assert.ok(matrix.architecture, 'architecture should be in parameter matrix');
+                assert.strictEqual(matrix.architecture.valueSpace, 'bounded');
+            });
+
+            it('should include backend in parameter matrix', () => {
+                const matrix = configManager.parameterMatrix;
+                assert.ok(matrix.backend, 'backend should be in parameter matrix');
+                assert.strictEqual(matrix.backend.valueSpace, 'bounded');
+            });
+
+            it('should include engine in parameter matrix', () => {
+                const matrix = configManager.parameterMatrix;
+                assert.ok(matrix.engine, 'engine should be in parameter matrix');
+                assert.strictEqual(matrix.engine.cliOption, 'engine');
+            });
+
+            it('should not include framework in parameter matrix', () => {
+                const matrix = configManager.parameterMatrix;
+                assert.strictEqual(matrix.framework, undefined);
+            });
+
+            it('should not include modelServer in parameter matrix', () => {
+                const matrix = configManager.parameterMatrix;
+                assert.strictEqual(matrix.modelServer, undefined);
+            });
+        });
+
+        describe('old-format values rejected with migration messages (Req 6.4)', () => {
+            it('should reject sklearn-flask with migration message', async () => {
+                await configManager.loadConfiguration();
+                configManager.config.deploymentConfig = 'sklearn-flask';
+
+                const errors = configManager.validateConfiguration();
+
+                assert.strictEqual(errors.length, 1);
+                assert.ok(errors[0].includes('sklearn-flask'));
+                assert.ok(errors[0].includes('Use --deployment-config=http-flask --engine=sklearn instead'));
+            });
+
+            it('should reject sklearn-fastapi with migration message', async () => {
+                await configManager.loadConfiguration();
+                configManager.config.deploymentConfig = 'sklearn-fastapi';
+
+                const errors = configManager.validateConfiguration();
+
+                assert.strictEqual(errors.length, 1);
+                assert.ok(errors[0].includes('Use --deployment-config=http-fastapi --engine=sklearn instead'));
+            });
+
+            it('should reject xgboost-flask with migration message', async () => {
+                await configManager.loadConfiguration();
+                configManager.config.deploymentConfig = 'xgboost-flask';
+
+                const errors = configManager.validateConfiguration();
+
+                assert.strictEqual(errors.length, 1);
+                assert.ok(errors[0].includes('Use --deployment-config=http-flask --engine=xgboost instead'));
+            });
+
+            it('should reject xgboost-fastapi with migration message', async () => {
+                await configManager.loadConfiguration();
+                configManager.config.deploymentConfig = 'xgboost-fastapi';
+
+                const errors = configManager.validateConfiguration();
+
+                assert.strictEqual(errors.length, 1);
+                assert.ok(errors[0].includes('Use --deployment-config=http-fastapi --engine=xgboost instead'));
+            });
+
+            it('should reject tensorflow-flask with migration message', async () => {
+                await configManager.loadConfiguration();
+                configManager.config.deploymentConfig = 'tensorflow-flask';
+
+                const errors = configManager.validateConfiguration();
+
+                assert.strictEqual(errors.length, 1);
+                assert.ok(errors[0].includes('Use --deployment-config=http-flask --engine=tensorflow instead'));
+            });
+
+            it('should reject tensorflow-fastapi with migration message', async () => {
+                await configManager.loadConfiguration();
+                configManager.config.deploymentConfig = 'tensorflow-fastapi';
+
+                const errors = configManager.validateConfiguration();
+
+                assert.strictEqual(errors.length, 1);
+                assert.ok(errors[0].includes('Use --deployment-config=http-fastapi --engine=tensorflow instead'));
+            });
+        });
+
+        describe('--engine flag parsing for http architecture (Req 6.1, 6.3)', () => {
+            it('should use engine from CLI option for http-flask', async () => {
+                mockGenerator = createMockGeneratorWithOptions({
+                    'deployment-config': 'http-flask',
+                    engine: 'sklearn'
+                });
+                configManager = new ConfigManager(mockGenerator);
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({});
+
+                assert.strictEqual(finalConfig.architecture, 'http');
+                assert.strictEqual(finalConfig.backend, 'flask');
+                assert.strictEqual(finalConfig.engine, 'sklearn');
+            });
+
+            it('should use engine from prompt answers when not in CLI', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'http-flask',
+                    engine: 'tensorflow'
+                });
+
+                assert.strictEqual(finalConfig.engine, 'tensorflow');
+            });
+
+            it('should prefer CLI engine over prompt engine', async () => {
+                mockGenerator = createMockGeneratorWithOptions({
+                    engine: 'sklearn'
+                });
+                configManager = new ConfigManager(mockGenerator);
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'http-flask',
+                    engine: 'xgboost'
+                });
+
+                assert.strictEqual(finalConfig.engine, 'sklearn');
+            });
+
+            it('should not set engine for triton configs even if provided', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'triton-fil'
+                });
+
+                assert.strictEqual(finalConfig.engine, null);
+            });
+
+            it('should not set engine for transformers configs', async () => {
+                await configManager.loadConfiguration();
+
+                const finalConfig = configManager.getFinalConfiguration({
+                    deploymentConfig: 'transformers-vllm'
+                });
+
+                assert.strictEqual(finalConfig.engine, null);
             });
         });
     });

--- a/test/unit/deployment-config-resolver.test.js
+++ b/test/unit/deployment-config-resolver.test.js
@@ -1,0 +1,123 @@
+import { strict as assert } from 'node:assert';
+import DeploymentConfigResolver from '../../generators/app/lib/deployment-config-resolver.js';
+
+describe('DeploymentConfigResolver', () => {
+    let resolver;
+
+    beforeEach(() => {
+        resolver = new DeploymentConfigResolver();
+    });
+
+    describe('getAllConfigs()', () => {
+        it('should return exactly 14 valid deployment-config strings', () => {
+            const configs = resolver.getAllConfigs();
+            assert.equal(configs.length, 14);
+        });
+
+        it('should include 2 http, 5 transformers, and 7 triton configs', () => {
+            const configs = resolver.getAllConfigs();
+            const http = configs.filter(c => c.startsWith('http-'));
+            const transformers = configs.filter(c => c.startsWith('transformers-'));
+            const triton = configs.filter(c => c.startsWith('triton-'));
+            assert.equal(http.length, 2);
+            assert.equal(transformers.length, 5);
+            assert.equal(triton.length, 7);
+        });
+    });
+
+    describe('decompose()', () => {
+        it('should decompose http-flask correctly', () => {
+            const result = resolver.decompose('http-flask');
+            assert.deepEqual(result, { architecture: 'http', backend: 'flask', engine: null });
+        });
+
+        it('should decompose triton-fil correctly', () => {
+            const result = resolver.decompose('triton-fil');
+            assert.deepEqual(result, { architecture: 'triton', backend: 'fil', engine: null });
+        });
+
+        it('should decompose transformers-tensorrt-llm correctly', () => {
+            const result = resolver.decompose('transformers-tensorrt-llm');
+            assert.deepEqual(result, { architecture: 'transformers', backend: 'tensorrt-llm', engine: null });
+        });
+
+        it('should throw for invalid deployment-config', () => {
+            assert.throws(
+                () => resolver.decompose('sklearn-flask'),
+                /Unsupported deployment-config: sklearn-flask/
+            );
+        });
+
+        it('should return a copy, not a reference to internal data', () => {
+            const a = resolver.decompose('http-flask');
+            const b = resolver.decompose('http-flask');
+            assert.notEqual(a, b);
+            assert.deepEqual(a, b);
+        });
+    });
+
+    describe('compose()', () => {
+        it('should compose from architecture and backend', () => {
+            assert.equal(
+                resolver.compose({ architecture: 'triton', backend: 'fil' }),
+                'triton-fil'
+            );
+        });
+
+        it('should compose transformers-tensorrt-llm', () => {
+            assert.equal(
+                resolver.compose({ architecture: 'transformers', backend: 'tensorrt-llm' }),
+                'transformers-tensorrt-llm'
+            );
+        });
+    });
+
+    describe('isValid()', () => {
+        it('should return true for all 14 canonical configs', () => {
+            for (const dc of resolver.getAllConfigs()) {
+                assert.equal(resolver.isValid(dc), true, `Expected ${dc} to be valid`);
+            }
+        });
+
+        it('should return false for old-format strings', () => {
+            const oldFormats = [
+                'sklearn-flask', 'sklearn-fastapi',
+                'xgboost-flask', 'xgboost-fastapi',
+                'tensorflow-flask', 'tensorflow-fastapi'
+            ];
+            for (const dc of oldFormats) {
+                assert.equal(resolver.isValid(dc), false, `Expected ${dc} to be invalid`);
+            }
+        });
+
+        it('should return false for arbitrary strings', () => {
+            assert.equal(resolver.isValid(''), false);
+            assert.equal(resolver.isValid('triton-openvino'), false);
+            assert.equal(resolver.isValid('foo'), false);
+        });
+    });
+
+    describe('getConfigsForArchitecture()', () => {
+        it('should return 2 configs for http', () => {
+            const configs = resolver.getConfigsForArchitecture('http');
+            assert.equal(configs.length, 2);
+            assert.ok(configs.includes('http-flask'));
+            assert.ok(configs.includes('http-fastapi'));
+        });
+
+        it('should return 5 configs for transformers', () => {
+            const configs = resolver.getConfigsForArchitecture('transformers');
+            assert.equal(configs.length, 5);
+        });
+
+        it('should return 7 configs for triton', () => {
+            const configs = resolver.getConfigsForArchitecture('triton');
+            assert.equal(configs.length, 7);
+        });
+
+        it('should return empty array for unknown architecture', () => {
+            const configs = resolver.getConfigsForArchitecture('unknown');
+            assert.equal(configs.length, 0);
+        });
+    });
+});

--- a/test/unit/namespace-metadata.unit.test.js
+++ b/test/unit/namespace-metadata.unit.test.js
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Namespace Metadata Unit Tests
+ *
+ * Verifies concrete acceptance criteria for the npm namespace rename:
+ * - Root package.json name and private field
+ * - CI workflow generator invocation and validation step
+ */
+
+import { describe, it } from 'mocha';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+describe('Namespace Metadata', () => {
+    describe('Root package.json', () => {
+        const rootPkg = JSON.parse(
+            readFileSync(resolve(REPO_ROOT, 'package.json'), 'utf-8')
+        );
+
+        it('has name @aws/generator-ml-container-creator (Req 1.1)', () => {
+            assert.strictEqual(rootPkg.name, '@aws/generator-ml-container-creator');
+        });
+
+        it('does not have "private": true (Req 1.2)', () => {
+            assert.notStrictEqual(rootPkg.private, true,
+                'Root package.json must not have "private": true');
+        });
+    });
+
+    describe('CI workflow (.github/workflows/ci.yml)', () => {
+        const ciYaml = readFileSync(
+            resolve(REPO_ROOT, '.github', 'workflows', 'ci.yml'), 'utf-8'
+        );
+
+        it('contains yo @aws/ml-container-creator invocation (Req 7.1, 7.2)', () => {
+            assert.ok(
+                ciYaml.includes('yo @aws/ml-container-creator'),
+                'CI workflow must reference yo @aws/ml-container-creator'
+            );
+        });
+
+        it('contains node scripts/validate-namespaces.js step (Req 8.7, 9.5)', () => {
+            assert.ok(
+                ciYaml.includes('node scripts/validate-namespaces.js'),
+                'CI workflow must include the namespace validation step'
+            );
+        });
+    });
+});

--- a/test/unit/triton-base-image-fallback.test.js
+++ b/test/unit/triton-base-image-fallback.test.js
@@ -1,0 +1,272 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for Triton base image fallback in _ensureTemplateVariables()
+ *
+ * Tests:
+ * - Triton architecture gets default base image when MCP returns nothing
+ * - --base-image CLI flag overrides the default
+ * - Framework registry lookup enriches Triton config with envVars, accelerator, etc.
+ * - Non-Triton architectures are not affected
+ *
+ * Validates: Requirements 10.1, 10.2
+ */
+
+import { describe, it } from 'mocha';
+import assert from 'assert';
+
+/**
+ * Creates a minimal mock generator that exposes _ensureTemplateVariables
+ * by simulating the relevant parts of the Generator class from index.js
+ */
+function createMockGeneratorInstance(answers = {}, registryConfigManager = null) {
+    return {
+        answers: { ...answers },
+        registryConfigManager,
+        async _ensureTemplateVariables() {
+            // Replicate the defaults logic from index.js
+            const defaults = {
+                chatTemplate: null,
+                chatTemplateSource: null,
+                hfToken: null,
+                ngcApiKey: null,
+                envVars: {},
+                inferenceAmiVersion: null,
+                accelerator: null,
+                frameworkVersion: null,
+                validationLevel: 'unknown',
+                configSources: [],
+                recommendedInstanceTypes: [],
+                roleArn: null,
+                deploymentConfig: '',
+                architecture: null,
+                backend: null,
+                engine: null,
+                codebuildComputeType: null,
+                codebuildProjectName: null,
+                modelName: null,
+                modelFormat: null,
+                includeSampleModel: false,
+                includeTesting: true,
+                testTypes: [],
+                buildTimestamp: new Date().toISOString(),
+                buildTarget: 'codebuild',
+                deploymentTarget: 'managed-inference',
+                hyperPodCluster: null,
+                hyperPodNamespace: 'default',
+                hyperPodReplicas: 1,
+                fsxVolumeHandle: null,
+                baseImage: null
+            };
+
+            Object.entries(defaults).forEach(([key, value]) => {
+                if (this.answers[key] === undefined) {
+                    this.answers[key] = value;
+                }
+            });
+
+            this.answers.includeTesting = true;
+            if (!this.answers.testTypes || this.answers.testTypes.length === 0) {
+                if (this.answers.architecture === 'transformers' || this.answers.framework === 'transformers') {
+                    this.answers.testTypes = ['hosted-model-endpoint'];
+                } else {
+                    this.answers.testTypes = ['local-model-cli', 'local-model-server', 'hosted-model-endpoint'];
+                }
+            }
+
+            // Triton base image fallback logic (mirrors index.js)
+            if (this.answers.architecture === 'triton' && !this.answers.baseImage) {
+                const tritonRegistryKey = this.answers.deploymentConfig;
+                if (tritonRegistryKey && this.registryConfigManager?.frameworkRegistry) {
+                    const tritonFrameworkConfig = this.registryConfigManager.frameworkRegistry[tritonRegistryKey];
+                    if (tritonFrameworkConfig) {
+                        const versions = Object.keys(tritonFrameworkConfig).sort((a, b) =>
+                            b.localeCompare(a, undefined, { numeric: true })
+                        );
+                        if (versions.length > 0) {
+                            const latestConfig = tritonFrameworkConfig[versions[0]];
+                            if (latestConfig.baseImage) {
+                                this.answers.baseImage = latestConfig.baseImage;
+                            }
+                            if (latestConfig.envVars) {
+                                this.answers.envVars = { ...latestConfig.envVars, ...this.answers.envVars };
+                            }
+                            if (latestConfig.inferenceAmiVersion && !this.answers.inferenceAmiVersion) {
+                                this.answers.inferenceAmiVersion = latestConfig.inferenceAmiVersion;
+                            }
+                            if (latestConfig.accelerator) {
+                                this.answers.accelerator = latestConfig.accelerator;
+                            }
+                        }
+                    }
+                }
+                if (!this.answers.baseImage) {
+                    this.answers.baseImage = 'nvcr.io/nvidia/tritonserver:24.08-py3';
+                }
+            }
+        }
+    };
+}
+
+describe('Triton base image fallback (_ensureTemplateVariables)', () => {
+
+    describe('Requirement 10.1: Default fallback when MCP returns no results', () => {
+        it('should set default Triton base image when architecture is triton and no baseImage provided', async () => {
+            const gen = createMockGeneratorInstance({
+                architecture: 'triton',
+                backend: 'fil',
+                deploymentConfig: 'triton-fil'
+            });
+
+            await gen._ensureTemplateVariables();
+
+            assert.strictEqual(gen.answers.baseImage, 'nvcr.io/nvidia/tritonserver:24.08-py3');
+        });
+
+        it('should set default Triton base image for all Triton backends without registry', async () => {
+            const tritonConfigs = [
+                'triton-fil', 'triton-onnxruntime', 'triton-tensorflow',
+                'triton-pytorch', 'triton-vllm', 'triton-tensorrtllm', 'triton-python'
+            ];
+
+            for (const dc of tritonConfigs) {
+                const backend = dc.replace('triton-', '');
+                const gen = createMockGeneratorInstance({
+                    architecture: 'triton',
+                    backend,
+                    deploymentConfig: dc
+                });
+
+                await gen._ensureTemplateVariables();
+
+                assert.strictEqual(gen.answers.baseImage, 'nvcr.io/nvidia/tritonserver:24.08-py3',
+                    `Expected default base image for ${dc}`);
+            }
+        });
+    });
+
+    describe('Requirement 10.2: --base-image CLI flag override', () => {
+        it('should honor user-provided base image and not overwrite it', async () => {
+            const customImage = 'nvcr.io/nvidia/tritonserver:23.12-py3';
+            const gen = createMockGeneratorInstance({
+                architecture: 'triton',
+                backend: 'fil',
+                deploymentConfig: 'triton-fil',
+                baseImage: customImage
+            });
+
+            await gen._ensureTemplateVariables();
+
+            assert.strictEqual(gen.answers.baseImage, customImage,
+                'User-provided base image should not be overwritten');
+        });
+
+        it('should honor --base-image even when registry has a different image', async () => {
+            const customImage = 'my-custom-triton:latest';
+            const registry = {
+                'triton-fil': {
+                    '24.08': {
+                        baseImage: 'nvcr.io/nvidia/tritonserver:24.08-py3',
+                        envVars: { TRITON_MODEL_REPOSITORY: '/opt/ml/model/model_repository' }
+                    }
+                }
+            };
+            const gen = createMockGeneratorInstance(
+                {
+                    architecture: 'triton',
+                    backend: 'fil',
+                    deploymentConfig: 'triton-fil',
+                    baseImage: customImage
+                },
+                { frameworkRegistry: registry }
+            );
+
+            await gen._ensureTemplateVariables();
+
+            assert.strictEqual(gen.answers.baseImage, customImage,
+                'CLI override should take precedence over registry');
+        });
+    });
+
+    describe('Framework registry enrichment for Triton configs', () => {
+        it('should use base image from framework registry when available', async () => {
+            const registry = {
+                'triton-vllm': {
+                    '24.08': {
+                        baseImage: 'nvcr.io/nvidia/tritonserver:24.08-py3',
+                        accelerator: { type: 'cuda', version: '12.5' },
+                        envVars: { TRITON_MODEL_REPOSITORY: '/opt/ml/model/model_repository' },
+                        inferenceAmiVersion: 'al2-ami-sagemaker-inference-gpu-3-2'
+                    }
+                }
+            };
+            const gen = createMockGeneratorInstance(
+                {
+                    architecture: 'triton',
+                    backend: 'vllm',
+                    deploymentConfig: 'triton-vllm'
+                },
+                { frameworkRegistry: registry }
+            );
+
+            await gen._ensureTemplateVariables();
+
+            assert.strictEqual(gen.answers.baseImage, 'nvcr.io/nvidia/tritonserver:24.08-py3');
+            assert.deepStrictEqual(gen.answers.accelerator, { type: 'cuda', version: '12.5' });
+            assert.strictEqual(gen.answers.inferenceAmiVersion, 'al2-ami-sagemaker-inference-gpu-3-2');
+            assert.strictEqual(gen.answers.envVars.TRITON_MODEL_REPOSITORY, '/opt/ml/model/model_repository');
+        });
+
+        it('should fall back to hardcoded default when registry has no matching entry', async () => {
+            const registry = {
+                'triton-fil': {
+                    '24.08': {
+                        baseImage: 'nvcr.io/nvidia/tritonserver:24.08-py3'
+                    }
+                }
+            };
+            const gen = createMockGeneratorInstance(
+                {
+                    architecture: 'triton',
+                    backend: 'pytorch',
+                    deploymentConfig: 'triton-pytorch'
+                },
+                { frameworkRegistry: registry }
+            );
+
+            await gen._ensureTemplateVariables();
+
+            assert.strictEqual(gen.answers.baseImage, 'nvcr.io/nvidia/tritonserver:24.08-py3',
+                'Should fall back to hardcoded default when registry has no entry for this backend');
+        });
+    });
+
+    describe('Non-Triton architectures are unaffected', () => {
+        it('should not set Triton base image for http architecture', async () => {
+            const gen = createMockGeneratorInstance({
+                architecture: 'http',
+                backend: 'flask',
+                deploymentConfig: 'http-flask'
+            });
+
+            await gen._ensureTemplateVariables();
+
+            assert.strictEqual(gen.answers.baseImage, null,
+                'HTTP architecture should not get Triton base image');
+        });
+
+        it('should not set Triton base image for transformers architecture', async () => {
+            const gen = createMockGeneratorInstance({
+                architecture: 'transformers',
+                backend: 'vllm',
+                deploymentConfig: 'transformers-vllm'
+            });
+
+            await gen._ensureTemplateVariables();
+
+            assert.strictEqual(gen.answers.baseImage, null,
+                'Transformers architecture should not get Triton base image');
+        });
+    });
+});

--- a/test/unit/triton-prompt-flow.test.js
+++ b/test/unit/triton-prompt-flow.test.js
@@ -1,0 +1,378 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for Triton prompt flow
+ *
+ * Tests:
+ * - Triton deployment-configs appear in prompt choices
+ * - Backend-specific model format auto-setting
+ * - HF token prompt only for triton-vllm and triton-tensorrtllm
+ * - No NGC key prompt for any Triton config
+ *
+ * Feature: triton-integration
+ * Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 9.1, 9.2
+ */
+
+import { strict as assert } from 'node:assert';
+import {
+    deploymentConfigPrompts,
+    enginePrompts,
+    modelFormatPrompts,
+    hfTokenPrompts,
+    ngcApiKeyPrompts
+} from '../../generators/app/lib/prompts.js';
+import PromptRunner from '../../generators/app/lib/prompt-runner.js';
+
+describe('Triton Prompt Flow', () => {
+
+    describe('deploymentConfigPrompts - Triton choices (Requirement 3.1)', () => {
+        const deploymentConfigPrompt = deploymentConfigPrompts[0];
+
+        it('should have a deployment-config list prompt', () => {
+            assert.equal(deploymentConfigPrompt.type, 'list');
+            assert.equal(deploymentConfigPrompt.name, 'deploymentConfig');
+        });
+
+        it('should include NVIDIA Triton Inference Server separator', () => {
+            const separators = deploymentConfigPrompt.choices.filter(c => c.type === 'separator');
+            const tritonSeparator = separators.find(s => s.separator.includes('NVIDIA Triton'));
+            assert.ok(tritonSeparator, 'Should have NVIDIA Triton Inference Server separator');
+        });
+
+        it('should include all 7 Triton deployment-config choices', () => {
+            const tritonConfigs = [
+                'triton-fil',
+                'triton-onnxruntime',
+                'triton-tensorflow',
+                'triton-pytorch',
+                'triton-vllm',
+                'triton-tensorrtllm',
+                'triton-python'
+            ];
+
+            const choices = deploymentConfigPrompt.choices.filter(c => !c.type);
+            const values = choices.map(c => c.value);
+
+            for (const config of tritonConfigs) {
+                assert.ok(values.includes(config), `Should include ${config}`);
+            }
+        });
+
+        it('should include http-flask and http-fastapi (not old format)', () => {
+            const choices = deploymentConfigPrompt.choices.filter(c => !c.type);
+            const values = choices.map(c => c.value);
+
+            assert.ok(values.includes('http-flask'), 'Should include http-flask');
+            assert.ok(values.includes('http-fastapi'), 'Should include http-fastapi');
+
+            // Old format should NOT be present
+            assert.ok(!values.includes('sklearn-flask'), 'Should NOT include sklearn-flask');
+            assert.ok(!values.includes('xgboost-flask'), 'Should NOT include xgboost-flask');
+        });
+    });
+
+    describe('enginePrompts - http architecture only (Requirement 3.7)', () => {
+        const enginePrompt = enginePrompts[0];
+
+        it('should show engine prompt for http architecture', () => {
+            const answers = { architecture: 'http' };
+            assert.equal(enginePrompt.when(answers), true);
+        });
+
+        it('should show engine prompt when deploymentConfig starts with http', () => {
+            const answers = { deploymentConfig: 'http-flask' };
+            assert.equal(enginePrompt.when(answers), true);
+        });
+
+        it('should NOT show engine prompt for triton architecture', () => {
+            const answers = { architecture: 'triton' };
+            assert.equal(enginePrompt.when(answers), false);
+        });
+
+        it('should NOT show engine prompt for transformers architecture', () => {
+            const answers = { architecture: 'transformers' };
+            assert.equal(enginePrompt.when(answers), false);
+        });
+    });
+
+    describe('_getTritonAutoModelFormat - Backend-specific auto-setting (Requirements 3.3, 3.4, 3.5)', () => {
+        let runner;
+
+        beforeEach(() => {
+            // Create a minimal mock generator
+            const mockGenerator = {
+                configManager: null,
+                registryConfigManager: null,
+                options: {},
+                baseConfig: {},
+                prompt: async () => ({})
+            };
+            runner = new PromptRunner(mockGenerator);
+        });
+
+        it('should auto-set onnx for triton-onnxruntime', () => {
+            const result = runner._getTritonAutoModelFormat('triton', 'onnxruntime');
+            assert.equal(result, 'onnx');
+        });
+
+        it('should auto-set savedmodel for triton-tensorflow', () => {
+            const result = runner._getTritonAutoModelFormat('triton', 'tensorflow');
+            assert.equal(result, 'savedmodel');
+        });
+
+        it('should auto-set torchscript for triton-pytorch', () => {
+            const result = runner._getTritonAutoModelFormat('triton', 'pytorch');
+            assert.equal(result, 'torchscript');
+        });
+
+        it('should NOT auto-set for triton-fil (multiple formats)', () => {
+            const result = runner._getTritonAutoModelFormat('triton', 'fil');
+            assert.equal(result, null);
+        });
+
+        it('should NOT auto-set for triton-python (multiple formats)', () => {
+            const result = runner._getTritonAutoModelFormat('triton', 'python');
+            assert.equal(result, null);
+        });
+
+        it('should NOT auto-set for triton-vllm (uses HF Hub)', () => {
+            const result = runner._getTritonAutoModelFormat('triton', 'vllm');
+            assert.equal(result, null);
+        });
+
+        it('should NOT auto-set for triton-tensorrtllm (uses HF Hub)', () => {
+            const result = runner._getTritonAutoModelFormat('triton', 'tensorrtllm');
+            assert.equal(result, null);
+        });
+
+        it('should return null for non-triton architecture', () => {
+            const result = runner._getTritonAutoModelFormat('http', 'flask');
+            assert.equal(result, null);
+        });
+
+        it('should return null for transformers architecture', () => {
+            const result = runner._getTritonAutoModelFormat('transformers', 'vllm');
+            assert.equal(result, null);
+        });
+    });
+
+    describe('modelFormatPrompts - Triton backend-specific choices (Requirements 3.2, 3.6, 3.7)', () => {
+        const modelFormatPrompt = modelFormatPrompts[0];
+
+        describe('when function', () => {
+            it('should show for triton-fil (multiple format choices)', () => {
+                const answers = { architecture: 'triton', backend: 'fil' };
+                assert.equal(modelFormatPrompt.when(answers), true);
+            });
+
+            it('should show for triton-python (multiple format choices)', () => {
+                const answers = { architecture: 'triton', backend: 'python' };
+                assert.equal(modelFormatPrompt.when(answers), true);
+            });
+
+            it('should NOT show for triton-onnxruntime (auto-set)', () => {
+                const answers = { architecture: 'triton', backend: 'onnxruntime' };
+                assert.equal(modelFormatPrompt.when(answers), false);
+            });
+
+            it('should NOT show for triton-tensorflow (auto-set)', () => {
+                const answers = { architecture: 'triton', backend: 'tensorflow' };
+                assert.equal(modelFormatPrompt.when(answers), false);
+            });
+
+            it('should NOT show for triton-pytorch (auto-set)', () => {
+                const answers = { architecture: 'triton', backend: 'pytorch' };
+                assert.equal(modelFormatPrompt.when(answers), false);
+            });
+
+            it('should NOT show for triton-vllm (uses HF Hub)', () => {
+                const answers = { architecture: 'triton', backend: 'vllm' };
+                assert.equal(modelFormatPrompt.when(answers), false);
+            });
+
+            it('should NOT show for triton-tensorrtllm (uses HF Hub)', () => {
+                const answers = { architecture: 'triton', backend: 'tensorrtllm' };
+                assert.equal(modelFormatPrompt.when(answers), false);
+            });
+
+            it('should show for http architecture', () => {
+                const answers = { architecture: 'http', backend: 'flask' };
+                assert.equal(modelFormatPrompt.when(answers), true);
+            });
+
+            it('should NOT show for transformers architecture', () => {
+                const answers = { architecture: 'transformers', backend: 'vllm' };
+                assert.equal(modelFormatPrompt.when(answers), false);
+            });
+
+            it('should derive architecture from deploymentConfig if not set', () => {
+                const answers = { deploymentConfig: 'triton-fil' };
+                assert.equal(modelFormatPrompt.when(answers), true);
+            });
+        });
+
+        describe('choices function', () => {
+            it('should return FIL format choices for triton-fil', () => {
+                const answers = { architecture: 'triton', backend: 'fil' };
+                const choices = modelFormatPrompt.choices(answers);
+                assert.deepEqual(choices, ['xgboost_json', 'xgboost_ubj', 'lightgbm_txt']);
+            });
+
+            it('should return Python format choices for triton-python', () => {
+                const answers = { architecture: 'triton', backend: 'python' };
+                const choices = modelFormatPrompt.choices(answers);
+                assert.deepEqual(choices, ['pkl', 'joblib', 'custom']);
+            });
+
+            it('should return empty array for triton-onnxruntime (auto-set)', () => {
+                const answers = { architecture: 'triton', backend: 'onnxruntime' };
+                const choices = modelFormatPrompt.choices(answers);
+                assert.deepEqual(choices, []);
+            });
+
+            it('should return http engine-based choices for http architecture', () => {
+                const answers = { architecture: 'http', engine: 'sklearn' };
+                const choices = modelFormatPrompt.choices(answers);
+                assert.deepEqual(choices, ['pkl', 'joblib']);
+            });
+        });
+    });
+
+    describe('hfTokenPrompts - Triton LLM backends only (Requirements 9.1, 9.2)', () => {
+        const hfTokenPrompt = hfTokenPrompts[0];
+
+        it('should show for triton-vllm', () => {
+            const answers = { architecture: 'triton', backend: 'vllm' };
+            assert.equal(hfTokenPrompt.when(answers), true);
+        });
+
+        it('should show for triton-tensorrtllm', () => {
+            const answers = { architecture: 'triton', backend: 'tensorrtllm' };
+            assert.equal(hfTokenPrompt.when(answers), true);
+        });
+
+        it('should NOT show for triton-fil', () => {
+            const answers = { architecture: 'triton', backend: 'fil' };
+            assert.equal(hfTokenPrompt.when(answers), false);
+        });
+
+        it('should NOT show for triton-onnxruntime', () => {
+            const answers = { architecture: 'triton', backend: 'onnxruntime' };
+            assert.equal(hfTokenPrompt.when(answers), false);
+        });
+
+        it('should NOT show for triton-tensorflow', () => {
+            const answers = { architecture: 'triton', backend: 'tensorflow' };
+            assert.equal(hfTokenPrompt.when(answers), false);
+        });
+
+        it('should NOT show for triton-pytorch', () => {
+            const answers = { architecture: 'triton', backend: 'pytorch' };
+            assert.equal(hfTokenPrompt.when(answers), false);
+        });
+
+        it('should NOT show for triton-python', () => {
+            const answers = { architecture: 'triton', backend: 'python' };
+            assert.equal(hfTokenPrompt.when(answers), false);
+        });
+
+        it('should show for transformers architecture', () => {
+            const answers = { architecture: 'transformers', backend: 'vllm' };
+            assert.equal(hfTokenPrompt.when(answers), true);
+        });
+
+        it('should derive architecture/backend from deploymentConfig', () => {
+            const answers = { deploymentConfig: 'triton-vllm' };
+            assert.equal(hfTokenPrompt.when(answers), true);
+        });
+
+        it('should NOT show for deploymentConfig triton-fil', () => {
+            const answers = { deploymentConfig: 'triton-fil' };
+            assert.equal(hfTokenPrompt.when(answers), false);
+        });
+    });
+
+    describe('ngcApiKeyPrompts - Never for Triton (Requirement 9.2)', () => {
+        const ngcApiKeyPrompt = ngcApiKeyPrompts[0];
+
+        it('should NOT show for triton-vllm', () => {
+            const answers = { architecture: 'triton', backend: 'vllm' };
+            assert.equal(ngcApiKeyPrompt.when(answers), false);
+        });
+
+        it('should NOT show for triton-tensorrtllm', () => {
+            const answers = { architecture: 'triton', backend: 'tensorrtllm' };
+            assert.equal(ngcApiKeyPrompt.when(answers), false);
+        });
+
+        it('should NOT show for triton-fil', () => {
+            const answers = { architecture: 'triton', backend: 'fil' };
+            assert.equal(ngcApiKeyPrompt.when(answers), false);
+        });
+
+        it('should NOT show for triton-onnxruntime', () => {
+            const answers = { architecture: 'triton', backend: 'onnxruntime' };
+            assert.equal(ngcApiKeyPrompt.when(answers), false);
+        });
+
+        it('should NOT show for triton-tensorflow', () => {
+            const answers = { architecture: 'triton', backend: 'tensorflow' };
+            assert.equal(ngcApiKeyPrompt.when(answers), false);
+        });
+
+        it('should NOT show for triton-pytorch', () => {
+            const answers = { architecture: 'triton', backend: 'pytorch' };
+            assert.equal(ngcApiKeyPrompt.when(answers), false);
+        });
+
+        it('should NOT show for triton-python', () => {
+            const answers = { architecture: 'triton', backend: 'python' };
+            assert.equal(ngcApiKeyPrompt.when(answers), false);
+        });
+
+        it('should show for transformers-tensorrt-llm (non-Triton)', () => {
+            const answers = { architecture: 'transformers', backend: 'tensorrt-llm' };
+            assert.equal(ngcApiKeyPrompt.when(answers), true);
+        });
+
+        it('should derive architecture from deploymentConfig', () => {
+            const answers = { deploymentConfig: 'triton-tensorrtllm' };
+            assert.equal(ngcApiKeyPrompt.when(answers), false);
+        });
+    });
+
+    describe('modelName prompt - Triton LLM backends (Requirement 3.6)', () => {
+        const modelNamePrompt = modelFormatPrompts[1];
+
+        it('should show for triton-vllm', () => {
+            const answers = { architecture: 'triton', backend: 'vllm' };
+            assert.equal(modelNamePrompt.when(answers), true);
+        });
+
+        it('should show for triton-tensorrtllm', () => {
+            const answers = { architecture: 'triton', backend: 'tensorrtllm' };
+            assert.equal(modelNamePrompt.when(answers), true);
+        });
+
+        it('should NOT show for triton-fil', () => {
+            const answers = { architecture: 'triton', backend: 'fil' };
+            assert.equal(modelNamePrompt.when(answers), false);
+        });
+
+        it('should NOT show for triton-onnxruntime', () => {
+            const answers = { architecture: 'triton', backend: 'onnxruntime' };
+            assert.equal(modelNamePrompt.when(answers), false);
+        });
+
+        it('should NOT show for triton-python', () => {
+            const answers = { architecture: 'triton', backend: 'python' };
+            assert.equal(modelNamePrompt.when(answers), false);
+        });
+
+        it('should show for transformers architecture', () => {
+            const answers = { architecture: 'transformers', backend: 'vllm' };
+            assert.equal(modelNamePrompt.when(answers), true);
+        });
+    });
+});


### PR DESCRIPTION
*Issue #, if available:* #77

*Description of changes:*
This PR adds NVIDIA Triton Inference Server as a third serving architecture alongside the existing http (Flask/FastAPI) and transformers (vLLM/SGLang/TensorRT-LLM/LMI/DJL) paths.

What's new
DeploymentConfigResolver — New component that decomposes flat deployment-config strings into structured { architecture, backend, engine } triples. This replaces the scattered split('-') logic across ConfigManager, PromptRunner, and index.js. 14 canonical deployment-config values are now supported: 2 http, 5 transformers, 7 triton.

7 Triton deployment configs — triton-fil, triton-onnxruntime, triton-tensorflow, triton-pytorch, triton-vllm, triton-tensorrtllm, triton-python. Each generates a Triton-specific project with Dockerfile (based on nvcr.io/nvidia/tritonserver), config.pbtxt, and model repository layout.

Triton prompt flow — Interactive prompts present a third "NVIDIA Triton Inference Server" section. Backend-specific follow-ups handle model format selection (FIL offers xgboost_json/xgboost_ubj/lightgbm_txt, ONNX/TF/PyTorch auto-set, Python offers pkl/joblib/custom). HuggingFace token prompt only appears for LLM backends (triton-vllm, triton-tensorrtllm).

Three-way architecture routing — The writing phase routes to the correct template set via an architecture switch (http, transformers, triton), replacing the old framework === 'transformers' branch.

Sample model support for Triton — Four Triton backends (fil, onnxruntime, tensorflow, python) support sample model training on the Abalone dataset. Training scripts produce artifacts in the correct format per backend (XGBoost JSON/UBJ, LightGBM text, ONNX, TensorFlow SavedModel, pickle/joblib).

Framework registry extensions — All 7 Triton backends have registry entries specifying base images, accelerator requirements, env vars, recommended instance types, and validation levels.

Triton backend metadata — New triton-backends.js registry defines per-backend metadata: requiresGpu, modelFormats, modelArtifactName, requiresModelName, supportsSampleModel.

Breaking change
The 6 old predictive deployment-config values (sklearn-flask, sklearn-fastapi, xgboost-flask, xgboost-fastapi, tensorflow-flask, tensorflow-fastapi) are replaced with http-flask and http-fastapi plus a separate --engine flag. Old values are rejected with migration guidance.

Old value	New equivalent
sklearn-flask	--deployment-config=http-flask --engine=sklearn
xgboost-fastapi	--deployment-config=http-fastapi --engine=xgboost
tensorflow-flask	--deployment-config=http-flask --engine=tensorflow