### PR TITLE
docs: update documentation for do-framework and deployment changes (#67)

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -8,7 +8,7 @@ Common issues and solutions when using ML Container Creator.
 |-------|-----------|
 | `yo: command not found` | `npm install -g yo` |
 | `generator not found` | `npm link` in project directory |
-| `SyntaxError: Unexpected token` | Update Node.js: `nvm use node` |
+| `SyntaxError: Unexpected token` | Update Node.js to latest: `nvm install node` |
 | Container won't start | Check logs: `docker logs <container-id>` |
 | Health check fails | Verify `/ping` endpoint returns 200 |
 | Model not found | Check model file path in `/opt/ml/model/` |
@@ -52,9 +52,9 @@ Error: The engine "node" is incompatible with this module
 # Check your Node.js version
 node --version
 
-# Update to Node.js 18+ (recommended: latest LTS)
-nvm install --lts
-nvm use --lts
+# Update to Node.js 24+ (required)
+nvm install 24
+nvm use 24
 
 # Or install latest
 nvm install node
@@ -194,7 +194,7 @@ Error: Repository does not exist
 aws ecr create-repository --repository-name my-model-name
 
 # Or let the build script create it automatically
-./deploy/build_and_push.sh
+./do/build && ./do/push
 ```
 
 ### IAM Permissions
@@ -211,9 +211,9 @@ You need these AWS permissions:
 - `ecr:InitiateLayerUpload`
 - `ecr:UploadLayerPart`
 - `ecr:CompleteLayerUpload`
-- `sagemaker:CreateModel`
-- `sagemaker:CreateEndpointConfig` 
+- `sagemaker:CreateEndpointConfig`
 - `sagemaker:CreateEndpoint`
+- `sagemaker:CreateInferenceComponent`
 - `iam:PassRole`
 
 Contact your AWS administrator to add these permissions to your user or role.
@@ -230,8 +230,11 @@ Status: Failed
 
 **Solution:**
 ```bash
-# Check CloudWatch logs for detailed error
-aws logs tail /aws/sagemaker/Endpoints/my-model --follow
+# Use do/logs to tail the correct log group automatically
+./do/logs
+
+# Or check CloudWatch logs manually (inference component logs)
+aws logs tail /aws/sagemaker/InferenceComponents/my-model-ic --follow
 
 # Common causes:
 # 1. Container fails to start - check Dockerfile
@@ -248,15 +251,14 @@ Endpoint stays in "Creating" status for 15+ minutes
 **Solution:**
 ```bash
 # Check logs for errors
-aws logs tail /aws/sagemaker/Endpoints/my-model --follow
+./do/logs
 
-# If truly stuck, delete and recreate
-aws sagemaker delete-endpoint --endpoint-name my-model
-aws sagemaker delete-endpoint-config --endpoint-config-name my-model
-aws sagemaker delete-model --model-name my-model
+# If truly stuck, clean up and recreate
+./do/clean endpoint
 
 # Then redeploy
-./deploy/deploy.sh <your-sagemaker-role-arn>
+export ROLE_ARN=arn:aws:iam::ACCOUNT_ID:role/YOUR_ROLE
+./do/deploy
 ```
 
 ### Inference Errors
@@ -466,9 +468,8 @@ Error: Failed to download model from HuggingFace Hub
    Rebuild with token:
    ```bash
    yo @aws/ml-container-creator my-llm-project \
-     --framework=transformers \
+     --deployment-config=transformers-vllm \
      --model-name=meta-llama/Llama-2-7b-hf \
-     --model-server=vllm \
      --hf-token=hf_your_token_here \
      --skip-prompts
    ```
@@ -609,7 +610,7 @@ SageMaker endpoint costs are too high
 2. **Use auto-scaling** to scale down during low traffic
 3. **Delete unused endpoints**:
    ```bash
-   aws sagemaker delete-endpoint --endpoint-name unused-model
+   ./do/clean endpoint
    ```
 4. **Consider serverless inference** for sporadic workloads
 
@@ -650,10 +651,14 @@ curl -X POST http://localhost:8080/invocations \
 ### Check All Logs
 
 ```bash
+# Use do/logs for automatic log tailing (detects deployment target)
+./do/logs
+
+# Or check manually:
 # Local container logs
 docker logs <container-id>
 
-# SageMaker endpoint logs  
+# SageMaker endpoint logs
 aws logs tail /aws/sagemaker/Endpoints/my-model --follow
 
 # Build logs
@@ -678,7 +683,7 @@ docker build -t my-model . 2>&1 | tee build.log
 ## Prevention Checklist
 
 Before you start:
-- ✅ Node.js 18+ installed (`node --version`)
+- ✅ Node.js 24+ installed (`node --version`)
 - ✅ Docker installed and running
 - ✅ AWS CLI configured (`aws configure list`)
 - ✅ Model file ready in correct format

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -42,7 +42,7 @@ yo @aws/ml-container-creator
 ? Test type? local-model-cli, local-model-server, hosted-model-endpoint
 
 💪 Infrastructure & Performance
-? Deployment target? sagemaker
+? Deployment target? managed-inference
 ? Instance type? cpu-optimized
 ? Target AWS region? us-east-1
 ```
@@ -58,32 +58,32 @@ cp /path/to/your/model.pkl code/model.pkl
 
 ```bash
 # Build Docker image
-docker build -t sklearn-iris-classifier .
+./do/build
 
 # Run container locally
-docker run -p 8080:8080 sklearn-iris-classifier
+./do/run
 
-# Test in another terminal
-curl -X POST http://localhost:8080/invocations \
-  -H "Content-Type: application/json" \
-  -d '{"instances": [[5.1, 3.5, 1.4, 0.2]]}'
+# In another terminal, test the endpoints
+./do/test
 ```
 
 ### Step 4: Deploy to SageMaker
 
 ```bash
 # Build and push to ECR
-./deploy/build_and_push.sh
+./do/build
+./do/push
 
-# Deploy to SageMaker (replace with your IAM role ARN)
-./deploy/deploy.sh arn:aws:iam::123456789012:role/SageMakerExecutionRole
+# Deploy to SageMaker (set ROLE_ARN in do/config or export it)
+export ROLE_ARN=arn:aws:iam::123456789012:role/SageMakerExecutionRole
+./do/deploy
 ```
 
 ### Step 5: Test Endpoint
 
 ```bash
 # Test the deployed endpoint
-./test/test_endpoint.sh sklearn-iris-classifier
+./do/test
 ```
 
 ---
@@ -142,8 +142,9 @@ def preprocess(data):
 
 ```bash
 cd xgboost-house-prices-*
-./deploy/build_and_push.sh
-./deploy/deploy.sh arn:aws:iam::123456789012:role/SageMakerExecutionRole
+./do/build
+./do/push
+./do/deploy
 ```
 
 ---
@@ -206,8 +207,9 @@ def preprocess(data):
 
 ```bash
 cd tensorflow-image-classifier-*
-./deploy/build_and_push.sh
-./deploy/deploy.sh arn:aws:iam::123456789012:role/SageMakerExecutionRole
+./do/build
+./do/push
+./do/deploy
 ```
 
 The deployment script will automatically select a GPU instance (ml.g4dn.xlarge) based on your configuration.
@@ -296,8 +298,8 @@ cp -r /path/to/llama2-model/* llama2-7b-chat-*/model/
 ```bash
 cd llama2-7b-chat-*
 
-# Upload model to S3 (script will prompt for bucket name)
-./deploy/upload_to_s3.sh
+# Upload model to S3 (if using S3-based model loading)
+aws s3 cp model/ s3://my-bucket/models/llama2-7b/ --recursive
 ```
 
 ### Step 4: Update Dockerfile
@@ -313,8 +315,13 @@ ENV MODEL_NAME="meta-llama/Llama-2-7b-chat-hf"
 ### Step 5: Deploy
 
 ```bash
-./deploy/build_and_push.sh
-./deploy/deploy.sh arn:aws:iam::123456789012:role/SageMakerExecutionRole
+# Build and push (or use ./do/submit for CodeBuild)
+./do/build
+./do/push
+
+# Deploy (set ROLE_ARN in do/config or export it)
+export ROLE_ARN=arn:aws:iam::123456789012:role/SageMakerExecutionRole
+./do/deploy
 ```
 
 **Note:** Transformer deployments require:
@@ -400,9 +407,11 @@ ls -la
 # Key files for TensorRT-LLM:
 # - Dockerfile (uses TensorRT-LLM base image)
 # - code/serve (TensorRT-LLM entrypoint script)
-# - deploy/upload_to_s3.sh (Upload model to S3)
-# - deploy/build_and_push.sh (Build and push to ECR)
-# - deploy/deploy.sh (Deploy to SageMaker)
+# - do/build (Build Docker image)
+# - do/push (Push to ECR)
+# - do/deploy (Deploy to SageMaker)
+# - do/test (Test endpoint)
+# - do/clean (Clean up resources)
 ```
 
 ### Step 5: Prepare Model Files
@@ -432,11 +441,8 @@ cp -r /path/to/llama3-model/* ./model/
 TensorRT-LLM models are typically loaded from S3 for SageMaker deployments:
 
 ```bash
-# Upload model to S3 (script will prompt for bucket name)
-./deploy/upload_to_s3.sh
-
-# Or specify bucket directly:
-# aws s3 cp model/ s3://my-bucket/models/llama3-3b/ --recursive
+# Upload model to S3
+aws s3 cp model/ s3://my-bucket/models/llama3-3b/ --recursive
 ```
 
 ### Step 7: Build and Push Container
@@ -447,8 +453,9 @@ Before building, you need to authenticate with NVIDIA NGC (NVIDIA GPU Cloud) to 
 # Set your NGC API key (get from https://ngc.nvidia.com/setup/api-key)
 export NGC_API_KEY='your-ngc-api-key-here'
 
-# Build Docker image with TensorRT-LLM
-./deploy/build_and_push.sh
+# Build and push Docker image with TensorRT-LLM
+./do/build
+./do/push
 ```
 
 The build script automatically:
@@ -471,8 +478,9 @@ This creates a container with:
 ### Step 8: Deploy to SageMaker
 
 ```bash
-# Deploy to SageMaker endpoint (replace with your IAM role ARN)
-./deploy/deploy.sh arn:aws:iam::123456789012:role/SageMakerExecutionRole
+# Deploy to SageMaker endpoint (set ROLE_ARN in do/config or export it)
+export ROLE_ARN=arn:aws:iam::123456789012:role/SageMakerExecutionRole
+./do/deploy
 ```
 
 **Important Notes:**
@@ -591,7 +599,7 @@ For optimal performance:
 
 ```bash
 # Use larger GPU instance for better throughput
-# Edit deploy/deploy.sh:
+# Edit do/config:
 INSTANCE_TYPE="ml.g5.12xlarge"  # 4 GPUs
 
 # Enable tensor parallelism in Dockerfile:
@@ -673,7 +681,7 @@ CUDA out of memory
 **Solution:**
 ```bash
 # Use larger GPU instance
-# Edit deploy/deploy.sh:
+# Edit do/config:
 INSTANCE_TYPE="ml.g5.12xlarge"  # More memory
 
 # Or reduce batch size in Dockerfile:
@@ -769,14 +777,16 @@ The CodeBuild deployment includes additional files:
 cd sklearn-codebuild-project
 ls -la
 
+# do-framework scripts (primary):
+# - do/build, do/push, do/deploy, do/test, do/clean, do/submit, do/logs, do/export
+# - do/config (centralized configuration)
+
 # CodeBuild-specific files:
 # - buildspec.yml (CodeBuild build specification)
-# - deploy/submit_build.sh (Submit build job script)
 # - IAM_PERMISSIONS.md (Required IAM permissions documentation)
 
-# Standard files:
-# - Dockerfile, requirements.txt, code/, test/
-# - deploy/deploy.sh (SageMaker deployment script)
+# Legacy scripts (deprecated, forward to do/ equivalents):
+# - deploy/submit_build.sh, deploy/deploy.sh, deploy/build_and_push.sh
 ```
 
 ### Step 3: Add Your Model
@@ -799,7 +809,7 @@ python test/test_local_model_cli.py
 # 4. Upload source code to S3
 # 5. Start build job and monitor progress
 
-./deploy/submit_build.sh
+./do/submit
 ```
 
 **Expected Output:**
@@ -835,7 +845,8 @@ Build started with ID: sklearn-codebuild-project-sklearn-build-20240102:abc123
 
 ```bash
 # Deploy the CodeBuild-generated image to SageMaker
-./deploy/deploy.sh arn:aws:iam::123456789012:role/SageMakerExecutionRole
+export ROLE_ARN=arn:aws:iam::123456789012:role/SageMakerExecutionRole
+./do/deploy
 ```
 
 ### Step 6: Test the Endpoint
@@ -1200,23 +1211,17 @@ http {
 
 ### Custom Deployment Script
 
-Edit `deploy/deploy.sh` to customize instance type:
+Edit `do/config` to customize instance type:
 
 ```bash
-#!/bin/bash
+# In do/config, change the instance type
+export INSTANCE_TYPE="ml.m5.2xlarge"
+```
 
-# Use larger instance for production
-INSTANCE_TYPE="ml.m5.2xlarge"
-INSTANCE_COUNT=2  # Multiple instances for HA
+Or override via environment variable:
 
-# Create endpoint configuration with auto-scaling
-aws sagemaker create-endpoint-config \
-  --endpoint-config-name ${PROJECT_NAME}-config \
-  --production-variants \
-    VariantName=AllTraffic,\
-    ModelName=${PROJECT_NAME}-model,\
-    InstanceType=${INSTANCE_TYPE},\
-    InitialInstanceCount=${INSTANCE_COUNT}
+```bash
+INSTANCE_TYPE=ml.m5.2xlarge ./do/deploy
 ```
 
 ### Custom Instance Types
@@ -1357,7 +1362,7 @@ Container killed due to memory limit
 **Solution:**
 ```bash
 # Use larger instance type
-# Edit deploy/deploy.sh
+# Edit do/config
 INSTANCE_TYPE="ml.m5.2xlarge"  # 32GB RAM instead of 16GB
 
 # Or optimize model

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ Configuration sources are applied in strict precedence order (highest to lowest 
 
 | Priority | Source | Description | Example |
 |----------|--------|-------------|---------|
-| **1** | CLI Options | Command-line flags | `--framework=sklearn` |
+| **1** | CLI Options | Command-line flags | `--deployment-config=http-flask` |
 | **2** | CLI Arguments | Positional arguments | `yo @aws/ml-container-creator my-project` |
 | **3** | Environment Variables | Shell environment | `export AWS_REGION=us-east-1` |
 | **4** | CLI Config File | `--config` specified file | `--config=production.json` |
@@ -27,17 +27,26 @@ This table shows which parameters are supported by each configuration source:
 | Parameter | CLI Option | CLI Arg | Env Var | Config File | Package.json | Default | Promptable | Required |
 |-----------|------------|---------|---------|-------------|--------------|---------|------------|----------|
 | **Core Parameters** |
-| Framework | `--framework` | ❌ | ❌ | ✅ | ❌ | N/A | ✅ | ✅ |
-| Model Server | `--model-server` | ❌ | ❌ | ✅ | ❌ | N/A | ✅ | ✅ |
+| Deployment Config | `--deployment-config` | ❌ | ❌ | ✅ | ❌ | N/A | ✅ | ✅ |
+| Engine | `--engine` | ❌ | ❌ | ✅ | ❌ | N/A | ✅ | ❌ |
+| Framework | `--framework` | ❌ | ❌ | ✅ | ❌ | N/A | ✅ | ❌ |
+| Model Server | `--model-server` | ❌ | ❌ | ✅ | ❌ | N/A | ✅ | ❌ |
 | Model Format | `--model-format` | ❌ | ❌ | ✅ | ❌ | N/A | ✅ | ✅ |
 | **Module Options** |
 | Include Sample | `--include-sample` | ❌ | ❌ | ✅ | ❌ | `false` | ✅ | ✅ |
 | Include Testing | `--include-testing` | ❌ | ❌ | ✅ | ❌ | `true` | ✅ | ✅ |
 | **Infrastructure** |
+| Deployment Target | `--deployment-target` | ❌ | ❌ | ✅ | ❌ | N/A | ✅ | ✅ |
+| Build Target | `--build-target` | ❌ | ❌ | ✅ | ❌ | N/A | ✅ | ✅ |
 | Instance Type | `--instance-type` | ❌ | `ML_INSTANCE_TYPE` | ✅ | ❌ | N/A | ✅ | ✅ |
-| Custom Instance Type | `--custom-instance-type` | ❌ | `ML_CUSTOM_INSTANCE_TYPE` | ✅ | ❌ | N/A | ✅ | ❌ |
+| CodeBuild Compute Type | `--codebuild-compute-type` | ❌ | ❌ | ✅ | ❌ | `BUILD_GENERAL1_MEDIUM` | ✅ | ❌ |
 | AWS Region | `--region` | ❌ | `AWS_REGION` | ✅ | ✅ | `us-east-1` | ✅ | ❌ |
 | AWS Role ARN | `--role-arn` | ❌ | `AWS_ROLE` | ✅ | ✅ | N/A | ✅ | ❌ |
+| **HyperPod EKS** |
+| HyperPod Cluster | `--hyperpod-cluster` | ❌ | ❌ | ✅ | ❌ | N/A | ✅ | ❌ |
+| HyperPod Namespace | `--hyperpod-namespace` | ❌ | ❌ | ✅ | ❌ | N/A | ✅ | ❌ |
+| HyperPod Replicas | `--hyperpod-replicas` | ❌ | ❌ | ✅ | ❌ | `1` | ✅ | ❌ |
+| FSx Volume Handle | `--fsx-volume-handle` | ❌ | ❌ | ✅ | ❌ | N/A | ✅ | ❌ |
 | **Project Settings** |
 | Project Name | `--project-name` | ✅ | ❌ | ✅ | ✅ | N/A | ❌ | ✅ |
 | Project Directory | `--project-dir` | ❌ | ❌ | ✅ | ✅ | `.` | ❌ | ✅ |
@@ -70,18 +79,22 @@ Use command-line flags for quick one-off configurations:
 ```bash
 # Basic sklearn project
 yo @aws/ml-container-creator my-project \
-  --framework=sklearn \
-  --model-server=flask \
+  --deployment-config=http-flask \
+  --engine=sklearn \
   --model-format=pkl \
+  --deployment-target=managed-inference \
+  --instance-type=ml.m5.large \
+  --build-target=codebuild \
   --skip-prompts
 
-# Advanced configuration
+# Advanced LLM configuration
 yo @aws/ml-container-creator my-llm-project \
-  --framework=transformers \
-  --model-server=vllm \
-  --instance-type=gpu-enabled \
+  --deployment-config=transformers-vllm \
+  --deployment-target=managed-inference \
+  --instance-type=ml.g5.2xlarge \
   --region=us-west-2 \
   --role-arn=arn:aws:iam::123456789012:role/SageMakerRole \
+  --build-target=codebuild \
   --skip-prompts
 ```
 
@@ -93,15 +106,46 @@ yo @aws/ml-container-creator my-llm-project \
 | `--config=<file>` | String | Load configuration from file | File path |
 | `--project-name=<name>` | String | Project name | Any valid name |
 | `--project-dir=<dir>` | String | Output directory | Directory path |
-| `--framework=<framework>` | String | ML framework | `sklearn`, `xgboost`, `tensorflow`, `transformers` |
-| `--model-server=<server>` | String | Model server | `flask`, `fastapi`, `vllm`, `sglang` |
+| `--deployment-config=<config>` | String | Deployment configuration | See [Deployment Configs](#deployment-configs) |
+| `--engine=<engine>` | String | ML engine (traditional ML only) | `sklearn`, `xgboost`, `tensorflow` |
+| `--framework=<framework>` | String | ML framework (deprecated) | Use `--deployment-config` instead |
+| `--model-server=<server>` | String | Model server (deprecated) | Use `--deployment-config` instead |
 | `--model-format=<format>` | String | Model format | Framework-dependent |
 | `--include-sample` | Boolean | Include sample model code | `true`/`false` |
 | `--include-testing` | Boolean | Include test suite | `true`/`false` |
-| `--instance-type=<type>` | String | Instance type | `cpu-optimized`, `gpu-enabled`, `custom` |
-| `--custom-instance-type=<type>` | String | Custom AWS instance type | `ml.m5.large`, `ml.g4dn.xlarge` |
+| `--deployment-target=<target>` | String | Where the model runs | `managed-inference`, `hyperpod-eks` |
+| `--build-target=<target>` | String | Where Docker image is built | `codebuild` |
+| `--instance-type=<type>` | String | AWS instance type | `ml.m5.large`, `ml.g5.2xlarge`, etc. |
+| `--codebuild-compute-type=<type>` | String | CodeBuild compute type | `BUILD_GENERAL1_SMALL`, `BUILD_GENERAL1_MEDIUM`, `BUILD_GENERAL1_LARGE` |
 | `--region=<region>` | String | AWS region | AWS region code |
 | `--role-arn=<arn>` | String | AWS IAM role ARN | Valid ARN |
+| `--hyperpod-cluster=<name>` | String | HyperPod EKS cluster name | Cluster name |
+| `--hyperpod-namespace=<ns>` | String | HyperPod K8s namespace | Namespace |
+| `--hyperpod-replicas=<n>` | Number | HyperPod replica count | `1` (default) |
+| `--fsx-volume-handle=<id>` | String | FSx volume handle for HyperPod | Volume ID |
+
+#### Deployment Configs
+
+The `--deployment-config` flag bundles the architecture and model server into a single value:
+
+| Config | Architecture | Backend | Use Case |
+|--------|-------------|---------|----------|
+| `http-flask` | HTTP | Flask | Traditional ML with Flask server |
+| `http-fastapi` | HTTP | FastAPI | Traditional ML with FastAPI server |
+| `transformers-vllm` | Transformers | vLLM | LLM serving with vLLM |
+| `transformers-sglang` | Transformers | SGLang | LLM serving with SGLang |
+| `transformers-tensorrt-llm` | Transformers | TensorRT-LLM | LLM serving with TensorRT-LLM |
+| `transformers-lmi` | Transformers | LMI | LLM serving with Large Model Inference |
+| `transformers-djl` | Transformers | DJL | LLM serving with Deep Java Library |
+| `triton-fil` | Triton | FIL | Tree models (XGBoost, LightGBM) on Triton |
+| `triton-onnxruntime` | Triton | ONNX Runtime | ONNX models on Triton |
+| `triton-tensorflow` | Triton | TensorFlow | TensorFlow models on Triton |
+| `triton-pytorch` | Triton | PyTorch | PyTorch models on Triton |
+| `triton-vllm` | Triton | vLLM | LLM serving on Triton |
+| `triton-tensorrtllm` | Triton | TensorRT-LLM | LLM serving on Triton with TensorRT-LLM |
+| `triton-python` | Triton | Python | Custom Python models on Triton |
+
+For traditional ML configs (`http-flask`, `http-fastapi`), also specify `--engine` to set the ML framework (e.g., `--engine=sklearn`).
 
 ### 3. CLI Arguments
 
@@ -109,7 +153,7 @@ Use positional arguments for the project name:
 
 ```bash
 # Project name as first argument
-yo @aws/ml-container-creator my-awesome-model --framework=sklearn --skip-prompts
+yo @aws/ml-container-creator my-awesome-model --deployment-config=http-flask --engine=sklearn --skip-prompts
 ```
 
 ### 4. Environment Variables
@@ -118,27 +162,26 @@ Set environment variables for deployment-specific configuration:
 
 ```bash
 # Set environment variables
-export ML_INSTANCE_TYPE="gpu-enabled"
+export ML_INSTANCE_TYPE="ml.g5.2xlarge"
 export AWS_REGION="us-west-2"
 export AWS_ROLE="arn:aws:iam::123456789012:role/SageMakerRole"
 export ML_CONTAINER_CREATOR_CONFIG="./production.json"
 
 # Generate with environment config + CLI options for core parameters
-yo @aws/ml-container-creator --framework=transformers --model-server=vllm --skip-prompts
+yo @aws/ml-container-creator --deployment-config=transformers-vllm --skip-prompts
 ```
 
 #### Supported Environment Variables
 
 | Variable | Maps To | Description | Example |
 |----------|---------|-------------|---------|
-| `ML_INSTANCE_TYPE` | `instanceType` | Instance type | `cpu-optimized`, `gpu-enabled`, `custom` |
-| `ML_CUSTOM_INSTANCE_TYPE` | `customInstanceType` | Custom AWS instance type | `ml.g4dn.xlarge` |
+| `ML_INSTANCE_TYPE` | `instanceType` | AWS instance type | `ml.m5.large`, `ml.g5.2xlarge` |
 | `AWS_REGION` | `awsRegion` | AWS region | `us-east-1` |
 | `AWS_ROLE` | `awsRoleArn` | AWS IAM role ARN | `arn:aws:iam::123456789012:role/SageMakerRole` |
 | `ML_CONTAINER_CREATOR_CONFIG` | `configFile` | Config file path | `./my-config.json` |
 
 !!! note "Limited Environment Variable Support"
-    Only infrastructure and system parameters support environment variables. Core parameters (framework, model-server, etc.) must be configured via CLI options or configuration files for security and clarity.
+    Only infrastructure and system parameters support environment variables. Core parameters (deployment-config, engine, etc.) must be configured via CLI options or configuration files for security and clarity.
 
 ### 5. Configuration Files
 
@@ -149,15 +192,15 @@ Create a configuration file in your project directory:
 ```json
 {
   "projectName": "my-ml-project",
-  "framework": "sklearn",
-  "modelServer": "flask",
+  "deploymentConfig": "http-flask",
+  "engine": "sklearn",
   "modelFormat": "pkl",
   "includeSampleModel": false,
   "includeTesting": true,
   "testTypes": ["local-model-cli", "hosted-model-endpoint"],
-  "deployTarget": "sagemaker",
-  "instanceType": "cpu-optimized",
-  "customInstanceType": "ml.m5.large",
+  "deploymentTarget": "managed-inference",
+  "buildTarget": "codebuild",
+  "instanceType": "ml.m5.large",
   "awsRegion": "us-east-1",
   "awsRoleArn": "arn:aws:iam::123456789012:role/SageMakerRole"
 }
@@ -198,7 +241,7 @@ Add configuration to your `package.json` for project-specific defaults:
 ```
 
 !!! note "Package.json Limitations"
-    Only infrastructure and project settings are supported in package.json. Core parameters (framework, model-server, etc.) are not supported to avoid confusion.
+    Only infrastructure and project settings are supported in package.json. Core parameters (deployment-config, engine, etc.) are not supported to avoid confusion.
 
 ## CLI Commands
 
@@ -267,17 +310,15 @@ You can:
 ```bash
 # Direct token
 yo @aws/ml-container-creator my-llm-project \
-  --framework=transformers \
+  --deployment-config=transformers-vllm \
   --model-name=meta-llama/Llama-2-7b-hf \
-  --model-server=vllm \
   --hf-token=hf_abc123... \
   --skip-prompts
 
 # Environment variable reference
 yo @aws/ml-container-creator my-llm-project \
-  --framework=transformers \
+  --deployment-config=transformers-vllm \
   --model-name=meta-llama/Llama-2-7b-hf \
-  --model-server=vllm \
   --hf-token='$HF_TOKEN' \
   --skip-prompts
 ```
@@ -286,9 +327,8 @@ yo @aws/ml-container-creator my-llm-project \
 
 ```json
 {
-  "framework": "transformers",
+  "deploymentConfig": "transformers-vllm",
   "modelName": "meta-llama/Llama-2-7b-hf",
-  "modelServer": "vllm",
   "hfToken": "$HF_TOKEN"
 }
 ```
@@ -303,7 +343,7 @@ yo @aws/ml-container-creator my-llm-project \
 1. **Use environment variable references for CI/CD**:
    ```bash
    export HF_TOKEN=hf_your_token_here
-   yo @aws/ml-container-creator --framework=transformers --hf-token='$HF_TOKEN' --skip-prompts
+   yo @aws/ml-container-creator --deployment-config=transformers-vllm --hf-token='$HF_TOKEN' --skip-prompts
    ```
 
 2. **Never commit tokens to version control**: Use `$HF_TOKEN` in config files, not actual tokens.
@@ -345,25 +385,30 @@ For more troubleshooting, see the [Troubleshooting Guide](./TROUBLESHOOTING.md).
 ```bash
 # scikit-learn with Flask
 yo @aws/ml-container-creator sklearn-project \
-  --framework=sklearn \
-  --model-server=flask \
+  --deployment-config=http-flask \
+  --engine=sklearn \
   --model-format=pkl \
+  --deployment-target=managed-inference \
+  --instance-type=ml.m5.large \
   --include-sample \
   --skip-prompts
 
 # XGBoost with FastAPI
 yo @aws/ml-container-creator xgb-project \
-  --framework=xgboost \
-  --model-server=fastapi \
+  --deployment-config=http-fastapi \
+  --engine=xgboost \
   --model-format=json \
-  --instance-type=cpu-optimized \
+  --deployment-target=managed-inference \
+  --instance-type=ml.m5.large \
   --skip-prompts
 
-# TensorFlow with custom format
+# TensorFlow with Flask
 yo @aws/ml-container-creator tf-project \
-  --framework=tensorflow \
-  --model-server=flask \
+  --deployment-config=http-flask \
+  --engine=tensorflow \
   --model-format=SavedModel \
+  --deployment-target=managed-inference \
+  --instance-type=ml.m5.large \
   --skip-prompts
 ```
 
@@ -380,17 +425,17 @@ yo @aws/ml-container-creator tf-project \
 ```bash
 # Transformers with vLLM
 yo @aws/ml-container-creator llm-project \
-  --framework=transformers \
-  --model-server=vllm \
-  --instance-type=gpu-enabled \
+  --deployment-config=transformers-vllm \
+  --deployment-target=managed-inference \
+  --instance-type=ml.g5.2xlarge \
   --region=us-west-2 \
   --skip-prompts
 
 # Transformers with SGLang
 yo @aws/ml-container-creator llm-project \
-  --framework=transformers \
-  --model-server=sglang \
-  --instance-type=gpu-enabled \
+  --deployment-config=transformers-sglang \
+  --deployment-target=managed-inference \
+  --instance-type=ml.g5.2xlarge \
   --skip-prompts
 ```
 
@@ -406,12 +451,13 @@ yo @aws/ml-container-creator llm-project \
 ```json
 {
   "projectName": "dev-model",
-  "framework": "sklearn",
-  "modelServer": "flask",
+  "deploymentConfig": "http-flask",
+  "engine": "sklearn",
   "modelFormat": "pkl",
   "includeSampleModel": true,
   "includeTesting": true,
-  "instanceType": "cpu-optimized",
+  "deploymentTarget": "managed-inference",
+  "instanceType": "ml.m5.large",
   "awsRegion": "us-east-1"
 }
 ```
@@ -421,13 +467,15 @@ yo @aws/ml-container-creator llm-project \
 ```json
 {
   "projectName": "prod-recommendation-service",
-  "framework": "tensorflow",
-  "modelServer": "fastapi",
+  "deploymentConfig": "http-fastapi",
+  "engine": "tensorflow",
   "modelFormat": "SavedModel",
   "includeSampleModel": false,
   "includeTesting": true,
   "testTypes": ["local-model-server", "hosted-model-endpoint"],
-  "instanceType": "gpu-enabled",
+  "deploymentTarget": "managed-inference",
+  "buildTarget": "codebuild",
+  "instanceType": "ml.g4dn.xlarge",
   "awsRegion": "us-west-2",
   "awsRoleArn": "arn:aws:iam::123456789012:role/ProdSageMakerRole"
 }
@@ -438,11 +486,12 @@ yo @aws/ml-container-creator llm-project \
 ```json
 {
   "projectName": "llm-chat-service",
-  "framework": "transformers",
-  "modelServer": "vllm",
+  "deploymentConfig": "transformers-vllm",
   "includeSampleModel": false,
   "includeTesting": true,
-  "instanceType": "gpu-enabled",
+  "deploymentTarget": "managed-inference",
+  "buildTarget": "codebuild",
+  "instanceType": "ml.g5.12xlarge",
   "awsRegion": "us-west-2",
   "awsRoleArn": "arn:aws:iam::123456789012:role/LLMSageMakerRole"
 }
@@ -453,14 +502,14 @@ yo @aws/ml-container-creator llm-project \
 ### ❌ Mixing Incompatible Options
 
 ```bash
-# DON'T: sklearn with vLLM server
-yo @aws/ml-container-creator --framework=sklearn --model-server=vllm --skip-prompts
+# DON'T: traditional ML engine with LLM deployment config
+yo @aws/ml-container-creator --deployment-config=transformers-vllm --engine=sklearn --skip-prompts
 
 # DON'T: transformers with model format
-yo @aws/ml-container-creator --framework=transformers --model-format=pkl --skip-prompts
+yo @aws/ml-container-creator --deployment-config=transformers-vllm --model-format=pkl --skip-prompts
 
 # DON'T: transformers with sample model
-yo @aws/ml-container-creator --framework=transformers --include-sample --skip-prompts
+yo @aws/ml-container-creator --deployment-config=transformers-vllm --include-sample --skip-prompts
 ```
 
 ### ❌ Using Unsupported Environment Variables
@@ -472,7 +521,7 @@ export ML_MODEL_SERVER=flask       # Not supported
 export ML_MODEL_FORMAT=pkl         # Not supported
 
 # DO: Use CLI options or config files for core parameters
-yo @aws/ml-container-creator --framework=sklearn --model-server=flask --skip-prompts
+yo @aws/ml-container-creator --deployment-config=http-flask --engine=sklearn --skip-prompts
 ```
 
 ### ❌ Invalid Configuration Files
@@ -504,15 +553,15 @@ The generator validates all configuration and provides clear error messages:
 ### Framework Validation
 
 ```bash
-yo @aws/ml-container-creator --framework=invalid --skip-prompts
+yo @aws/ml-container-creator --deployment-config=invalid --skip-prompts
 # Error: ⚠️ invalid not implemented yet.
 ```
 
 ### Format Validation
 
 ```bash
-yo @aws/ml-container-creator --framework=sklearn --model-format=json --skip-prompts
-# Error: Invalid model format 'json' for framework 'sklearn'
+yo @aws/ml-container-creator --deployment-config=http-flask --engine=sklearn --model-format=json --skip-prompts
+# Error: Unsupported model format 'json' for engine 'sklearn'
 ```
 
 ### ARN Validation
@@ -526,7 +575,7 @@ yo @aws/ml-container-creator --role-arn=invalid-arn --skip-prompts
 
 ```bash
 yo @aws/ml-container-creator --skip-prompts
-# Error: Missing required parameter: framework
+# Error: Required parameter 'deploymentConfig' is missing
 ```
 
 ## Best Practices
@@ -550,8 +599,8 @@ export AWS_REGION=us-west-2     # Production
 ### 3. Use CLI Options for One-Off Changes
 
 ```bash
-# Quick test with different server
-yo @aws/ml-container-creator --model-server=fastapi --skip-prompts
+# Quick test with different deployment config
+yo @aws/ml-container-creator --deployment-config=http-fastapi --engine=sklearn --skip-prompts
 ```
 
 ### 4. Combine Methods Strategically
@@ -577,11 +626,11 @@ yo @aws/ml-container-creator --config=production.json
 The generator shows which configuration sources are being used:
 
 ```bash
-yo @aws/ml-container-creator --framework=sklearn --skip-prompts
+yo @aws/ml-container-creator --deployment-config=http-flask --engine=sklearn --skip-prompts
 
 # Output shows:
 # ⚙️ Configuration will be collected from prompts and merged with:
-#    • Framework: sklearn
+#    • Deployment config: http-flask
 #    • No external configuration found
 ```
 

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -1,18 +1,69 @@
-MCC supports two deployment paths: direct SageMaker deployment and CodeBuild-based CI/CD. For direct deployment, the generated `deploy.sh` script creates a SageMaker model (referencing the ECR image), an endpoint configuration (specifying instance type and count), and finally the endpoint itself. The script waits for the endpoint to reach "InService" status before completing. For CI/CD workflows, MCC generates a `submit_build.sh` script that creates an AWS CodeBuild project, which handles building the Docker image, pushing to ECR, and deploying to SageMaker automatically on code changes. Both approaches provision the necessary AWS resources (IAM roles, ECR repositories, SageMaker endpoints) and configure them according to the framework and instance type selected during generation. Once deployed, the endpoint is accessible via the SageMaker Runtime API for real-time inference requests.
+MCC supports two deployment targets and two build paths, all managed through standardized `do/` scripts inspired by the [do-framework](https://github.com/iankoulski/do-framework). Generated projects include a `do/` directory with scripts for every stage of the container lifecycle: `build`, `push`, `run`, `test`, `deploy`, `clean`, `logs`, `export`, and optionally `submit` (for CodeBuild).
 
+## Build Paths
+
+### Local Build
+For local builds, users run `./do/build` to create the Docker image and `./do/push` to upload it to Amazon ECR. This two-step approach lets you test locally with `./do/run` before pushing.
+
+### AWS CodeBuild
+For CI/CD workflows, `./do/submit` creates an AWS CodeBuild project that builds the Docker image and pushes it to ECR in a single step. This is the preferred method for building containers destined for production endpoints, as it avoids architecture mismatches between local machines and deployment instances.
+
+## Deployment Targets
+
+MCC supports two deployment targets, selected during project generation via the `--deployment-target` option. The chosen target determines how `./do/deploy`, `./do/test`, `./do/clean`, and `./do/logs` behave.
 
 #### Local Deployment
-Local endpoints can be deployed once the image has been built. Locak deployments are most easily accommodated by users who elect to build the container locally. Otherwise, users will have to download the container image from Amazon ECR to launch it locally. 
+Local endpoints can be deployed once the image has been built. Local deployments are most easily accommodated by users who elect to build the container locally. Otherwise, users will have to download the container image from Amazon ECR to launch it locally.
 
 !!! warning "Local LLM Containers"
-    Local deployment should be used sparingly. Predictive containers built on ML frameworks like XGBoost can easily be launched locally given their relatively small size and lack of GPU dependencies. This capability may not work for LLM-based serving frameworks. Images built from SGlang for example are quite large, and require GPU resources to be made available to your container. 
+    Local deployment should be used sparingly. Predictive containers built on ML frameworks like XGBoost can easily be launched locally given their relatively small size and lack of GPU dependencies. This capability may not work for LLM-based serving frameworks. Images built from SGLang for example are quite large, and require GPU resources to be made available to your container.
 
-#### Amazon SageMaker AI Managed Inference
-Amazon SageMaker AI Managed Inference is the preferred deployment target for MCC containers. MCC containers are built specifically for SageMaker endpoints, and users have the ability to select their preferred instance type, family and size when generating an MCC project. 
+#### Amazon SageMaker AI Managed Inference (`managed-inference`)
+Amazon SageMaker AI Managed Inference is the default deployment target for MCC containers. When this target is selected, `./do/deploy` provisions resources using the SageMaker Inference Components API:
+
+1. **Create endpoint configuration** -- specifies the instance type and count
+2. **Create endpoint** -- provisions the compute infrastructure
+3. **Create inference component** -- associates the ECR container image with the endpoint
+
+The inference component model decouples compute provisioning from model deployment, allowing multiple models to share a single endpoint. Once the inference component reaches `InService` status, the endpoint is accessible via the SageMaker Runtime API for real-time inference requests.
+
+Users select their preferred instance type, family, and size when generating an MCC project. The generated `do/config` file stores the `INSTANCE_TYPE` and optionally `INFERENCE_AMI_VERSION` for controlling the CUDA driver version on the instance.
+
+After deployment, `./do/test` validates the endpoint by invoking inference through the inference component, `./do/logs` tails CloudWatch logs, and `./do/clean endpoint` tears down the inference component, endpoint, and endpoint configuration.
 
 !!! info "Real-Time Only"
-    At this time, real-time endpoints are the only supported Sagemaker AI managed inference endpoints supported by MCC.
+    At this time, real-time endpoints are the only supported SageMaker AI managed inference endpoints supported by MCC.
 
-#### Amazon SageMaker HyperPodd
-!!! todo "Under Construction"
-    This feature is roadmapped, but currently not supported.
+#### Amazon SageMaker HyperPod EKS (`hyperpod-eks`)
+For users with existing [SageMaker HyperPod](https://aws.amazon.com/sagemaker/hyperpod/) clusters running on Amazon EKS, MCC can deploy containers directly to Kubernetes. When this target is selected:
+
+- `./do/deploy` retrieves the underlying EKS cluster from the HyperPod cluster, configures `kubectl`, and applies Kubernetes manifests (Deployment, Service, ConfigMap, and optionally PVC for FSx storage) to the specified namespace.
+- `./do/test hyperpod` port-forwards the Kubernetes service and runs the same `/ping` and `/invocations` health checks used for managed inference.
+- `./do/logs` tails pod logs via `kubectl`.
+- `./do/clean hyperpod` deletes the Kubernetes resources from the namespace.
+
+The generated `do/config` file stores HyperPod-specific variables: `HYPERPOD_CLUSTER_NAME`, `HYPERPOD_NAMESPACE`, `HYPERPOD_REPLICAS`, and optionally `FSX_VOLUME_HANDLE`.
+
+!!! note "Prerequisites for HyperPod EKS"
+    - An existing SageMaker HyperPod cluster with EKS orchestrator
+    - `kubectl` installed locally
+    - IAM permissions for `sagemaker:DescribeCluster` and `eks:DescribeCluster`
+    - Sufficient node capacity (especially GPU nodes for LLM workloads)
+
+## Lifecycle Scripts Reference
+
+All generated projects include these `do/` scripts:
+
+| Command | Description |
+|---------|-------------|
+| `./do/build` | Build Docker image locally |
+| `./do/push` | Push image to Amazon ECR |
+| `./do/run` | Run container locally on port 8080 |
+| `./do/test` | Test local container or deployed endpoint |
+| `./do/deploy` | Deploy to the configured deployment target |
+| `./do/logs` | Tail logs (CloudWatch for managed-inference, kubectl for HyperPod) |
+| `./do/clean <target>` | Clean up resources (local, ecr, endpoint/hyperpod, codebuild, all) |
+| `./do/export` | Export current configuration as a reproducible `yo` CLI command |
+| `./do/submit` | Submit build to AWS CodeBuild (CodeBuild build target only) |
+
+Configuration for all scripts is centralized in `do/config`. See the generated `do/README.md` for detailed documentation on each command.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -105,7 +105,7 @@ Run the generator using the `yo` command and selecting the generator from the pr
 ✔ Test type? local-model-cli, local-model-server, hosted-model-endpoint
 
 💪 Infrastructure & Performance
-✔ Deployment target? sagemaker
+✔ Deployment target? managed-inference
 ✔ Instance type? CPU-optimized (ml.m6g.large)
 ✔ Target AWS region? us-east-1
 ✔ AWS IAM Role ARN for SageMaker execution (optional)? <IAM ROLE>
@@ -171,9 +171,20 @@ scikit-test-project/
 │   └── flask/                  # Flask-specific code
 |       ├── gunicorn_config.py    # Gunicorn Config (Flask only)
 |       └── wsgi.py               # Creates Flask app
-├── deploy/
-│   ├── build_and_push.sh  # Build and push to ECR
-│   └── deploy.sh          # Deploy to SageMaker
+├── do/                    # do-framework lifecycle scripts
+│   ├── config             # Centralized configuration
+│   ├── build              # Build Docker image
+│   ├── push               # Push to Amazon ECR
+│   ├── deploy             # Deploy to SageMaker
+│   ├── run                # Run container locally
+│   ├── test               # Test container or endpoint
+│   ├── clean              # Clean up resources
+│   ├── logs               # Tail deployment logs
+│   ├── export             # Export config as CLI command
+│   └── README.md          # Detailed documentation
+├── deploy/                # Legacy scripts (deprecated)
+│   ├── build_and_push.sh  # Use ./do/build && ./do/push instead
+│   └── deploy.sh          # Use ./do/deploy instead
 └── test/
     ├── test_endpoint.sh       # Test hosted endpoint
     ├── test_local_image.sh    # Test local container
@@ -283,100 +294,95 @@ We will come back to this once we deploy the model in the next step.
 #### 5.1: Build and Push to ECR
 
 ```bash
-# Build and push Docker image to ECR
-(base) frgud@842f5776eab6 scikit-test-project % ./deploy/build_and_push.sh
-Building Docker image for project: scikit-test-project...
-[+] Building 0.3s (21/21) 
+# Build Docker image
+(base) frgud@842f5776eab6 scikit-test-project % ./do/build
+🚀 Building Docker image for scikit-test-project
+   Deployment config: sklearn-flask
+   Framework: sklearn
+   Model server: flask
+🏗️  Building CPU-optimized image...
 ...
-View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/uz31052ank7nn4xgmv2pltmm1
-Logging into ECR...
+✅ Build complete!
+   Image: scikit-test-project:latest
+   Tagged: scikit-test-project:20260129-175045
 
-WARNING! Your credentials are stored unencrypted in '/Users/frgud/.docker/config.json'.
-Configure a credential helper to remove this warning. See
-https://docs.docker.com/go/credential-store/
+Next steps:
+  • Test locally: ./do/run
+  • Push to ECR: ./do/push
+  • Deploy to SageMaker: ./do/deploy
 
-Login Succeeded
-📦 Checking ECR repository...
-{
-    "repositories": [
-        {
-            "repositoryArn": "<REPOSITORY_ARN>",
-            "registryId": "<REGISTRY_ID>",
-            "repositoryName": "ml-container-creator",
-            "repositoryUri": "<ECR_URI>/ml-container-creator",
-            "createdAt": "2025-10-29T22:02:34.906000-04:00",
-            "imageTagMutability": "MUTABLE",
-            "imageScanningConfiguration": {
-                "scanOnPush": false
-            },
-            "encryptionConfiguration": {
-                "encryptionType": "AES256"
-            }
-        }
-    ]
-}
-Pushing images to ECR repository: ml-container-creator...
-The push refers to repository [<ECR_URI>/ml-container-creator]
-...
-✅ Images successfully pushed to ECR:
-  - <ECR_URI>:scikit-test-project-20260129-175045 (timestamped build)
-  - <ECR_URI>:scikit-test-project-latest (project latest)
-  - <ECR_URI>:latest (global latest)
-(base) frgud@842f5776eab6 scikit-test-project % 
+# Push to ECR
+(base) frgud@842f5776eab6 scikit-test-project % ./do/push
+🚀 Pushing Docker image to Amazon ECR
+   Project: scikit-test-project
+   Region: us-east-1
+   Repository: ml-container-creator
+🔍 Validating AWS credentials...
+✅ AWS credentials validated (Account: <ACCOUNT_NO>)
+🔐 Authenticating with Amazon ECR...
+✅ ECR authentication successful
+✅ ECR repository exists
+🏷️  Tagging images for ECR...
+📤 Pushing images to ECR...
+✅ Push complete!
+
+📦 Pushed image URIs:
+   <ECR_URI>/ml-container-creator:latest
+   <ECR_URI>/ml-container-creator:scikit-test-project-latest
+   <ECR_URI>/ml-container-creator:scikit-test-project-20260129-175045
 ```
 
 #### 5.2: Deploy to SageMaker AI
 ```bash
-(base) frgud@842f5776eab6 scikit-test-project % ./deploy/deploy.sh 
-Using configured execution role: <EXECUTION_ROLE_ARN>
-🚀 Deploying locally built image to SageMaker...
-Pulling image from ECR...
-latest: Pulling from ml-container-creator
-Digest: <IMAGE_DIGEST>
-Status: Image is up to date for <ECR_URI>/ml-container-creator:latest
-<ECR_URI>/ml-container-creator:latest
-Creating SageMaker model: scikit-test-project-model-1769727239
-{
-    "ModelArn": "arn:aws:sagemaker:us-east-1:<ACCOUNT_NO>:model/scikit-test-project-model-1769727239"
-}
-Creating endpoint configuration: scikit-test-project-endpoint-config-1769727239
-{
-    "EndpointConfigArn": "arn:aws:sagemaker:us-east-1:<ACCOUNT_NO>:endpoint-config/<ENDPOINT_CONFIG_NAME>"
-}
-Creating endpoint: <ENDPOINT_NAME>
-{
-    "EndpointArn": "arn:aws:sagemaker:us-east-1:<ACCOUNT_NO>:endpoint/<ENDPOINT_NAME>"
-}
-Waiting for endpoint to be in service...
-Deployment complete!
-Endpoint name: <ENDPOINT_NAME>
-You can test the endpoint with:
-./test_endpoint.sh <ENDPOINT_NAME>
-(base) frgud@842f5776eab6 scikit-test-project % 
+(base) frgud@842f5776eab6 scikit-test-project % ./do/deploy
+🚀 Deploying to AWS
+   Project: scikit-test-project
+   Deployment config: sklearn-flask
+   Region: us-east-1
+   Build target: local
+   Deployment target: managed-inference
+   Instance type: ml.m6g.large
+🔍 Validating AWS credentials...
+✅ AWS credentials validated (Account: <ACCOUNT_NO>)
+🔍 Verifying ECR image exists...
+✅ ECR image found: <ECR_URI>/ml-container-creator:scikit-test-project-latest
+⚙️  Creating endpoint configuration: scikit-test-project-epc-<TIMESTAMP>
+✅ Endpoint configuration created
+🚀 Creating endpoint: scikit-test-project-endpoint-<TIMESTAMP>
+✅ Endpoint creation initiated
+⏳ Waiting for endpoint to reach InService status...
+✅ Endpoint is InService
+📦 Creating inference component: scikit-test-project-ic-<TIMESTAMP>
+⏳ Waiting for inference component to reach InService status...
+✅ Deployment complete!
+
+📋 Deployment Details:
+   Endpoint: scikit-test-project-endpoint-<TIMESTAMP>
+   Inference Component: scikit-test-project-ic-<TIMESTAMP>
+   Region: us-east-1
+   Instance Type: ml.m6g.large
+
+🧪 Test your endpoint:
+   ./do/test
 ```
 
 #### 5.3: Test the Endpoint
 
 ```bash
-(base) frgud@842f5776eab6 scikit-test-project % ./test/test_endpoint.sh <ENDPOINT_NAME>
-Testing SageMaker endpoint: <ENDPOINT_NAME>
-Checking endpoint status...
-InService
-Testing inference endpoint...
-{
-    "ContentType": "application/json",
-    "InvokedProductionVariant": "primary"
-}
-Response:
-{
-  "predictions": [
-    12.86
-  ]
-}
+(base) frgud@842f5776eab6 scikit-test-project % ./do/test
+🧪 Testing SageMaker endpoint: scikit-test-project-endpoint-<TIMESTAMP>
 
-Cleaning up files...
-Test complete!
-(base) frgud@842f5776eab6 scikit-test-project % 
+🔍 Test 1: Health check
+   Checking endpoint status...
+✅ Endpoint is InService
+
+🔍 Test 2: Inference request
+   Payload: Sample feature vector
+   Invoking SageMaker endpoint...
+✅ Inference request successful
+   Response preview: {"predictions": [12.86]}
+
+✅ All tests passed!
 ```
 
 ## Generative AI
@@ -458,10 +464,19 @@ sglang-gptoss-test/
     ├── code/
     │   ├── serve                     # Shell entrypoint script that launches SGLang server
     │   └── serving.properties        # SGLang server configuration (model ID, port, etc.)
-    ├── deploy/
-    │   ├── deploy.sh                 # Creates SageMaker model and endpoint
-    │   ├── submit_build.sh           # Triggers CodeBuild to build and push Docker image
-    │   └── upload_to_s3.sh           # Uploads model artifacts to S3 (if needed)
+    ├── do/                           # do-framework lifecycle scripts
+    │   ├── config                    # Centralized configuration
+    │   ├── build                     # Build Docker image
+    │   ├── push                      # Push to Amazon ECR
+    │   ├── deploy                    # Deploy to SageMaker
+    │   ├── test                      # Test container or endpoint
+    │   ├── clean                     # Clean up resources
+    │   ├── logs                      # Tail deployment logs
+    │   ├── export                    # Export config as CLI command
+    │   └── submit                    # Submit build to CodeBuild
+    ├── deploy/                       # Legacy scripts (deprecated)
+    │   ├── deploy.sh                 # Use ./do/deploy instead
+    │   └── submit_build.sh           # Use ./do/submit instead
     └── test/
         └── test_endpoint.sh          # Tests the deployed SageMaker endpoint with sample requests
 ```
@@ -469,8 +484,8 @@ sglang-gptoss-test/
 The transformer based projects used managed containers from framework providers to build the final container. These containers take significantly longer to build given how large they are. It is recommended to use AWS CodeBuild for transformer-based containers. Building with AWS CodeBuild helps reduce the likelihood of architecture mismatches as well.
 
 ```bash
-(base) frgud@842f5776eab6 sglang-gptoss-test % ./deploy/submit_build.sh 
-🏗️  Submitting CodeBuild job...
+(base) frgud@842f5776eab6 sglang-gptoss-test % ./do/submit
+🚀 Submitting CodeBuild job for sglang-gptoss-test
 Project: sglang-gptoss-test-llm-build-20260129
 Region: us-east-1
 Compute Type: BUILD_GENERAL1_MEDIUM
@@ -532,8 +547,8 @@ Build started with ID: sglang-gptoss-test-llm-build-20260129:e49cb662-7e0a-485d-
 🐳 Docker image available at: <ACCOUNT_NO>.dkr.ecr.us-east-1.amazonaws.com/ml-container-creator:latest
 
 Next steps:
-  1. Run './deploy/deploy.sh' to deploy to SageMaker
-  2. Or use the ECR image URI in your own deployment process
+  • Deploy to SageMaker: ./do/deploy
+  • Or use the ECR image URI in your own deployment process
 (base) frgud@842f5776eab6 sglang-gptoss-test % 
 ```
 
@@ -542,45 +557,54 @@ Transformer based containers typically require GPU to successfully deploy. Take 
 
 #### 3.1: Deploy
 ```bash
-(base) frgud@842f5776eab6 sglang-gptoss-test % ./deploy/deploy.sh 
-Using configured execution role: <ROLE_ARN>
-🚀 Deploying CodeBuild-generated image to SageMaker...
+(base) frgud@842f5776eab6 sglang-gptoss-test % ./do/deploy
+🚀 Deploying to AWS
+   Project: sglang-gptoss-test
+   Deployment config: transformers-sglang
+   Region: us-east-1
+   Build target: codebuild
+   Deployment target: managed-inference
+   Instance type: ml.g6.12xlarge
+🔍 Validating AWS credentials...
+✅ AWS credentials validated (Account: <ACCOUNT_NO>)
 🔍 Verifying ECR image exists...
-✅ ECR image found: <ACCOUNT_NO>.dkr.ecr.us-east-1.amazonaws.com/ml-container-creator:latest
-Creating SageMaker model: sglang-gptoss-test-model-1769729378
-{
-    "ModelArn": "arn:aws:sagemaker:us-east-1:<ACCOUNT_NO>:model/sglang-gptoss-test-model-1769729378"
-}
-Creating endpoint configuration: sglang-gptoss-test-endpoint-config-1769729378
-{
-    "EndpointConfigArn": "arn:aws:sagemaker:us-east-1:<ACCOUNT_NO>:endpoint-config/<ENDPOINT_CONFIG_NAME>"
-}
-Creating endpoint: sglang-gptoss-test-endpoint-1769729378
-{
-    "EndpointArn": "arn:aws:sagemaker:us-east-1:<ACCOUNT_NO>:endpoint/<ENDPOINT_NAME>"
-}
-Waiting for endpoint to be in service...
-Deployment complete!
-Endpoint name: <ENDPOINT_NAME>
-You can test the endpoint with:
-./test_endpoint.sh <ENDPOINT_NAME> openai/gpt-oss-20b
-(base) frgud@842f5776eab6 sglang-gptoss-test % 
+✅ ECR image found: <ACCOUNT_NO>.dkr.ecr.us-east-1.amazonaws.com/ml-container-creator:sglang-gptoss-test-latest
+⚙️  Creating endpoint configuration: sglang-gptoss-test-epc-<TIMESTAMP>
+✅ Endpoint configuration created
+🚀 Creating endpoint: sglang-gptoss-test-endpoint-<TIMESTAMP>
+✅ Endpoint creation initiated
+⏳ Waiting for endpoint to reach InService status...
+✅ Endpoint is InService
+📦 Creating inference component: sglang-gptoss-test-ic-<TIMESTAMP>
+⏳ Waiting for inference component to reach InService status...
+   This may take 5-10 minutes...
+✅ Deployment complete!
+
+📋 Deployment Details:
+   Endpoint: sglang-gptoss-test-endpoint-<TIMESTAMP>
+   Inference Component: sglang-gptoss-test-ic-<TIMESTAMP>
+   Region: us-east-1
+   Instance Type: ml.g6.12xlarge
+
+🧪 Test your endpoint:
+   ./do/test
 ```
 
-#### 3.1: Test
+#### 3.2: Test
 ```bash
-(base) frgud@842f5776eab6 sglang-gptoss-test % ./test/test_endpoint.sh <ENDPOINT_NAME> openai/gpt-oss-20b
+(base) frgud@842f5776eab6 sglang-gptoss-test % ./do/test
 
-Testing SageMaker endpoint: <ENDPOINT_NAME>
-Checking endpoint status...
-InService
-Testing inference endpoint...
-{
-    "ContentType": "application/json",
-    "InvokedProductionVariant": "primary"
-}
-Response:
-{
+🧪 Testing SageMaker endpoint: sglang-gptoss-test-endpoint-<TIMESTAMP>
+
+🔍 Test 1: Health check
+   Checking endpoint status...
+✅ Endpoint is InService
+
+🔍 Test 2: Inference request
+   Payload: OpenAI-compatible chat completion request
+   Invoking SageMaker endpoint...
+✅ Inference request successful
+   Response preview: {
   "id": "5e7ce6ccc0f04cb8abd320b27b508ff5",
   "object": "chat.completion",
   "created": 1769730729,
@@ -611,9 +635,11 @@ Response:
   }
 }
 
-Cleaning up files...
-Test complete!
-(base) frgud@842f5776eab6 sglang-gptoss-test % 
+✅ All tests passed!
+
+Endpoint is ready for production use!
+  • Endpoint name: sglang-gptoss-test-endpoint-<TIMESTAMP>
+  • Region: us-east-1
 ```
 
 ## Configuration Options
@@ -660,17 +686,22 @@ For complete configuration documentation, see the [Configuration Guide](configur
 
 ## Cleanup
 
-To avoid ongoing charges, delete your SageMaker endpoint:
+To avoid ongoing charges, use the `do/clean` script to tear down all deployed resources:
 
 ```bash
-# Delete endpoint
-aws sagemaker delete-endpoint --endpoint-name <ENDPOINT_NAME>
+# Delete SageMaker endpoint, inference component, and endpoint configuration
+./do/clean endpoint
 
-# Delete endpoint configuration
-aws sagemaker delete-endpoint-config --endpoint-config-name <ENDPOINT_CONFIG_NAME>
+# Or clean everything (local images, ECR images, endpoint, CodeBuild)
+./do/clean all
+```
 
-# Delete model
-aws sagemaker delete-model --model-name <MODEL_NAME>
+You can also clean individual resource types:
+
+```bash
+./do/clean local      # Remove local Docker images
+./do/clean ecr        # Remove images from Amazon ECR
+./do/clean codebuild  # Delete CodeBuild project and IAM role
 ```
 
 <!-- ## Next Steps

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -16,7 +16,7 @@ MCC is built to assist customers in standardizing and simplifying the  technical
 
 While these decisions seem independent, they become interrelated as you consider approaches to containerizing and customizing models. Moreover, each decision is an inflexion point that influences the technical assets used in deployment, such as Dockerfiles or start-up scripts for serving. 
 
-MCC provides users with a standard interface for building and deploying these technical assets. This is accomplished using templated assets that accommodate a growing list of options. Actions can be taken using standardized scripts built in a manner reminiscent of the [do-framework](https://github.com/iankoulski/do-framework). 
+MCC provides users with a standard interface for building and deploying these technical assets. This is accomplished using templated assets that accommodate a growing list of options. Actions can be taken using standardized `do/` scripts inspired by the [do-framework](https://github.com/iankoulski/do-framework). MCC adapts the do-framework conventions into a `do/` subdirectory with scripts like `build`, `push`, `run`, `test`, `deploy`, `clean`, `logs`, and `export`, and extends the pattern with AWS-specific lifecycle commands for SageMaker deployment.
 
 MCC started as a [Yeoman Generator](https://yeoman.io/), allowing users to generate containerized deployment assets using a decision-tree style REPL. This is an easy way to understand the generation flow, though not the only way to interact with MCC. Users can automate the generation of these assets using a CLI configured by environment variables, CLI flags, and configuration files.
 
@@ -55,14 +55,19 @@ For more information, check out the sections on supported [HTTP Servers](http-se
 
 ## Container Building
 
-MCC generates Docker containers that package everything needed to serve model inference requests over HTTP. The generated Dockerfile bundles the appropriate base image, application code (model handlers and web servers), configuration files, and dependencies. For traditional ML frameworks (scikit-learn, XGBoost, TensorFlow), model artifacts are included directly in the container. For transformer models, the container downloads models from HuggingFace Hub at runtime to keep image sizes manageable.
+MCC generates Docker containers that package everything needed to serve model inference requests over HTTP. The generated Dockerfile bundles the appropriate base image, application code (model handlers and web servers), configuration files, and dependencies. For traditional ML frameworks (scikit-learn, XGBoost, TensorFlow), model artifacts are included directly in the container. For transformer models, the container downloads models from HuggingFace Hub at runtime to keep image sizes manageable. For Triton Inference Server configurations, MCC generates the model repository structure, `config.pbtxt`, and backend-specific files.
 
-The build process follows a standard Docker workflow: build the image locally, push it to Amazon Elastic Container Registry (ECR), and deploy to SageMaker. MCC generates deployment scripts (`build_and_push.sh` and `deploy.sh`) that automate this entire process, handling AWS authentication, ECR repository creation, and SageMaker resource provisioning. The resulting container exposes SageMaker-compatible endpoints (`/ping` for health checks and `/invocations` for inference) on port 8080, ready for production deployment.
+The build process follows a standard Docker workflow managed by `do/` scripts: `./do/build` creates the image locally, `./do/push` uploads it to Amazon Elastic Container Registry (ECR), and `./do/deploy` provisions the deployment target. For CI/CD workflows, `./do/submit` handles building and pushing via AWS CodeBuild. The resulting container exposes SageMaker-compatible endpoints (`/ping` for health checks and `/invocations` for inference) on port 8080, ready for production deployment.
 
 
 For more information, check out the section on [Containerization](containerization.md).
 
 ### Endpoint Deployment
-Once an MCC container is built, it can be launched as a process. MCC is opinionated about deployment targets, building containers specifically designed to run on Amazon Sagemaker AI managed inference endpoints. Currently, these are real-time endpoints. 
+Once an MCC container is built, it can be launched as a process. MCC supports two deployment targets:
+
+- **Managed Inference** (`managed-inference`): Deploys to Amazon SageMaker AI managed inference endpoints using the Inference Components API. This is the default target and supports real-time inference.
+- **HyperPod EKS** (`hyperpod-eks`): Deploys to an existing SageMaker HyperPod cluster running on Amazon EKS using Kubernetes manifests.
+
+Both targets are managed through the `./do/deploy` script. After deployment, `./do/test` validates the endpoint, `./do/logs` tails deployment logs, and `./do/clean` tears down resources.
 
 For more information, check out the deployment deep-dive on the [Deployment & Inference](deployments.md) page.


### PR DESCRIPTION
Update 6 documentation files to reflect the current do-framework scripts, deployment config naming, and inference components API:

- Replace deploy/*.sh references with do/ script equivalents
- Update --framework/--model-server to --deployment-config/--engine
- Fix "sagemaker" deployment target to "managed-inference"
- Fix instance types from cpu-optimized/gpu-enabled to ml.* format
- Add missing CLI params (--deployment-target, --build-target, etc.)
- Add deployment configs reference table (all 14 configs incl. Triton)
- Document HyperPod EKS deployment target and parameters
- Update SageMaker flow for inference components API (3-step)
- Fix Node.js version requirement (18+ → 24+)
- Add do/logs, do/clean, do/export references

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
