### PR TITLE
feat: integrate model-picker MCP server into generator prompting flow

### DIFF
--- a/generators/app/lib/prompt-runner.js
+++ b/generators/app/lib/prompt-runner.js
@@ -30,8 +30,15 @@ import {
     formatImageChoices
 } from './prompts.js';
 
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'node:url';
 import instanceAcceleratorMapping from '../config/registries/instance-accelerator-mapping.js';
 import tritonBackends from '../config/registries/triton-backends.js';
+
+const __pr_filename = fileURLToPath(import.meta.url);
+const __pr_dirname = path.dirname(__pr_filename);
+const GENERATOR_ROOT = path.resolve(__pr_dirname, '..', '..', '..');
 
 export default class PromptRunner {
     constructor(generator) {
@@ -169,9 +176,22 @@ export default class PromptRunner {
             existingConfig
         );
         
+        // Query model-picker MCP server for model choices
+        this._queryMcpForModels()
+        if (this._mcpModelChoices) {
+            console.log(`   🔍 Querying model-picker...`)
+            console.log(`   ✓ ${this._mcpModelChoices.length} model(s) available from catalog`)
+        }
+        const modelFormatPreviousAnswers = {
+            ...frameworkAnswers,
+            ...engineAnswers,
+            ...frameworkVersionAnswers,
+            ...frameworkProfileAnswers,
+            ...(this._mcpModelChoices ? { _mcpModelChoices: this._mcpModelChoices } : {})
+        }
         const modelFormatAnswers = await this._runPhase(
             modelFormatPrompts, 
-            {...frameworkAnswers, ...engineAnswers, ...frameworkVersionAnswers, ...frameworkProfileAnswers}, 
+            modelFormatPreviousAnswers, 
             explicitConfig, 
             existingConfig
         );
@@ -632,6 +652,54 @@ export default class PromptRunner {
     }
 
     /**
+     * Query model-picker MCP server catalog for model choices.
+     * Reads the popular-models.json catalog to populate the model selection prompt.
+     * @private
+     */
+    _queryMcpForModels() {
+        const cm = this.configManager
+        if (!cm) return
+
+        const mcpServers = cm.getMcpServerNames()
+        if (!mcpServers.includes('model-picker')) return
+
+        try {
+            const mcpConfigPath = path.join(GENERATOR_ROOT, 'config', 'mcp.json')
+            if (!fs.existsSync(mcpConfigPath)) return
+
+            const mcpConfig = JSON.parse(fs.readFileSync(mcpConfigPath, 'utf8'))
+            const serverConfig = mcpConfig.mcpServers?.['model-picker']
+            if (!serverConfig?.args?.length) return
+
+            // Resolve the server entry point directory from the args
+            const serverEntryPoint = serverConfig.args[serverConfig.args.length - 1]
+            const serverDir = path.dirname(serverEntryPoint)
+
+            // Read manifest to find catalog path
+            const manifestPath = path.join(serverDir, 'manifest.json')
+            if (!fs.existsSync(manifestPath)) return
+
+            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+            const catalogRelPath = manifest.catalogs?.['popular-models']
+            if (!catalogRelPath) return
+
+            const catalogPath = path.resolve(serverDir, catalogRelPath)
+            if (!fs.existsSync(catalogPath)) return
+
+            const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'))
+
+            // Extract model IDs, filtering out glob patterns (entries with *)
+            const modelIds = Object.keys(catalog).filter(id => !id.includes('*'))
+
+            if (modelIds.length > 0) {
+                this._mcpModelChoices = modelIds
+            }
+        } catch {
+            // Silently fall back to hardcoded defaults
+        }
+    }
+
+    /**
      * Get framework version choices from registry
      * Requirements: 2.1, 2.6, 8.2, 8.3
      * @private
@@ -801,85 +869,166 @@ export default class PromptRunner {
      * @private
      */
     async _fetchAndDisplayModelInfo(modelId) {
-        const registryConfigManager = this.generator.registryConfigManager;
-        
-        if (!registryConfigManager) {
-            return;
-        }
-        
-        console.log(`\n🔍 Fetching model information for: ${modelId}`);
-        
-        const sources = [];
-        let chatTemplate = null;
-        let modelFamily = null;
-        
-        // Try HuggingFace API first
-        try {
-            const hfData = await registryConfigManager._fetchHuggingFaceData(modelId);
-            if (hfData) {
-                sources.push('HuggingFace_Hub_API');
-                if (hfData.chatTemplate) {
-                    chatTemplate = hfData.chatTemplate;
+            console.log(`\n   🔍 Querying model-picker [discover]...`);
+
+            const sources = [];
+            let chatTemplate = null;
+            let modelFamily = null;
+            let mcpUsed = false;
+
+            // Try model-picker MCP server in discover mode (queries HuggingFace + merges with catalog)
+            const cm = this.configManager;
+            if (cm) {
+                const mcpServers = cm.getMcpServerNames();
+                if (mcpServers.includes('model-picker')) {
+                    try {
+                        const mcpConfigPath = path.join(GENERATOR_ROOT, 'config', 'mcp.json');
+                        if (fs.existsSync(mcpConfigPath)) {
+                            const mcpConfig = JSON.parse(fs.readFileSync(mcpConfigPath, 'utf8'));
+                            const serverConfig = mcpConfig.mcpServers?.['model-picker'];
+                            if (serverConfig) {
+                                const { McpClient } = await import('./mcp-client.js');
+                                const client = new McpClient(serverConfig, { timeout: 15000 });
+
+                                // Override _buildContext to pass model_id and mode directly
+                                client._getUnboundedParameterNames = () => [];
+                                client._buildContext = () => ({});
+
+                                // Connect and call get_models directly
+                                const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+                                const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
+
+                                const transport = new StdioClientTransport({
+                                    command: serverConfig.command,
+                                    args: serverConfig.args || [],
+                                    env: { ...process.env, ...(serverConfig.env || {}) },
+                                    stderr: 'pipe'
+                                });
+
+                                const mcpClient = new Client(
+                                    { name: 'ml-container-creator', version: '1.0.0' },
+                                    { capabilities: {} }
+                                );
+
+                                await mcpClient.connect(transport);
+
+                                const result = await mcpClient.callTool({
+                                    name: 'get_models',
+                                    arguments: { model_id: modelId, mode: 'discover' }
+                                });
+
+                                await mcpClient.close();
+
+                                // Parse the response
+                                const textBlock = result?.content?.find(b => b.type === 'text');
+                                if (textBlock) {
+                                    const parsed = JSON.parse(textBlock.text);
+                                    if (parsed.values && Object.keys(parsed.values).length > 0) {
+                                        mcpUsed = true;
+                                        const vals = parsed.values;
+
+                                        if (vals.chat_template) {
+                                            chatTemplate = vals.chat_template;
+                                        }
+                                        if (vals.family) {
+                                            modelFamily = vals.family;
+                                        }
+
+                                        // Determine sources based on what was returned
+                                        if (vals.tags || vals.pipeline_tag) {
+                                            sources.push('HuggingFace_Hub_API');
+                                        }
+                                        if (vals.validation_level || vals.framework_compatibility) {
+                                            sources.push('Model_Picker_Catalog');
+                                        }
+                                        if (sources.length === 0) {
+                                            sources.push('model-picker');
+                                        }
+                                        console.log(`   ✓ Resolved: ${modelId}`);
+                                    } else if (parsed.message) {
+                                        console.log(`   ↳ ${parsed.message}`);
+                                    }
+                                }
+                            }
+                        }
+                    } catch (err) {
+                        console.log('   ↳ model-picker unavailable, using fallback');
+                    }
                 }
-                console.log('   ✅ Found on HuggingFace Hub');
-            } else {
-                console.log('   ℹ️  Not found on HuggingFace Hub (may be private or offline)');
             }
-        } catch (error) {
-            console.log('   ⚠️  HuggingFace API unavailable');
-        }
-        
-        // Check Model Registry for overrides
-        if (registryConfigManager.modelRegistry) {
-            let modelConfig = registryConfigManager.modelRegistry[modelId];
-            
-            // Try pattern matching if no exact match
-            if (!modelConfig) {
-                for (const [pattern, config] of Object.entries(registryConfigManager.modelRegistry)) {
-                    if (pattern.includes('*')) {
-                        const regex = new RegExp(`^${  pattern.replace(/\*/g, '.*')  }$`);
-                        if (regex.test(modelId)) {
-                            modelConfig = config;
-                            console.log(`   ✅ Matched pattern in Model_Registry: ${pattern}`);
-                            break;
+
+            // Fallback to legacy path if MCP didn't resolve
+            if (!mcpUsed) {
+                const registryConfigManager = this.generator.registryConfigManager;
+                if (registryConfigManager) {
+                    // Try HuggingFace API directly
+                    try {
+                        const hfData = await registryConfigManager._fetchHuggingFaceData(modelId);
+                        if (hfData) {
+                            sources.push('HuggingFace_Hub_API');
+                            if (hfData.chatTemplate) {
+                                chatTemplate = hfData.chatTemplate;
+                            }
+                            console.log('   ✅ Found on HuggingFace Hub');
+                        } else {
+                            console.log('   ℹ️  Not found on HuggingFace Hub (may be private or offline)');
+                        }
+                    } catch (error) {
+                        console.log('   ⚠️  HuggingFace API unavailable');
+                    }
+
+                    // Check Model Registry for overrides
+                    if (registryConfigManager.modelRegistry) {
+                        let modelConfig = registryConfigManager.modelRegistry[modelId];
+
+                        if (!modelConfig) {
+                            for (const [pattern, config] of Object.entries(registryConfigManager.modelRegistry)) {
+                                if (pattern.includes('*')) {
+                                    const regex = new RegExp('^' + pattern.replace(/\*/g, '.*') + '$');
+                                    if (regex.test(modelId)) {
+                                        modelConfig = config;
+                                        console.log(`   ✅ Matched pattern in Model_Registry: ${pattern}`);
+                                        break;
+                                    }
+                                }
+                            }
+                        } else {
+                            console.log('   ✅ Found in Model_Registry');
+                        }
+
+                        if (modelConfig) {
+                            sources.push('Model_Registry');
+                            if (modelConfig.chatTemplate) {
+                                chatTemplate = modelConfig.chatTemplate;
+                            }
+                            if (modelConfig.family) {
+                                modelFamily = modelConfig.family;
+                            }
                         }
                     }
                 }
-            } else {
-                console.log('   ✅ Found in Model_Registry');
             }
-            
-            if (modelConfig) {
-                sources.push('Model_Registry');
-                if (modelConfig.chatTemplate) {
-                    chatTemplate = modelConfig.chatTemplate; // Model registry overrides HF
+
+            // Display information
+            if (sources.length > 0) {
+                console.log('\n📋 Model Information:');
+                console.log(`   • Model ID: ${modelId}`);
+                if (modelFamily) {
+                    console.log(`   • Family: ${modelFamily}`);
                 }
-                if (modelConfig.family) {
-                    modelFamily = modelConfig.family;
+                if (chatTemplate) {
+                    console.log('   • Chat Template: ✅ Available');
+                    console.log('     (Will be injected into generated files)');
+                } else {
+                    console.log('   • Chat Template: ❌ Not available');
+                    console.log('     (Chat endpoints may require manual configuration)');
                 }
+                console.log(`   • Sources: ${sources.join(', ')}`);
+            } else {
+                console.log('   ℹ️  No additional model information available');
+                console.log('   Proceeding with default configuration');
             }
         }
-        
-        // Display information
-        if (sources.length > 0) {
-            console.log('\n📋 Model Information:');
-            console.log(`   • Model ID: ${modelId}`);
-            if (modelFamily) {
-                console.log(`   • Family: ${modelFamily}`);
-            }
-            if (chatTemplate) {
-                console.log('   • Chat Template: ✅ Available');
-                console.log('     (Will be injected into generated files)');
-            } else {
-                console.log('   • Chat Template: ❌ Not available');
-                console.log('     (Chat endpoints may require manual configuration)');
-            }
-            console.log(`   • Sources: ${sources.join(', ')}`);
-        } else {
-            console.log('   ℹ️  No additional model information available');
-            console.log('   Proceeding with default configuration');
-        }
-    }
 
 
 

--- a/generators/app/lib/prompts.js
+++ b/generators/app/lib/prompts.js
@@ -272,13 +272,25 @@ const modelFormatPrompts = [
         type: 'list',
         name: 'modelName',
         message: 'Which model do you want to use?',
-        choices: [
-            'openai/gpt-oss-20b',
-            'meta-llama/Llama-3.2-3B-Instruct',
-            'meta-llama/Llama-3.2-1B-Instruct',
-            'Custom (enter manually)'
-        ],
-        default: 'openai/gpt-oss-20b',
+        choices: (answers) => {
+            // Use MCP model-picker choices when available
+            if (answers._mcpModelChoices && answers._mcpModelChoices.length > 0) {
+                return [...answers._mcpModelChoices, 'Custom (enter manually)']
+            }
+            // Fallback to hardcoded defaults
+            return [
+                'openai/gpt-oss-20b',
+                'meta-llama/Llama-3.2-3B-Instruct',
+                'meta-llama/Llama-3.2-1B-Instruct',
+                'Custom (enter manually)'
+            ]
+        },
+        default: (answers) => {
+            if (answers._mcpModelChoices && answers._mcpModelChoices.length > 0) {
+                return answers._mcpModelChoices[0]
+            }
+            return 'openai/gpt-oss-20b'
+        },
         when: answers => {
             const architecture = answers.architecture || answers.deploymentConfig?.split('-')[0]
             const backend = answers.backend || answers.deploymentConfig?.split('-').slice(1).join('-')

--- a/servers/model-picker/catalogs/popular-models.json
+++ b/servers/model-picker/catalogs/popular-models.json
@@ -1,0 +1,154 @@
+{
+    "openai/gpt-oss-20b": {
+        "family": "gpt-oss",
+        "chat_template": "",
+        "gated": false,
+        "tags": ["text-generation", "openai", "conversational"],
+        "architecture": "GPT2LMHeadModel",
+        "framework_compatibility": {
+            "vllm": ">=0.3.0",
+            "tensorrt-llm": ">=0.8.0",
+            "sglang": ">=0.2.0"
+        },
+        "validation_level": "community-validated",
+        "notes": "Open-source 20B parameter model. Requires significant GPU memory for inference"
+    },
+    "meta-llama/Llama-2-7b-chat-hf": {
+        "family": "llama-2",
+        "chat_template": "{% for message in messages %}{% if message['role'] == 'system' %}{{ '[INST] <<SYS>>\\n' + message['content'] + '\\n<</SYS>>\\n\\n' }}{% elif message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ ' ' + message['content'] + ' ' }}{% endif %}{% endfor %}",
+        "gated": true,
+        "tags": ["text-generation", "llama-2", "conversational"],
+        "architecture": "LlamaForCausalLM",
+        "framework_compatibility": {
+            "vllm": ">=0.3.0",
+            "tensorrt-llm": ">=0.8.0",
+            "sglang": ">=0.2.0"
+        },
+        "validation_level": "tested",
+        "notes": "Llama-2 7B chat model with official chat template. Requires HuggingFace authentication for download"
+    },
+    "meta-llama/Llama-2-13b-chat-hf": {
+        "family": "llama-2",
+        "chat_template": "{% for message in messages %}{% if message['role'] == 'system' %}{{ '[INST] <<SYS>>\\n' + message['content'] + '\\n<</SYS>>\\n\\n' }}{% elif message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ ' ' + message['content'] + ' ' }}{% endif %}{% endfor %}",
+        "gated": true,
+        "tags": ["text-generation", "llama-2", "conversational"],
+        "architecture": "LlamaForCausalLM",
+        "framework_compatibility": {
+            "vllm": ">=0.3.0",
+            "tensorrt-llm": ">=0.8.0",
+            "sglang": ">=0.2.0"
+        },
+        "validation_level": "tested",
+        "notes": "Llama-2 13B chat model. Requires more GPU memory than 7B variant"
+    },
+    "meta-llama/Llama-2-70b-chat-hf": {
+        "family": "llama-2",
+        "chat_template": "{% for message in messages %}{% if message['role'] == 'system' %}{{ '[INST] <<SYS>>\\n' + message['content'] + '\\n<</SYS>>\\n\\n' }}{% elif message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ ' ' + message['content'] + ' ' }}{% endif %}{% endfor %}",
+        "gated": true,
+        "tags": ["text-generation", "llama-2", "conversational"],
+        "architecture": "LlamaForCausalLM",
+        "framework_compatibility": {
+            "vllm": ">=0.3.0",
+            "tensorrt-llm": ">=0.8.0",
+            "sglang": ">=0.2.0"
+        },
+        "validation_level": "community-validated",
+        "notes": "Llama-2 70B requires tensor parallelism across multiple GPUs"
+    },
+    "mistralai/Mistral-7B-Instruct-v0.1": {
+        "family": "mistral",
+        "chat_template": "{{ bos_token }}{% for message in messages %}{% if message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ message['content'] + eos_token }}{% endif %}{% endfor %}",
+        "gated": false,
+        "tags": ["text-generation", "mistral", "conversational"],
+        "architecture": "MistralForCausalLM",
+        "framework_compatibility": {
+            "vllm": ">=0.3.0",
+            "tensorrt-llm": ">=0.8.0",
+            "sglang": ">=0.2.0"
+        },
+        "validation_level": "tested",
+        "notes": "Mistral 7B v0.1 with 8K context window"
+    },
+    "mistralai/Mistral-7B-Instruct-v0.2": {
+        "family": "mistral",
+        "chat_template": "{{ bos_token }}{% for message in messages %}{% if message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ message['content'] + eos_token }}{% endif %}{% endfor %}",
+        "gated": false,
+        "tags": ["text-generation", "mistral", "conversational"],
+        "architecture": "MistralForCausalLM",
+        "framework_compatibility": {
+            "vllm": ">=0.3.0",
+            "tensorrt-llm": ">=0.8.0",
+            "sglang": ">=0.2.0"
+        },
+        "validation_level": "tested",
+        "notes": "Mistral 7B v0.2 with extended 32K context window. Requires more memory for long contexts"
+    },
+    "mistralai/Mixtral-8x7B-Instruct-v0.1": {
+        "family": "mistral",
+        "chat_template": "{{ bos_token }}{% for message in messages %}{% if message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ message['content'] + eos_token }}{% endif %}{% endfor %}",
+        "gated": false,
+        "tags": ["text-generation", "mistral", "mixture-of-experts"],
+        "architecture": "MixtralForCausalLM",
+        "framework_compatibility": {
+            "vllm": ">=0.3.0",
+            "tensorrt-llm": ">=0.8.0",
+            "sglang": ">=0.2.0"
+        },
+        "validation_level": "community-validated",
+        "notes": "Mixtral 8x7B MoE model. Requires tensor parallelism for efficient inference"
+    },
+    "meta-llama/Llama-2-*": {
+        "family": "llama-2",
+        "chat_template": "{% for message in messages %}{% if message['role'] == 'system' %}{{ '[INST] <<SYS>>\\n' + message['content'] + '\\n<</SYS>>\\n\\n' }}{% elif message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ ' ' + message['content'] + ' ' }}{% endif %}{% endfor %}",
+        "gated": true,
+        "tags": ["text-generation", "llama-2"],
+        "architecture": null,
+        "framework_compatibility": {
+            "vllm": ">=0.3.0",
+            "tensorrt-llm": ">=0.8.0",
+            "sglang": ">=0.2.0"
+        },
+        "validation_level": "experimental",
+        "notes": "Fallback for Llama-2 variants not explicitly listed"
+    },
+    "mistralai/Mistral-*": {
+        "family": "mistral",
+        "chat_template": "{{ bos_token }}{% for message in messages %}{% if message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ message['content'] + eos_token }}{% endif %}{% endfor %}",
+        "gated": false,
+        "tags": ["text-generation", "mistral"],
+        "architecture": null,
+        "framework_compatibility": {
+            "vllm": ">=0.3.0",
+            "tensorrt-llm": ">=0.8.0",
+            "sglang": ">=0.2.0"
+        },
+        "validation_level": "experimental",
+        "notes": "Fallback configuration for Mistral models not explicitly listed. Uses standard Mistral chat template"
+    },
+    "codellama/*": {
+        "family": "codellama",
+        "chat_template": "{% for message in messages %}{% if message['role'] == 'system' %}{{ '[INST] <<SYS>>\\n' + message['content'] + '\\n<</SYS>>\\n\\n' }}{% elif message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ ' ' + message['content'] + ' ' }}{% endif %}{% endfor %}",
+        "gated": false,
+        "tags": ["text-generation", "code", "codellama"],
+        "architecture": null,
+        "framework_compatibility": {
+            "vllm": ">=0.3.0",
+            "tensorrt-llm": ">=0.8.0"
+        },
+        "validation_level": "experimental",
+        "notes": "CodeLlama models use Llama-2 chat template. Optimized for code generation"
+    },
+    "tiiuae/falcon-*": {
+        "family": "falcon",
+        "chat_template": null,
+        "gated": false,
+        "tags": ["text-generation", "falcon"],
+        "architecture": null,
+        "framework_compatibility": {
+            "vllm": ">=0.3.0",
+            "tensorrt-llm": ">=0.8.0"
+        },
+        "validation_level": "experimental",
+        "notes": "Falcon models typically don't require chat templates for instruction following"
+    }
+}

--- a/servers/model-picker/index.js
+++ b/servers/model-picker/index.js
@@ -1,0 +1,445 @@
+#!/usr/bin/env node
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Model Picker MCP Server
+ *
+ * A bundled MCP server that returns model metadata for ML Container Creator.
+ * Supports two operating modes:
+ *   - Static: Returns metadata from a local popular-models.json catalog
+ *   - Discover: Queries HuggingFace Hub API for live metadata, merging with static catalog
+ *
+ * Uses a pluggable ModelResolver architecture. V1 ships with HuggingFaceResolver
+ * and StaticCatalogResolver.
+ *
+ * Tool: get_models
+ *   Accepts: { model_id: string, fields?: string[], mode?: string, context?: object }
+ *   Returns: { values, choices, message }
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { resolve, dirname } from 'node:path'
+import { DynamicResolver } from '../lib/dynamic-resolver.js'
+
+// ── Catalog loader ───────────────────────────────────────────────────────────
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+/**
+ * Load and parse a JSON catalog file relative to the server directory.
+ * Throws on missing file or invalid JSON with the file path in the message.
+ *
+ * @param {string} relativePath - Path relative to server dir (e.g. './catalogs/popular-models.json')
+ * @returns {any} Parsed JSON content
+ */
+function loadCatalog(relativePath) {
+    const fullPath = resolve(__dirname, relativePath)
+    let raw
+    try {
+        raw = readFileSync(fullPath, 'utf8')
+    } catch (err) {
+        throw new Error(`Catalog file not found: ${fullPath}`)
+    }
+    try {
+        return JSON.parse(raw)
+    } catch (err) {
+        throw new Error(`Failed to parse catalog ${fullPath}: ${err.message}`)
+    }
+}
+
+// ── ModelResolver interface ──────────────────────────────────────────────────
+
+/**
+ * ModelResolver — model-specific dynamic resolver.
+ *
+ * Extends DynamicResolver with model-specific method names (fetchModelMetadata,
+ * supportedPatterns) that delegate to the generic fetch/supportedKeys interface.
+ *
+ * Each resolver knows how to fetch metadata from a specific model source.
+ * The MCP server delegates to the appropriate resolver based on model ID pattern.
+ */
+class ModelResolver extends DynamicResolver {
+    /**
+     * Fetch metadata for a model ID.
+     * @param {string} modelId - e.g. 'meta-llama/Llama-2-7b-chat-hf'
+     * @param {object} options - { fields, limit, context }
+     * @returns {Promise<object|null>} Model metadata or null
+     */
+    async fetchModelMetadata(modelId, options = {}) {
+        throw new Error('fetchModelMetadata() must be implemented by subclass')
+    }
+
+    /**
+     * Returns glob patterns this resolver handles.
+     * @returns {string[]} e.g. ['hf:org/model'] for HuggingFace org/model pattern
+     */
+    supportedPatterns() {
+        throw new Error('supportedPatterns() must be implemented by subclass')
+    }
+
+    // ── DynamicResolver interface bridge ─────────────────────────────────
+
+    async fetch(key, options = {}) {
+        return this.fetchModelMetadata(key, options)
+    }
+
+    supportedKeys() {
+        return this.supportedPatterns()
+    }
+}
+
+
+// ── StaticCatalogResolver ────────────────────────────────────────────────────
+
+/**
+ * StaticCatalogResolver — fallback resolver.
+ *
+ * Returns model metadata from the popular-models.json catalog.
+ * No network calls, no auth, no external dependencies.
+ * Supports exact match and glob-style pattern matching.
+ */
+class StaticCatalogResolver extends ModelResolver {
+    constructor(catalog) {
+        super()
+        this._catalog = catalog
+    }
+
+    supportedPatterns() {
+        return ['*']
+    }
+
+    async fetchModelMetadata(modelId, options = {}) {
+        // Exact match first
+        if (this._catalog[modelId]) {
+            return { ...this._catalog[modelId] }
+        }
+
+        // Glob pattern match (e.g., 'meta-llama/Llama-2-*')
+        for (const [pattern, metadata] of Object.entries(this._catalog)) {
+            if (pattern.includes('*') || pattern.includes('?')) {
+                if (this._globMatch(modelId, pattern)) {
+                    return { ...metadata }
+                }
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * Match a string against a glob pattern.
+     * Converts * to .* and ? to . for regex matching.
+     *
+     * @param {string} str - The string to test
+     * @param {string} pattern - Glob pattern with * and ? wildcards
+     * @returns {boolean}
+     */
+    _globMatch(str, pattern) {
+        const regex = new RegExp(
+            '^' + pattern.replace(/\*/g, '.*').replace(/\?/g, '.') + '$'
+        )
+        return regex.test(str)
+    }
+}
+
+
+// ── HuggingFaceResolver ──────────────────────────────────────────────────────
+
+/**
+ * HuggingFaceResolver — fetches live model metadata from HuggingFace Hub API.
+ *
+ * Handles model IDs matching the org/model-name pattern. Queries three endpoints:
+ *   - /api/models/{modelId} — model info (always)
+ *   - /{modelId}/resolve/main/tokenizer_config.json — chat template (conditional)
+ *   - /{modelId}/resolve/main/config.json — architecture (conditional)
+ *
+ * All HTTP errors are non-fatal: returns null for affected fields and logs to stderr.
+ */
+class HuggingFaceResolver extends ModelResolver {
+    constructor(options = {}) {
+        super()
+        this.baseUrl = options.baseUrl || 'https://huggingface.co'
+        this.timeout = options.timeout || 5000
+    }
+
+    supportedPatterns() {
+        return ['hf:*/*']
+    }
+
+    async fetchModelMetadata(modelId, options = {}) {
+        const { fields } = options
+        const metadata = {}
+
+        // Fetch model info (always)
+        const modelInfo = await this._fetchJson(
+            `${this.baseUrl}/api/models/${modelId}`
+        )
+        if (modelInfo) {
+            metadata.tags = modelInfo.tags || []
+            metadata.gated = modelInfo.gated || false
+            metadata.pipeline_tag = modelInfo.pipeline_tag || null
+        }
+
+        // Fetch tokenizer config (conditional)
+        if (!fields || fields.includes('chat_template')) {
+            const tokenizerConfig = await this._fetchJson(
+                `${this.baseUrl}/${modelId}/resolve/main/tokenizer_config.json`
+            )
+            metadata.chat_template = tokenizerConfig?.chat_template || null
+        }
+
+        // Fetch model config (conditional)
+        if (!fields || fields.includes('architecture')) {
+            const modelConfig = await this._fetchJson(
+                `${this.baseUrl}/${modelId}/resolve/main/config.json`
+            )
+            metadata.architecture = modelConfig?.architectures?.[0] || null
+        }
+
+        return Object.keys(metadata).length > 0 ? metadata : null
+    }
+
+    /**
+     * Fetch JSON from a URL with timeout and error handling.
+     * Returns null on any error (429, 404, network, timeout).
+     *
+     * @param {string} url - URL to fetch
+     * @returns {Promise<object|null>}
+     */
+    async _fetchJson(url) {
+        const controller = new AbortController()
+        const timer = setTimeout(() => controller.abort(), this.timeout)
+        try {
+            const response = await fetch(url, { signal: controller.signal })
+            clearTimeout(timer)
+            if (response.status === 429) {
+                process.stderr.write(
+                    `[model-picker] Rate limited: ${url}\n`
+                )
+                return null
+            }
+            if (response.status === 404) return null
+            if (!response.ok) return null
+            return await response.json()
+        } catch (err) {
+            clearTimeout(timer)
+            process.stderr.write(
+                `[model-picker] Fetch failed: ${url} — ${err.message}\n`
+            )
+            return null
+        }
+    }
+}
+
+
+// ── ResolverRegistry ─────────────────────────────────────────────────────────
+
+/**
+ * ResolverRegistry — maps model ID patterns to their responsible ModelResolver.
+ *
+ * Each resolver is registered with a match function that determines whether
+ * it can handle a given model ID. The first matching resolver wins.
+ * A default resolver is used as fallback when no match function returns true.
+ */
+class ResolverRegistry {
+    constructor() {
+        this._resolvers = []
+        this._defaultResolver = null
+    }
+
+    /**
+     * Register a resolver with its match function.
+     * @param {ModelResolver} resolver
+     * @param {function(string): boolean} matchFn
+     */
+    register(resolver, matchFn) {
+        this._resolvers.push({ resolver, matchFn })
+    }
+
+    /**
+     * Set the fallback resolver used when no match function returns true.
+     * @param {ModelResolver} resolver
+     */
+    setDefault(resolver) {
+        this._defaultResolver = resolver
+    }
+
+    /**
+     * Get the resolver for a given model ID.
+     * @param {string} modelId
+     * @returns {ModelResolver|null}
+     */
+    getResolver(modelId) {
+        for (const { resolver, matchFn } of this._resolvers) {
+            if (matchFn(modelId)) return resolver
+        }
+        return this._defaultResolver
+    }
+}
+
+// ── Merge logic ──────────────────────────────────────────────────────────────
+
+/**
+ * Merge live API metadata with static catalog metadata.
+ * Live data takes precedence for non-null fields.
+ *
+ * @param {object|null} liveData - Metadata from live API (e.g. HuggingFace)
+ * @param {object|null} staticData - Metadata from static catalog
+ * @returns {object|null} Merged metadata, or null if both inputs are null
+ */
+function mergeMetadata(liveData, staticData) {
+    if (!liveData && !staticData) return null
+    if (!liveData) return { ...staticData }
+    if (!staticData) return { ...liveData }
+
+    // Shallow merge: live takes precedence for non-null fields
+    const merged = { ...staticData }
+    for (const [key, value] of Object.entries(liveData)) {
+        if (value !== null && value !== undefined) {
+            merged[key] = value
+        }
+    }
+    return merged
+}
+
+// ── Load catalog ─────────────────────────────────────────────────────────────
+
+let POPULAR_MODELS_CATALOG
+
+try {
+    POPULAR_MODELS_CATALOG = loadCatalog('./catalogs/popular-models.json')
+} catch (err) {
+    process.stderr.write(`[model-picker] Fatal: ${err.message}\n`)
+    process.exit(1)
+}
+
+// ── Wiring ───────────────────────────────────────────────────────────────────
+
+const staticResolver = new StaticCatalogResolver(POPULAR_MODELS_CATALOG)
+const hfResolver = new HuggingFaceResolver()
+const registry = new ResolverRegistry()
+
+registry.register(
+    hfResolver,
+    id => /^[^/]+\/[^/]+$/.test(id) && !id.includes('://')
+)
+registry.setDefault(staticResolver)
+
+// ── Tool handler ─────────────────────────────────────────────────────────────
+
+/**
+ * Handle a get_models tool call.
+ * Extracted as a standalone function so tests can call it directly.
+ *
+ * @param {object} params
+ * @param {string} params.model_id - Model identifier
+ * @param {string[]} [params.fields] - Metadata fields to return
+ * @param {string} [params.mode] - 'static' or 'discover'
+ * @param {object} [params.context] - Configuration context
+ * @returns {Promise<{content: Array}>} MCP response
+ */
+async function resolveModel({ model_id, fields, mode = 'discover', context }) {
+    let values = {}
+    let message = null
+
+    if (mode === 'static') {
+        // Static mode: use StaticCatalogResolver only
+        const metadata = await staticResolver.fetchModelMetadata(model_id, { fields })
+        if (metadata) {
+            values = { ...metadata }
+        } else {
+            message = `Model not found in static catalog: ${model_id}`
+        }
+    } else {
+        // Discover mode: use ResolverRegistry for live data, merge with static
+        const resolver = registry.getResolver(model_id)
+        let liveData = null
+
+        if (resolver) {
+            liveData = await resolver.fetchModelMetadata(model_id, { fields })
+        }
+
+        const staticData = await staticResolver.fetchModelMetadata(model_id, { fields })
+        const merged = mergeMetadata(liveData, staticData)
+
+        if (merged) {
+            values = { ...merged }
+        } else {
+            message = `Model not found: ${model_id}`
+        }
+    }
+
+    // Filter fields if specified
+    if (fields && fields.length > 0 && Object.keys(values).length > 0) {
+        const filtered = {}
+        for (const field of fields) {
+            if (field in values) {
+                filtered[field] = values[field]
+            }
+        }
+        values = filtered
+    }
+
+    return {
+        content: [{
+            type: 'text',
+            text: JSON.stringify({ values, choices: {}, message })
+        }]
+    }
+}
+
+// ── MCP Server ───────────────────────────────────────────────────────────────
+
+const server = new McpServer({
+    name: 'model-picker',
+    version: '1.0.0'
+})
+
+server.tool(
+    'get_models',
+    'Returns model metadata for ML Container Creator',
+    {
+        model_id: z.string().min(1).describe('Model identifier'),
+        fields: z.array(z.string()).optional().describe(
+            'Metadata fields to return (omit for all)'
+        ),
+        mode: z.enum(['static', 'discover']).optional().default('discover')
+            .describe('Operating mode'),
+        context: z.record(z.string(), z.any()).optional().describe(
+            'Current configuration context'
+        )
+    },
+    async (params) => resolveModel(params)
+)
+
+// ── Exports for testing ──────────────────────────────────────────────────────
+
+export {
+    loadCatalog,
+    ModelResolver,
+    StaticCatalogResolver,
+    HuggingFaceResolver,
+    ResolverRegistry,
+    mergeMetadata,
+    resolveModel,
+    staticResolver,
+    hfResolver,
+    registry,
+    POPULAR_MODELS_CATALOG
+}
+
+// ── Main guard ───────────────────────────────────────────────────────────────
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === __filename
+
+if (isMain) {
+    process.stderr.write('[model-picker] Starting model-picker MCP server\n')
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+}

--- a/servers/model-picker/manifest.json
+++ b/servers/model-picker/manifest.json
@@ -1,0 +1,16 @@
+{
+    "name": "@amzn/ml-container-creator-model-picker",
+    "version": "1.0.0",
+    "description": "MCP server that returns model metadata for ML Container Creator.",
+    "modes": {
+        "static": true,
+        "smart": false,
+        "discover": true
+    },
+    "catalogs": {
+        "popular-models": "./catalogs/popular-models.json"
+    },
+    "tool": {
+        "name": "get_models"
+    }
+}

--- a/servers/model-picker/package-lock.json
+++ b/servers/model-picker/package-lock.json
@@ -1,0 +1,1142 @@
+{
+    "name": "@amzn/ml-container-creator-model-picker",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@amzn/ml-container-creator-model-picker",
+            "version": "1.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@modelcontextprotocol/sdk": "^1.0.0"
+            }
+        },
+        "node_modules/@hono/node-server": {
+            "version": "1.19.11",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+            "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.14.1"
+            },
+            "peerDependencies": {
+                "hono": "^4"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk": {
+            "version": "1.27.1",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+            "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+            "license": "MIT",
+            "dependencies": {
+                "@hono/node-server": "^1.19.9",
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
+                "content-type": "^1.0.5",
+                "cors": "^2.8.5",
+                "cross-spawn": "^7.0.5",
+                "eventsource": "^3.0.2",
+                "eventsource-parser": "^3.0.0",
+                "express": "^5.2.1",
+                "express-rate-limit": "^8.2.1",
+                "hono": "^4.11.4",
+                "jose": "^6.1.3",
+                "json-schema-typed": "^8.0.2",
+                "pkce-challenge": "^5.0.0",
+                "raw-body": "^3.0.0",
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@cfworker/json-schema": "^4.1.1",
+                "zod": "^3.25 || ^4.0"
+            },
+            "peerDependenciesMeta": {
+                "@cfworker/json-schema": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/ajv": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-formats": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+            "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependencies": {
+                "ajv": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/body-parser": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^1.0.5",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.0",
+                "iconv-lite": "^0.7.0",
+                "on-finished": "^2.4.1",
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/content-disposition": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+            "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
+        },
+        "node_modules/cors": {
+            "version": "2.8.6",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+            "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+            "license": "MIT",
+            "dependencies": {
+                "object-assign": "^4",
+                "vary": "^1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
+        },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
+        },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/eventsource": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+            "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+            "license": "MIT",
+            "dependencies": {
+                "eventsource-parser": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/eventsource-parser": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+            "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/express": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express-rate-limit": {
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+            "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+            "license": "MIT",
+            "dependencies": {
+                "ip-address": "10.1.0"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
+            }
+        },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/finalhandler": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/hono": {
+            "version": "4.12.8",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+            "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
+        "node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
+        },
+        "node_modules/ip-address": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "license": "ISC"
+        },
+        "node_modules/jose": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+            "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
+        },
+        "node_modules/json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-to-regexp": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/pkce-challenge": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+            "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+            "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT"
+        },
+        "node_modules/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/type-is": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
+        },
+        "node_modules/zod": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+            "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-to-json-schema": {
+            "version": "3.25.1",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+            "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+            "license": "ISC",
+            "peerDependencies": {
+                "zod": "^3.25 || ^4"
+            }
+        }
+    }
+}

--- a/servers/model-picker/package.json
+++ b/servers/model-picker/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "@amzn/ml-container-creator-model-picker",
+    "private": true,
+    "version": "1.0.0",
+    "description": "MCP server that returns model metadata from HuggingFace Hub and a static catalog.",
+    "type": "module",
+    "main": "index.js",
+    "license": "Apache-2.0",
+    "scripts": {
+        "test": "node test.js"
+    },
+    "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0"
+    }
+}

--- a/test/servers/model-picker/model-picker.property.test.js
+++ b/test/servers/model-picker/model-picker.property.test.js
@@ -1,0 +1,632 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Model Picker Server Property-Based Tests
+ *
+ * Property-based tests for the model-picker MCP server, covering
+ * resolver routing, glob pattern matching, and metadata merge precedence.
+ *
+ * Feature: model-picker-mcp
+ */
+
+import fc from 'fast-check'
+import { describe, it } from 'mocha'
+import { strict as assert } from 'node:assert'
+import {
+    StaticCatalogResolver,
+    HuggingFaceResolver,
+    ResolverRegistry,
+    mergeMetadata,
+    resolveModel,
+    loadCatalog,
+    POPULAR_MODELS_CATALOG
+} from '../../../servers/model-picker/index.js'
+
+const FAST_PROPERTY_CONFIG = {
+    numRuns: 100,
+    timeout: 30000,
+    verbose: false
+}
+
+// ── Shared arbitrary generators ──────────────────────────────────────────────
+
+/** Generate a simple alphanumeric segment (no `/` or `://`) */
+const arbSegment = fc.stringMatching(/^[a-zA-Z0-9._-]{1,20}$/)
+
+/** Generate an org/model style ID (exactly one `/`, no `://`) */
+const arbOrgModel = fc.tuple(arbSegment, arbSegment)
+    .map(([org, model]) => `${org}/${model}`)
+
+/** Generate a string with a URI prefix (contains `://`) */
+const arbUriPrefixed = fc.tuple(
+    fc.stringMatching(/^[a-z]{1,10}$/),
+    arbSegment
+).map(([scheme, rest]) => `${scheme}://${rest}`)
+
+/** Generate a plain string with no `/` */
+const arbNoSlash = fc.stringMatching(/^[a-zA-Z0-9._-]{1,30}$/)
+
+/** Generate a string with multiple slashes (more than one `/`) */
+const arbMultiSlash = fc.tuple(arbSegment, arbSegment, arbSegment)
+    .map(([a, b, c]) => `${a}/${b}/${c}`)
+
+
+// ── Property tests ───────────────────────────────────────────────────────────
+
+describe('Model Picker Server Property-Based Tests', () => {
+
+    // Feature: model-picker-mcp, Property 1: Resolver routing correctness
+    // **Validates: Requirements 2.2, 2.3, 2.5, 4.1, 8.1**
+    describe('Property 1: Resolver routing correctness', () => {
+        let registry
+        let hfResolver
+        let staticResolver
+
+        beforeEach(() => {
+            hfResolver = new HuggingFaceResolver()
+            staticResolver = new StaticCatalogResolver({})
+            registry = new ResolverRegistry()
+            registry.register(
+                hfResolver,
+                id => /^[^/]+\/[^/]+$/.test(id) && !id.includes('://')
+            )
+            registry.setDefault(staticResolver)
+        })
+
+        it('routes org/model IDs (exactly one /, no ://) to HuggingFaceResolver', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.property(
+                arbOrgModel,
+                (modelId) => {
+                    const resolver = registry.getResolver(modelId)
+                    assert.strictEqual(resolver, hfResolver,
+                        `Expected HuggingFaceResolver for "${modelId}", got ${resolver === staticResolver ? 'StaticCatalogResolver' : 'unknown'}`)
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+
+        it('routes URI-prefixed IDs (containing ://) to StaticCatalogResolver', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.property(
+                arbUriPrefixed,
+                (modelId) => {
+                    const resolver = registry.getResolver(modelId)
+                    assert.strictEqual(resolver, staticResolver,
+                        `Expected StaticCatalogResolver for URI-prefixed "${modelId}", got HuggingFaceResolver`)
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+
+        it('routes IDs with no slash to StaticCatalogResolver', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.property(
+                arbNoSlash,
+                (modelId) => {
+                    const resolver = registry.getResolver(modelId)
+                    assert.strictEqual(resolver, staticResolver,
+                        `Expected StaticCatalogResolver for no-slash "${modelId}", got HuggingFaceResolver`)
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+
+        it('routes IDs with multiple slashes to StaticCatalogResolver', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.property(
+                arbMultiSlash,
+                (modelId) => {
+                    const resolver = registry.getResolver(modelId)
+                    assert.strictEqual(resolver, staticResolver,
+                        `Expected StaticCatalogResolver for multi-slash "${modelId}", got HuggingFaceResolver`)
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+    })
+
+    // Feature: model-picker-mcp, Property 4: Glob pattern matching correctness
+    // **Validates: Requirements 5.4**
+    describe('Property 4: Glob pattern matching correctness', () => {
+        const resolver = new StaticCatalogResolver({})
+
+        /**
+         * Reference regex implementation for glob matching.
+         * Converts * to .* and ? to . — same logic as _globMatch.
+         */
+        function referenceGlobMatch(str, pattern) {
+            const regex = new RegExp(
+                '^' + pattern.replace(/\*/g, '.*').replace(/\?/g, '.') + '$'
+            )
+            return regex.test(str)
+        }
+
+        /** Generate a simple string to test against patterns */
+        const arbTestString = fc.stringMatching(/^[a-zA-Z0-9/_.-]{0,30}$/)
+
+        /** Generate a glob pattern with * wildcards interspersed with literal segments */
+        const arbGlobPattern = fc.array(
+            fc.oneof(
+                fc.constant('*'),
+                fc.stringMatching(/^[a-zA-Z0-9._-]{1,8}$/)
+            ),
+            { minLength: 1, maxLength: 5 }
+        ).map(parts => parts.join(''))
+
+        it('_globMatch agrees with reference regex implementation for random (string, pattern) pairs', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.property(
+                arbTestString,
+                arbGlobPattern,
+                (str, pattern) => {
+                    const actual = resolver._globMatch(str, pattern)
+                    const expected = referenceGlobMatch(str, pattern)
+                    assert.strictEqual(actual, expected,
+                        `_globMatch("${str}", "${pattern}") returned ${actual}, expected ${expected}`)
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+
+        it('* pattern matches any string', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.property(
+                arbTestString,
+                (str) => {
+                    assert.strictEqual(resolver._globMatch(str, '*'), true,
+                        `_globMatch("${str}", "*") should be true`)
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+
+        it('exact literal pattern matches only itself', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            const arbLiteral = fc.stringMatching(/^[a-zA-Z0-9]{1,20}$/)
+
+            fc.assert(fc.property(
+                arbLiteral,
+                (literal) => {
+                    assert.strictEqual(resolver._globMatch(literal, literal), true,
+                        `_globMatch("${literal}", "${literal}") should be true`)
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+    })
+
+    // Feature: model-picker-mcp, Property 5: Metadata merge precedence
+    // **Validates: Requirements 3.5, 3.6, 9.1, 9.2, 9.3, 11.1**
+    describe('Property 5: Metadata merge precedence', () => {
+
+        /** Generate a nullable string field */
+        const arbNullableString = fc.oneof(
+            fc.constant(null),
+            fc.string({ minLength: 1, maxLength: 20 })
+        )
+
+        /** Generate a metadata object with nullable fields */
+        const arbMetadata = fc.record({
+            family: arbNullableString,
+            chat_template: arbNullableString,
+            architecture: arbNullableString,
+            validation_level: arbNullableString
+        })
+
+        /** Generate a nullable metadata object (null or object) */
+        const arbNullableMetadata = fc.oneof(
+            fc.constant(null),
+            arbMetadata
+        )
+
+        it('live non-null fields take precedence over static fields', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.property(
+                arbMetadata,
+                arbMetadata,
+                (live, staticData) => {
+                    const merged = mergeMetadata(live, staticData)
+                    for (const [key, value] of Object.entries(live)) {
+                        if (value !== null && value !== undefined) {
+                            assert.strictEqual(merged[key], value,
+                                `Live field "${key}" should take precedence: expected "${value}", got "${merged[key]}"`)
+                        }
+                    }
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+
+        it('static fills gaps when live field is null', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.property(
+                arbMetadata,
+                arbMetadata,
+                (live, staticData) => {
+                    const merged = mergeMetadata(live, staticData)
+                    for (const [key, value] of Object.entries(live)) {
+                        if (value === null || value === undefined) {
+                            // Static should fill the gap
+                            assert.strictEqual(merged[key], staticData[key],
+                                `Static field "${key}" should fill gap: expected "${staticData[key]}", got "${merged[key]}"`)
+                        }
+                    }
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+
+        it('both null returns null', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            const result = mergeMetadata(null, null)
+            assert.strictEqual(result, null, 'mergeMetadata(null, null) should return null')
+        })
+
+        it('null live returns static copy', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.property(
+                arbMetadata,
+                (staticData) => {
+                    const merged = mergeMetadata(null, staticData)
+                    assert.deepStrictEqual(merged, { ...staticData },
+                        'mergeMetadata(null, static) should return a copy of static')
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+
+        it('null static returns live copy', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.property(
+                arbMetadata,
+                (live) => {
+                    const merged = mergeMetadata(live, null)
+                    assert.deepStrictEqual(merged, { ...live },
+                        'mergeMetadata(live, null) should return a copy of live')
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+
+        it('merged result contains all keys from both inputs', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.property(
+                arbNullableMetadata,
+                arbNullableMetadata,
+                (live, staticData) => {
+                    const merged = mergeMetadata(live, staticData)
+                    if (!live && !staticData) {
+                        assert.strictEqual(merged, null)
+                        return true
+                    }
+                    const liveKeys = live ? Object.keys(live) : []
+                    const staticKeys = staticData ? Object.keys(staticData) : []
+                    const allKeys = new Set([...liveKeys, ...staticKeys])
+                    for (const key of allKeys) {
+                        assert.ok(key in merged,
+                            `Merged result should contain key "${key}"`)
+                    }
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+    })
+
+    // Feature: model-picker-mcp, Property 2: Static mode returns catalog data
+    // **Validates: Requirements 3.2, 5.3**
+    describe('Property 2: Static mode returns catalog data', () => {
+
+        /** Generate a simple model ID key */
+        const arbModelKey = fc.stringMatching(/^[a-zA-Z0-9._-]{1,15}\/[a-zA-Z0-9._-]{1,15}$/)
+
+        /** Generate a random metadata value (non-null string) */
+        const arbMetaValue = fc.string({ minLength: 1, maxLength: 30 })
+
+        /** Generate a random metadata object with at least one field */
+        const arbCatalogMetadata = fc.record({
+            family: arbMetaValue,
+            chat_template: fc.oneof(fc.constant(null), arbMetaValue),
+            architecture: fc.oneof(fc.constant(null), arbMetaValue),
+            gated: fc.boolean(),
+            tags: fc.array(arbMetaValue, { minLength: 0, maxLength: 3 }),
+            validation_level: fc.constantFrom('tested', 'community-validated', 'experimental')
+        })
+
+        it('returns metadata matching the catalog entry for any model in the catalog', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.asyncProperty(
+                arbModelKey,
+                arbCatalogMetadata,
+                async (modelId, metadata) => {
+                    const catalog = { [modelId]: metadata }
+                    const resolver = new StaticCatalogResolver(catalog)
+                    const result = await resolver.fetchModelMetadata(modelId)
+                    assert.deepStrictEqual(result, { ...metadata },
+                        `Static lookup for "${modelId}" should return exact catalog metadata`)
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+
+        it('returns metadata via resolveModel in static mode matching the catalog entry', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.asyncProperty(
+                arbModelKey,
+                arbCatalogMetadata,
+                async (modelId, metadata) => {
+                    // We test StaticCatalogResolver directly since resolveModel uses the global
+                    // staticResolver wired to popular-models.json. This validates the same code path.
+                    const catalog = { [modelId]: metadata }
+                    const resolver = new StaticCatalogResolver(catalog)
+                    const result = await resolver.fetchModelMetadata(modelId)
+                    assert.ok(result !== null, `Should find model "${modelId}" in catalog`)
+                    for (const [key, value] of Object.entries(metadata)) {
+                        assert.deepStrictEqual(result[key], value,
+                            `Field "${key}" should match catalog entry`)
+                    }
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+    })
+
+    // Feature: model-picker-mcp, Property 3: Static mode returns null for missing models
+    // **Validates: Requirements 3.3, 5.5**
+    describe('Property 3: Static mode returns null for missing models', () => {
+
+        /** A small fixed catalog to test against */
+        const fixedCatalog = {
+            'org-a/model-x': { family: 'test', gated: false },
+            'org-b/model-y': { family: 'test2', gated: true }
+        }
+        const fixedCatalogKeys = new Set(Object.keys(fixedCatalog))
+
+        /** Generate model IDs that definitely don't match the fixed catalog */
+        const arbMissingModelId = fc.stringMatching(/^[a-zA-Z0-9._-]{1,20}$/)
+            .filter(id => !fixedCatalogKeys.has(id))
+
+        it('returns null for any model ID not in the catalog', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            const resolver = new StaticCatalogResolver(fixedCatalog)
+
+            fc.assert(fc.asyncProperty(
+                arbMissingModelId,
+                async (modelId) => {
+                    const result = await resolver.fetchModelMetadata(modelId)
+                    assert.strictEqual(result, null,
+                        `Static lookup for missing model "${modelId}" should return null`)
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+
+        it('returns null for random IDs against an empty catalog', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            const emptyResolver = new StaticCatalogResolver({})
+
+            fc.assert(fc.asyncProperty(
+                fc.string({ minLength: 1, maxLength: 30 }),
+                async (modelId) => {
+                    const result = await emptyResolver.fetchModelMetadata(modelId)
+                    assert.strictEqual(result, null,
+                        `Empty catalog should return null for "${modelId}"`)
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+    })
+
+    // Feature: model-picker-mcp, Property 7: Response structure invariant
+    // **Validates: Requirements 7.7, 7.8**
+    describe('Property 7: Response structure invariant', () => {
+
+        /** Generate a random model ID */
+        const arbModelId = fc.oneof(
+            fc.stringMatching(/^[a-zA-Z0-9._-]{1,15}$/),
+            fc.stringMatching(/^[a-zA-Z0-9._-]{1,10}\/[a-zA-Z0-9._-]{1,10}$/)
+        )
+
+        /** Generate a random mode */
+        const arbMode = fc.constantFrom('static', 'discover')
+
+        /** Generate optional fields array */
+        const arbFields = fc.oneof(
+            fc.constant(undefined),
+            fc.array(
+                fc.constantFrom('family', 'chat_template', 'architecture', 'gated', 'tags', 'validation_level'),
+                { minLength: 0, maxLength: 4 }
+            )
+        )
+
+        it('response always contains content array with one text entry, and parsed JSON has values and choices', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.asyncProperty(
+                arbModelId,
+                arbMode,
+                arbFields,
+                async (modelId, mode, fields) => {
+                    const params = { model_id: modelId, mode }
+                    if (fields !== undefined) {
+                        params.fields = fields
+                    }
+                    const response = await resolveModel(params)
+
+                    // Response must have content array
+                    assert.ok(Array.isArray(response.content),
+                        'Response must have a content array')
+                    assert.strictEqual(response.content.length, 1,
+                        'Response content must have exactly one entry')
+
+                    // Content entry must be text type
+                    const entry = response.content[0]
+                    assert.strictEqual(entry.type, 'text',
+                        'Content entry must have type "text"')
+                    assert.ok(typeof entry.text === 'string',
+                        'Content entry text must be a string')
+
+                    // Parsed JSON must have values and choices
+                    const parsed = JSON.parse(entry.text)
+                    assert.ok(typeof parsed.values === 'object' && parsed.values !== null,
+                        'Parsed response must have values as an object')
+                    assert.ok(typeof parsed.choices === 'object' && parsed.choices !== null,
+                        'Parsed response must have choices as an object')
+
+                    // When model not found, message should be non-empty string
+                    if (Object.keys(parsed.values).length === 0) {
+                        assert.ok(typeof parsed.message === 'string' && parsed.message.length > 0,
+                            'When values is empty, message must be a non-empty string')
+                    }
+
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+    })
+
+    // Feature: model-picker-mcp, Property 8: Omitted fields returns all metadata
+    // **Validates: Requirements 7.3**
+    describe('Property 8: Omitted fields returns all metadata', () => {
+
+        /** Generate a model ID key */
+        const arbModelKey = fc.stringMatching(/^[a-zA-Z0-9._-]{1,15}$/)
+
+        /** Generate a random metadata object */
+        const arbMetadata = fc.record({
+            family: fc.string({ minLength: 1, maxLength: 15 }),
+            chat_template: fc.oneof(fc.constant(null), fc.string({ minLength: 1, maxLength: 20 })),
+            architecture: fc.oneof(fc.constant(null), fc.string({ minLength: 1, maxLength: 20 })),
+            gated: fc.boolean(),
+            tags: fc.array(fc.string({ minLength: 1, maxLength: 10 }), { minLength: 0, maxLength: 3 }),
+            validation_level: fc.constantFrom('tested', 'community-validated', 'experimental')
+        })
+
+        it('calling without fields parameter returns all metadata fields in values', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.asyncProperty(
+                arbModelKey,
+                arbMetadata,
+                async (modelId, metadata) => {
+                    // Create a resolver with our generated catalog and call resolveModel-like logic
+                    const resolver = new StaticCatalogResolver({ [modelId]: metadata })
+                    const result = await resolver.fetchModelMetadata(modelId)
+
+                    assert.ok(result !== null, `Model "${modelId}" should be found`)
+
+                    // All fields from the original metadata should be present
+                    for (const key of Object.keys(metadata)) {
+                        assert.ok(key in result,
+                            `Field "${key}" should be present when fields parameter is omitted`)
+                        assert.deepStrictEqual(result[key], metadata[key],
+                            `Field "${key}" value should match original metadata`)
+                    }
+
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+
+        it('resolveModel without fields returns all metadata fields in response values', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            fc.assert(fc.asyncProperty(
+                arbModelKey,
+                arbMetadata,
+                async (modelId, metadata) => {
+                    // Use resolveModel in static mode with a known catalog model
+                    // We use a unique ID that won't collide with the real catalog
+                    const uniqueId = `__test_prop8_${modelId}`
+                    const resolver = new StaticCatalogResolver({ [uniqueId]: metadata })
+                    const fetchedMeta = await resolver.fetchModelMetadata(uniqueId)
+
+                    assert.ok(fetchedMeta !== null, `Model "${uniqueId}" should be found`)
+
+                    // Verify all original metadata keys are present
+                    for (const key of Object.keys(metadata)) {
+                        assert.ok(key in fetchedMeta,
+                            `Field "${key}" must be present in response values when fields is omitted`)
+                    }
+
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+    })
+
+    // Feature: model-picker-mcp, Property 6: Catalog entry schema completeness
+    // **Validates: Requirements 6.2**
+    describe('Property 6: Catalog entry schema completeness', () => {
+
+        const VALID_VALIDATION_LEVELS = ['tested', 'community-validated', 'experimental']
+
+        it('every entry in popular-models.json has all required fields with correct types', function () {
+            this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+            const entries = Object.entries(POPULAR_MODELS_CATALOG)
+
+            assert.ok(entries.length > 0, 'Catalog should have at least one entry')
+
+            fc.assert(fc.property(
+                fc.constantFrom(...entries),
+                ([modelId, entry]) => {
+                    // family: string
+                    assert.ok(typeof entry.family === 'string' && entry.family.length > 0,
+                        `[${modelId}] "family" must be a non-empty string, got ${typeof entry.family}`)
+
+                    // chat_template: string or null
+                    assert.ok(entry.chat_template === null || typeof entry.chat_template === 'string',
+                        `[${modelId}] "chat_template" must be a string or null, got ${typeof entry.chat_template}`)
+
+                    // gated: boolean
+                    assert.ok(typeof entry.gated === 'boolean',
+                        `[${modelId}] "gated" must be a boolean, got ${typeof entry.gated}`)
+
+                    // tags: array of strings
+                    assert.ok(Array.isArray(entry.tags),
+                        `[${modelId}] "tags" must be an array, got ${typeof entry.tags}`)
+                    for (const tag of entry.tags) {
+                        assert.ok(typeof tag === 'string',
+                            `[${modelId}] each tag must be a string, got ${typeof tag}`)
+                    }
+
+                    // architecture: string or null
+                    assert.ok(entry.architecture === null || typeof entry.architecture === 'string',
+                        `[${modelId}] "architecture" must be a string or null, got ${typeof entry.architecture}`)
+
+                    // framework_compatibility: object
+                    assert.ok(
+                        typeof entry.framework_compatibility === 'object'
+                        && entry.framework_compatibility !== null
+                        && !Array.isArray(entry.framework_compatibility),
+                        `[${modelId}] "framework_compatibility" must be a non-null object`)
+
+                    // validation_level: one of tested, community-validated, experimental
+                    assert.ok(VALID_VALIDATION_LEVELS.includes(entry.validation_level),
+                        `[${modelId}] "validation_level" must be one of ${VALID_VALIDATION_LEVELS.join(', ')}, got "${entry.validation_level}"`)
+
+                    return true
+                }
+            ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+        })
+    })
+})

--- a/test/servers/model-picker/model-picker.test.js
+++ b/test/servers/model-picker/model-picker.test.js
@@ -1,0 +1,941 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Model Picker Server Unit Tests
+ *
+ * Unit tests for the model-picker MCP server: resolvers, tool interface,
+ * merge logic, startup error handling, and graceful degradation.
+ *
+ * Feature: model-picker-mcp
+ */
+
+import { describe, it, beforeEach, afterEach } from 'mocha'
+import { strict as assert } from 'node:assert'
+import {
+    loadCatalog,
+    ModelResolver,
+    StaticCatalogResolver,
+    HuggingFaceResolver,
+    ResolverRegistry,
+    mergeMetadata,
+    resolveModel,
+    POPULAR_MODELS_CATALOG
+} from '../../../servers/model-picker/index.js'
+
+const VALID_VALIDATION_LEVELS = ['tested', 'community-validated', 'experimental']
+
+describe('Model Picker Server Unit Tests', () => {
+
+    // ── Task 6.1: Catalog schema validation ──────────────────────────────
+
+    describe('Catalog schema validation', () => {
+
+        it('loadCatalog returns a non-empty object', () => {
+            assert.ok(POPULAR_MODELS_CATALOG !== null && typeof POPULAR_MODELS_CATALOG === 'object',
+                'Catalog should be a non-null object')
+            assert.ok(Object.keys(POPULAR_MODELS_CATALOG).length > 0,
+                'Catalog should have at least one entry')
+        })
+
+        for (const [modelId, entry] of Object.entries(POPULAR_MODELS_CATALOG)) {
+            describe(`Entry: ${modelId}`, () => {
+
+                it('has "family" as a string', () => {
+                    assert.ok(typeof entry.family === 'string',
+                        `"family" should be a string, got ${typeof entry.family}`)
+                    assert.ok(entry.family.length > 0,
+                        '"family" should be non-empty')
+                })
+
+                it('has "chat_template" as a string or null', () => {
+                    assert.ok(entry.chat_template === null || typeof entry.chat_template === 'string',
+                        `"chat_template" should be a string or null, got ${typeof entry.chat_template}`)
+                })
+
+                it('has "gated" as a boolean', () => {
+                    assert.ok(typeof entry.gated === 'boolean',
+                        `"gated" should be a boolean, got ${typeof entry.gated}`)
+                })
+
+                it('has "tags" as an array of strings', () => {
+                    assert.ok(Array.isArray(entry.tags),
+                        `"tags" should be an array, got ${typeof entry.tags}`)
+                    for (const tag of entry.tags) {
+                        assert.ok(typeof tag === 'string',
+                            `Each tag should be a string, got ${typeof tag}`)
+                    }
+                })
+
+                it('has "architecture" as a string or null', () => {
+                    assert.ok(entry.architecture === null || typeof entry.architecture === 'string',
+                        `"architecture" should be a string or null, got ${typeof entry.architecture}`)
+                })
+
+                it('has "framework_compatibility" as an object', () => {
+                    assert.ok(typeof entry.framework_compatibility === 'object'
+                        && entry.framework_compatibility !== null
+                        && !Array.isArray(entry.framework_compatibility),
+                        `"framework_compatibility" should be a non-null object`)
+                })
+
+                it('has "validation_level" as one of tested, community-validated, experimental', () => {
+                    assert.ok(VALID_VALIDATION_LEVELS.includes(entry.validation_level),
+                        `"validation_level" should be one of ${VALID_VALIDATION_LEVELS.join(', ')}, got "${entry.validation_level}"`)
+                })
+            })
+        }
+    })
+
+    // ── Task 7.1: StaticCatalogResolver unit tests ───────────────────────
+
+    describe('StaticCatalogResolver', () => {
+        const testCatalog = {
+            'org/exact-model': {
+                family: 'test',
+                chat_template: 'template-a',
+                gated: false,
+                tags: ['text-generation'],
+                architecture: 'TestArch',
+                framework_compatibility: { vllm: '>=0.3.0' },
+                validation_level: 'tested'
+            },
+            'org/glob-*': {
+                family: 'glob-family',
+                chat_template: null,
+                gated: true,
+                tags: ['glob-tag'],
+                architecture: null,
+                framework_compatibility: { vllm: '>=0.1.0' },
+                validation_level: 'experimental'
+            },
+            'org/prefix-?-suffix': {
+                family: 'question-family',
+                chat_template: null,
+                gated: false,
+                tags: [],
+                architecture: null,
+                framework_compatibility: {},
+                validation_level: 'experimental'
+            }
+        }
+
+        let resolver
+
+        beforeEach(() => {
+            resolver = new StaticCatalogResolver(testCatalog)
+        })
+
+        it('returns exact match metadata', async () => {
+            const result = await resolver.fetchModelMetadata('org/exact-model')
+            assert.deepStrictEqual(result.family, 'test')
+            assert.deepStrictEqual(result.chat_template, 'template-a')
+            assert.deepStrictEqual(result.gated, false)
+            assert.deepStrictEqual(result.architecture, 'TestArch')
+        })
+
+        it('returns a copy, not a reference to the catalog entry', async () => {
+            const result = await resolver.fetchModelMetadata('org/exact-model')
+            result.family = 'mutated'
+            const result2 = await resolver.fetchModelMetadata('org/exact-model')
+            assert.strictEqual(result2.family, 'test')
+        })
+
+        it('returns glob match for * wildcard', async () => {
+            const result = await resolver.fetchModelMetadata('org/glob-something')
+            assert.ok(result !== null, 'Should match glob pattern org/glob-*')
+            assert.strictEqual(result.family, 'glob-family')
+            assert.strictEqual(result.gated, true)
+        })
+
+        it('returns glob match for ? wildcard', async () => {
+            const result = await resolver.fetchModelMetadata('org/prefix-X-suffix')
+            assert.ok(result !== null, 'Should match ? wildcard pattern')
+            assert.strictEqual(result.family, 'question-family')
+        })
+
+        it('prefers exact match over glob match', async () => {
+            const catalog = {
+                'org/model-v1': { family: 'exact' },
+                'org/model-*': { family: 'glob' }
+            }
+            const r = new StaticCatalogResolver(catalog)
+            const result = await r.fetchModelMetadata('org/model-v1')
+            assert.strictEqual(result.family, 'exact')
+        })
+
+        it('returns null when no match found', async () => {
+            const result = await resolver.fetchModelMetadata('unknown/model')
+            assert.strictEqual(result, null)
+        })
+
+        it('returns null for empty catalog', async () => {
+            const emptyResolver = new StaticCatalogResolver({})
+            const result = await emptyResolver.fetchModelMetadata('any/model')
+            assert.strictEqual(result, null)
+        })
+
+        it('supportedPatterns returns ["*"]', () => {
+            assert.deepStrictEqual(resolver.supportedPatterns(), ['*'])
+        })
+
+        it('loads the real popular-models.json catalog successfully', () => {
+            const catalog = loadCatalog('./catalogs/popular-models.json')
+            assert.ok(typeof catalog === 'object' && catalog !== null)
+            assert.ok(Object.keys(catalog).length > 0)
+        })
+    })
+
+
+    // ── Task 7.2: HuggingFaceResolver unit tests ─────────────────────────
+
+    describe('HuggingFaceResolver', () => {
+        let resolver
+        let originalFetch
+
+        beforeEach(() => {
+            originalFetch = globalThis.fetch
+            resolver = new HuggingFaceResolver({ baseUrl: 'https://huggingface.co', timeout: 500 })
+        })
+
+        afterEach(() => {
+            globalThis.fetch = originalFetch
+        })
+
+        // ── Pattern matching ─────────────────────────────────────────────
+
+        describe('pattern matching', () => {
+            it('supportedPatterns returns ["hf:*/*"]', () => {
+                assert.deepStrictEqual(resolver.supportedPatterns(), ['hf:*/*'])
+            })
+        })
+
+        // ── HTTP 200 success ─────────────────────────────────────────────
+
+        describe('successful fetch (200)', () => {
+            it('returns metadata from model info, tokenizer config, and model config', async () => {
+                globalThis.fetch = async (url) => {
+                    if (url.includes('/api/models/')) {
+                        return {
+                            ok: true, status: 200,
+                            json: async () => ({
+                                tags: ['text-generation', 'llama'],
+                                gated: true,
+                                pipeline_tag: 'text-generation'
+                            })
+                        }
+                    }
+                    if (url.includes('tokenizer_config.json')) {
+                        return {
+                            ok: true, status: 200,
+                            json: async () => ({ chat_template: '{% test %}' })
+                        }
+                    }
+                    if (url.includes('config.json')) {
+                        return {
+                            ok: true, status: 200,
+                            json: async () => ({ architectures: ['LlamaForCausalLM'] })
+                        }
+                    }
+                    return { ok: false, status: 500 }
+                }
+
+                const result = await resolver.fetchModelMetadata('meta-llama/Llama-2-7b', {})
+                assert.deepStrictEqual(result.tags, ['text-generation', 'llama'])
+                assert.strictEqual(result.gated, true)
+                assert.strictEqual(result.pipeline_tag, 'text-generation')
+                assert.strictEqual(result.chat_template, '{% test %}')
+                assert.strictEqual(result.architecture, 'LlamaForCausalLM')
+            })
+        })
+
+        // ── HTTP 404 not found ───────────────────────────────────────────
+
+        describe('HTTP 404 handling', () => {
+            it('returns null fields for 404 responses without logging', async () => {
+                const stderrWrites = []
+                const origWrite = process.stderr.write
+                process.stderr.write = (msg) => { stderrWrites.push(msg) }
+
+                globalThis.fetch = async () => ({ ok: false, status: 404 })
+
+                try {
+                    const result = await resolver.fetchModelMetadata('org/missing-model', {})
+                    // Model info returns null, so tags/gated/pipeline_tag won't be set
+                    // But chat_template and architecture are set to null explicitly
+                    assert.strictEqual(result.chat_template, null)
+                    assert.strictEqual(result.architecture, null)
+                    // No stderr output for 404
+                    const rateOrFetchLogs = stderrWrites.filter(m =>
+                        m.includes('Rate limited') || m.includes('Fetch failed'))
+                    assert.strictEqual(rateOrFetchLogs.length, 0,
+                        'Should not log warnings for 404 responses')
+                } finally {
+                    process.stderr.write = origWrite
+                }
+            })
+        })
+
+        // ── HTTP 429 rate limit ──────────────────────────────────────────
+
+        describe('HTTP 429 rate limit handling', () => {
+            it('returns null and logs rate-limit warning to stderr', async () => {
+                const stderrWrites = []
+                const origWrite = process.stderr.write
+                process.stderr.write = (msg) => { stderrWrites.push(msg) }
+
+                globalThis.fetch = async () => ({ ok: false, status: 429 })
+
+                try {
+                    const result = await resolver.fetchModelMetadata('org/rate-limited', {})
+                    assert.strictEqual(result.chat_template, null)
+                    assert.strictEqual(result.architecture, null)
+                    const rateLimitLogs = stderrWrites.filter(m => m.includes('Rate limited'))
+                    assert.ok(rateLimitLogs.length > 0,
+                        'Should log rate-limit warning to stderr')
+                } finally {
+                    process.stderr.write = origWrite
+                }
+            })
+        })
+
+        // ── Timeout handling ─────────────────────────────────────────────
+
+        describe('timeout handling', () => {
+            it('returns null and logs when request times out', async () => {
+                const stderrWrites = []
+                const origWrite = process.stderr.write
+                process.stderr.write = (msg) => { stderrWrites.push(msg) }
+
+                // Create resolver with very short timeout
+                const shortResolver = new HuggingFaceResolver({ timeout: 1 })
+
+                globalThis.fetch = async (url, opts) => {
+                    // Wait longer than the timeout
+                    return new Promise((resolve, reject) => {
+                        const timer = setTimeout(() => resolve({ ok: true, status: 200, json: async () => ({}) }), 5000)
+                        opts.signal.addEventListener('abort', () => {
+                            clearTimeout(timer)
+                            reject(new DOMException('The operation was aborted.', 'AbortError'))
+                        })
+                    })
+                }
+
+                try {
+                    const result = await shortResolver.fetchModelMetadata('org/slow-model', {})
+                    assert.strictEqual(result.chat_template, null)
+                    assert.strictEqual(result.architecture, null)
+                    const fetchFailLogs = stderrWrites.filter(m => m.includes('Fetch failed'))
+                    assert.ok(fetchFailLogs.length > 0,
+                        'Should log fetch failure to stderr on timeout')
+                } finally {
+                    process.stderr.write = origWrite
+                }
+            })
+        })
+
+        // ── Network error handling ───────────────────────────────────────
+
+        describe('network error handling', () => {
+            it('returns null and logs when network error occurs', async () => {
+                const stderrWrites = []
+                const origWrite = process.stderr.write
+                process.stderr.write = (msg) => { stderrWrites.push(msg) }
+
+                globalThis.fetch = async () => {
+                    throw new Error('Network unreachable')
+                }
+
+                try {
+                    const result = await resolver.fetchModelMetadata('org/unreachable', {})
+                    assert.strictEqual(result.chat_template, null)
+                    assert.strictEqual(result.architecture, null)
+                    const fetchFailLogs = stderrWrites.filter(m => m.includes('Fetch failed'))
+                    assert.ok(fetchFailLogs.length > 0,
+                        'Should log fetch failure to stderr on network error')
+                } finally {
+                    process.stderr.write = origWrite
+                }
+            })
+        })
+
+        // ── Conditional field fetching ───────────────────────────────────
+
+        describe('conditional field fetching', () => {
+            it('skips tokenizer fetch when fields does not include chat_template', async () => {
+                const fetchedUrls = []
+                globalThis.fetch = async (url) => {
+                    fetchedUrls.push(url)
+                    if (url.includes('/api/models/')) {
+                        return { ok: true, status: 200, json: async () => ({ tags: [], gated: false }) }
+                    }
+                    if (url.includes('config.json')) {
+                        return { ok: true, status: 200, json: async () => ({ architectures: ['TestArch'] }) }
+                    }
+                    return { ok: false, status: 404 }
+                }
+
+                await resolver.fetchModelMetadata('org/model', { fields: ['architecture'] })
+                const tokenizerFetches = fetchedUrls.filter(u => u.includes('tokenizer_config'))
+                assert.strictEqual(tokenizerFetches.length, 0,
+                    'Should not fetch tokenizer config when chat_template not in fields')
+            })
+
+            it('skips model config fetch when fields does not include architecture', async () => {
+                const fetchedUrls = []
+                globalThis.fetch = async (url) => {
+                    fetchedUrls.push(url)
+                    if (url.includes('/api/models/')) {
+                        return { ok: true, status: 200, json: async () => ({ tags: [], gated: false }) }
+                    }
+                    if (url.includes('tokenizer_config.json')) {
+                        return { ok: true, status: 200, json: async () => ({ chat_template: 'tmpl' }) }
+                    }
+                    return { ok: false, status: 404 }
+                }
+
+                await resolver.fetchModelMetadata('org/model', { fields: ['chat_template'] })
+                const configFetches = fetchedUrls.filter(u =>
+                    u.includes('config.json') && !u.includes('tokenizer'))
+                assert.strictEqual(configFetches.length, 0,
+                    'Should not fetch model config when architecture not in fields')
+            })
+
+            it('fetches all endpoints when fields is omitted', async () => {
+                const fetchedUrls = []
+                globalThis.fetch = async (url) => {
+                    fetchedUrls.push(url)
+                    return { ok: true, status: 200, json: async () => ({}) }
+                }
+
+                await resolver.fetchModelMetadata('org/model', {})
+                assert.ok(fetchedUrls.some(u => u.includes('/api/models/')),
+                    'Should fetch model info')
+                assert.ok(fetchedUrls.some(u => u.includes('tokenizer_config')),
+                    'Should fetch tokenizer config when fields omitted')
+                assert.ok(fetchedUrls.some(u =>
+                    u.includes('config.json') && !u.includes('tokenizer')),
+                    'Should fetch model config when fields omitted')
+            })
+        })
+
+        // ── Constructor defaults ─────────────────────────────────────────
+
+        describe('constructor defaults', () => {
+            it('uses default baseUrl and timeout', () => {
+                const defaultResolver = new HuggingFaceResolver()
+                assert.strictEqual(defaultResolver.baseUrl, 'https://huggingface.co')
+                assert.strictEqual(defaultResolver.timeout, 5000)
+            })
+
+            it('accepts custom baseUrl and timeout', () => {
+                const custom = new HuggingFaceResolver({ baseUrl: 'https://custom.co', timeout: 3000 })
+                assert.strictEqual(custom.baseUrl, 'https://custom.co')
+                assert.strictEqual(custom.timeout, 3000)
+            })
+        })
+    })
+
+
+    // ── Task 7.3: ResolverRegistry unit tests ────────────────────────────
+
+    describe('ResolverRegistry', () => {
+        let registry
+        let hfResolver
+        let staticResolver
+
+        beforeEach(() => {
+            hfResolver = new HuggingFaceResolver()
+            staticResolver = new StaticCatalogResolver({})
+            registry = new ResolverRegistry()
+        })
+
+        it('returns registered resolver when match function returns true', () => {
+            registry.register(hfResolver, id => id.includes('/'))
+            const result = registry.getResolver('org/model')
+            assert.strictEqual(result, hfResolver)
+        })
+
+        it('returns default resolver when no match function returns true', () => {
+            registry.register(hfResolver, id => id.includes('/'))
+            registry.setDefault(staticResolver)
+            const result = registry.getResolver('plain-model')
+            assert.strictEqual(result, staticResolver)
+        })
+
+        it('returns null when no resolver matches and no default set', () => {
+            registry.register(hfResolver, () => false)
+            const result = registry.getResolver('anything')
+            assert.strictEqual(result, null)
+        })
+
+        it('returns first matching resolver when multiple match', () => {
+            const resolver2 = new StaticCatalogResolver({})
+            registry.register(hfResolver, id => id.includes('/'))
+            registry.register(resolver2, id => id.includes('/'))
+            const result = registry.getResolver('org/model')
+            assert.strictEqual(result, hfResolver, 'First registered resolver should win')
+        })
+
+        it('routes org/model pattern to HuggingFaceResolver with standard match function', () => {
+            registry.register(
+                hfResolver,
+                id => /^[^/]+\/[^/]+$/.test(id) && !id.includes('://')
+            )
+            registry.setDefault(staticResolver)
+
+            assert.strictEqual(registry.getResolver('meta-llama/Llama-2-7b'), hfResolver)
+            assert.strictEqual(registry.getResolver('mistralai/Mistral-7B'), hfResolver)
+        })
+
+        it('routes URI-prefixed IDs to default (StaticCatalogResolver)', () => {
+            registry.register(
+                hfResolver,
+                id => /^[^/]+\/[^/]+$/.test(id) && !id.includes('://')
+            )
+            registry.setDefault(staticResolver)
+
+            assert.strictEqual(registry.getResolver('jumpstart://model'), staticResolver)
+            assert.strictEqual(registry.getResolver('marketplace://model'), staticResolver)
+        })
+
+        it('routes IDs with no slash to default', () => {
+            registry.register(
+                hfResolver,
+                id => /^[^/]+\/[^/]+$/.test(id) && !id.includes('://')
+            )
+            registry.setDefault(staticResolver)
+
+            assert.strictEqual(registry.getResolver('plain-model'), staticResolver)
+        })
+
+        it('routes IDs with multiple slashes to default', () => {
+            registry.register(
+                hfResolver,
+                id => /^[^/]+\/[^/]+$/.test(id) && !id.includes('://')
+            )
+            registry.setDefault(staticResolver)
+
+            assert.strictEqual(registry.getResolver('a/b/c'), staticResolver)
+        })
+
+        it('supports multiple resolvers with different match functions', () => {
+            const jumpstartResolver = new StaticCatalogResolver({})
+            registry.register(hfResolver, id => /^[^/]+\/[^/]+$/.test(id) && !id.includes('://'))
+            registry.register(jumpstartResolver, id => id.startsWith('jumpstart://'))
+            registry.setDefault(staticResolver)
+
+            assert.strictEqual(registry.getResolver('org/model'), hfResolver)
+            assert.strictEqual(registry.getResolver('jumpstart://my-model'), jumpstartResolver)
+            assert.strictEqual(registry.getResolver('unknown'), staticResolver)
+        })
+    })
+
+    // ── Task 7.4: mergeMetadata unit tests ───────────────────────────────
+
+    describe('mergeMetadata', () => {
+        it('returns null when both inputs are null', () => {
+            assert.strictEqual(mergeMetadata(null, null), null)
+        })
+
+        it('returns static copy when live is null', () => {
+            const staticData = { family: 'llama', architecture: 'LlamaArch' }
+            const result = mergeMetadata(null, staticData)
+            assert.deepStrictEqual(result, staticData)
+            // Verify it's a copy
+            result.family = 'mutated'
+            assert.strictEqual(staticData.family, 'llama')
+        })
+
+        it('returns live copy when static is null', () => {
+            const liveData = { tags: ['gen'], gated: true }
+            const result = mergeMetadata(liveData, null)
+            assert.deepStrictEqual(result, liveData)
+            // Verify it's a copy
+            result.gated = false
+            assert.strictEqual(liveData.gated, true)
+        })
+
+        it('live non-null fields take precedence over static', () => {
+            const live = { family: 'live-family', architecture: 'LiveArch' }
+            const staticData = { family: 'static-family', architecture: 'StaticArch', gated: false }
+            const result = mergeMetadata(live, staticData)
+            assert.strictEqual(result.family, 'live-family')
+            assert.strictEqual(result.architecture, 'LiveArch')
+            assert.strictEqual(result.gated, false)
+        })
+
+        it('static fills gaps when live field is null', () => {
+            const live = { family: 'live-family', architecture: null }
+            const staticData = { family: 'static-family', architecture: 'StaticArch' }
+            const result = mergeMetadata(live, staticData)
+            assert.strictEqual(result.family, 'live-family')
+            assert.strictEqual(result.architecture, 'StaticArch')
+        })
+
+        it('static fills gaps when live field is undefined', () => {
+            const live = { family: 'live-family' }
+            const staticData = { family: 'static-family', architecture: 'StaticArch', gated: true }
+            const result = mergeMetadata(live, staticData)
+            assert.strictEqual(result.family, 'live-family')
+            assert.strictEqual(result.architecture, 'StaticArch')
+            assert.strictEqual(result.gated, true)
+        })
+
+        it('merged result contains all keys from both inputs', () => {
+            const live = { a: 1, b: null }
+            const staticData = { b: 2, c: 3 }
+            const result = mergeMetadata(live, staticData)
+            assert.ok('a' in result)
+            assert.ok('b' in result)
+            assert.ok('c' in result)
+            assert.strictEqual(result.a, 1)
+            assert.strictEqual(result.b, 2) // static fills null gap
+            assert.strictEqual(result.c, 3)
+        })
+    })
+
+
+    // ── Task 7.5: get_models tool interface unit tests ───────────────────
+
+    describe('get_models tool interface (resolveModel)', () => {
+        let originalFetch
+
+        beforeEach(() => {
+            originalFetch = globalThis.fetch
+        })
+
+        afterEach(() => {
+            globalThis.fetch = originalFetch
+        })
+
+        /** Helper to parse the MCP response content */
+        function parseResponse(response) {
+            assert.ok(Array.isArray(response.content))
+            assert.strictEqual(response.content.length, 1)
+            assert.strictEqual(response.content[0].type, 'text')
+            return JSON.parse(response.content[0].text)
+        }
+
+        it('returns catalog metadata in static mode for known model', async () => {
+            const response = await resolveModel({
+                model_id: 'meta-llama/Llama-2-7b-chat-hf',
+                mode: 'static'
+            })
+            const parsed = parseResponse(response)
+            assert.ok(Object.keys(parsed.values).length > 0, 'Should return non-empty values')
+            assert.strictEqual(parsed.values.family, 'llama-2')
+            assert.deepStrictEqual(parsed.choices, {})
+            assert.strictEqual(parsed.message, null)
+        })
+
+        it('returns empty values and message in static mode for unknown model', async () => {
+            const response = await resolveModel({
+                model_id: 'unknown/nonexistent-model-xyz',
+                mode: 'static'
+            })
+            const parsed = parseResponse(response)
+            assert.deepStrictEqual(parsed.values, {})
+            assert.ok(typeof parsed.message === 'string' && parsed.message.length > 0,
+                'Should return a descriptive message')
+            assert.ok(parsed.message.includes('unknown/nonexistent-model-xyz'))
+        })
+
+        it('defaults to discover mode when mode is omitted', async () => {
+            // Mock fetch to fail so we can verify discover mode was used
+            // (it will try HF API, fail, then fall back to static)
+            globalThis.fetch = async () => { throw new Error('Network down') }
+
+            const stderrWrites = []
+            const origWrite = process.stderr.write
+            process.stderr.write = (msg) => { stderrWrites.push(msg) }
+
+            try {
+                const response = await resolveModel({
+                    model_id: 'meta-llama/Llama-2-7b-chat-hf'
+                    // mode omitted — should default to 'discover'
+                })
+                const parsed = parseResponse(response)
+                // In discover mode with HF failure, falls back to static catalog
+                assert.ok(Object.keys(parsed.values).length > 0,
+                    'Should return static catalog data as fallback')
+                // Verify HF was attempted (stderr logs from fetch failures)
+                assert.ok(stderrWrites.some(m => m.includes('Fetch failed')),
+                    'Should have attempted HF API (discover mode)')
+            } finally {
+                process.stderr.write = origWrite
+            }
+        })
+
+        it('filters fields when fields parameter is provided', async () => {
+            const response = await resolveModel({
+                model_id: 'meta-llama/Llama-2-7b-chat-hf',
+                mode: 'static',
+                fields: ['family', 'gated']
+            })
+            const parsed = parseResponse(response)
+            const keys = Object.keys(parsed.values)
+            assert.deepStrictEqual(keys.sort(), ['family', 'gated'].sort())
+            assert.strictEqual(parsed.values.family, 'llama-2')
+            assert.strictEqual(parsed.values.gated, true)
+        })
+
+        it('returns only requested fields even when more are available', async () => {
+            const response = await resolveModel({
+                model_id: 'meta-llama/Llama-2-7b-chat-hf',
+                mode: 'static',
+                fields: ['architecture']
+            })
+            const parsed = parseResponse(response)
+            assert.deepStrictEqual(Object.keys(parsed.values), ['architecture'])
+            assert.strictEqual(parsed.values.architecture, 'LlamaForCausalLM')
+        })
+
+        it('returns all fields when fields parameter is omitted', async () => {
+            const response = await resolveModel({
+                model_id: 'meta-llama/Llama-2-7b-chat-hf',
+                mode: 'static'
+            })
+            const parsed = parseResponse(response)
+            assert.ok('family' in parsed.values)
+            assert.ok('chat_template' in parsed.values)
+            assert.ok('gated' in parsed.values)
+            assert.ok('tags' in parsed.values)
+            assert.ok('architecture' in parsed.values)
+            assert.ok('framework_compatibility' in parsed.values)
+            assert.ok('validation_level' in parsed.values)
+        })
+
+        it('discover mode merges live and static data', async () => {
+            globalThis.fetch = async (url) => {
+                if (url.includes('/api/models/')) {
+                    return {
+                        ok: true, status: 200,
+                        json: async () => ({
+                            tags: ['live-tag'],
+                            gated: false,
+                            pipeline_tag: 'text-generation'
+                        })
+                    }
+                }
+                if (url.includes('tokenizer_config.json')) {
+                    return {
+                        ok: true, status: 200,
+                        json: async () => ({ chat_template: 'live-template' })
+                    }
+                }
+                if (url.includes('config.json')) {
+                    return {
+                        ok: true, status: 200,
+                        json: async () => ({ architectures: ['LiveArch'] })
+                    }
+                }
+                return { ok: false, status: 404 }
+            }
+
+            const response = await resolveModel({
+                model_id: 'meta-llama/Llama-2-7b-chat-hf',
+                mode: 'discover'
+            })
+            const parsed = parseResponse(response)
+            // Live data should take precedence
+            assert.deepStrictEqual(parsed.values.tags, ['live-tag'])
+            assert.strictEqual(parsed.values.chat_template, 'live-template')
+            assert.strictEqual(parsed.values.architecture, 'LiveArch')
+            // Static data should fill gaps (family, framework_compatibility, etc.)
+            assert.strictEqual(parsed.values.family, 'llama-2')
+            assert.ok(parsed.values.framework_compatibility !== undefined)
+        })
+
+        it('response always has values object and choices object', async () => {
+            const response = await resolveModel({
+                model_id: 'anything',
+                mode: 'static'
+            })
+            const parsed = parseResponse(response)
+            assert.ok(typeof parsed.values === 'object' && parsed.values !== null)
+            assert.ok(typeof parsed.choices === 'object' && parsed.choices !== null)
+        })
+
+        it('accepts context parameter without error', async () => {
+            const response = await resolveModel({
+                model_id: 'meta-llama/Llama-2-7b-chat-hf',
+                mode: 'static',
+                context: { framework: 'vllm', instanceType: 'ml.g5.xlarge' }
+            })
+            const parsed = parseResponse(response)
+            assert.ok(Object.keys(parsed.values).length > 0)
+        })
+    })
+
+    // ── Task 7.6: Startup error handling unit tests ──────────────────────
+
+    describe('Startup error handling (loadCatalog)', () => {
+        it('throws when catalog file is missing', () => {
+            assert.throws(
+                () => loadCatalog('./catalogs/nonexistent.json'),
+                (err) => {
+                    assert.ok(err.message.includes('Catalog file not found'),
+                        `Expected "Catalog file not found" in message, got: ${err.message}`)
+                    return true
+                }
+            )
+        })
+
+        it('throws when catalog file contains invalid JSON', () => {
+            // We can test this by trying to load a non-JSON file
+            // The index.js file itself is valid JS but not valid JSON
+            assert.throws(
+                () => loadCatalog('./index.js'),
+                (err) => {
+                    assert.ok(err.message.includes('Failed to parse catalog'),
+                        `Expected "Failed to parse catalog" in message, got: ${err.message}`)
+                    return true
+                }
+            )
+        })
+
+        it('successfully loads valid catalog file', () => {
+            const catalog = loadCatalog('./catalogs/popular-models.json')
+            assert.ok(typeof catalog === 'object' && catalog !== null)
+            assert.ok(Object.keys(catalog).length > 0)
+        })
+    })
+
+    // ── Task 7.7: Graceful degradation unit tests ────────────────────────
+
+    describe('Graceful degradation', () => {
+        let originalFetch
+
+        beforeEach(() => {
+            originalFetch = globalThis.fetch
+        })
+
+        afterEach(() => {
+            globalThis.fetch = originalFetch
+        })
+
+        /** Helper to parse the MCP response content */
+        function parseResponse(response) {
+            return JSON.parse(response.content[0].text)
+        }
+
+        it('discover mode falls back to static catalog when HF API fails for a cataloged model', async () => {
+            // Suppress stderr noise
+            const origWrite = process.stderr.write
+            process.stderr.write = () => {}
+
+            globalThis.fetch = async () => { throw new Error('Network down') }
+
+            try {
+                const response = await resolveModel({
+                    model_id: 'meta-llama/Llama-2-7b-chat-hf',
+                    mode: 'discover'
+                })
+                const parsed = parseResponse(response)
+                assert.ok(Object.keys(parsed.values).length > 0,
+                    'Should return static catalog data when HF fails')
+                assert.strictEqual(parsed.values.family, 'llama-2')
+                assert.strictEqual(parsed.message, null)
+            } finally {
+                process.stderr.write = origWrite
+            }
+        })
+
+        it('discover mode returns values with null fields and no message when HF partially resolves for uncataloged model', async () => {
+            const origWrite = process.stderr.write
+            process.stderr.write = () => {}
+
+            globalThis.fetch = async () => { throw new Error('Network down') }
+
+            try {
+                // HuggingFaceResolver still returns { chat_template: null, architecture: null }
+                // even on network failure (because those fields are explicitly set to null).
+                // mergeMetadata(liveData, null) returns liveData, so values is non-empty.
+                const response = await resolveModel({
+                    model_id: 'unknown-org/unknown-model-xyz',
+                    mode: 'discover'
+                })
+                const parsed = parseResponse(response)
+                // The HF resolver returns an object with null fields, not null itself
+                assert.strictEqual(parsed.values.chat_template, null)
+                assert.strictEqual(parsed.values.architecture, null)
+            } finally {
+                process.stderr.write = origWrite
+            }
+        })
+
+        it('discover mode returns empty values and message for non-HF uncataloged model', async () => {
+            const origWrite = process.stderr.write
+            process.stderr.write = () => {}
+
+            try {
+                // A model ID with no slash won't match HF resolver, falls to static default
+                // Static catalog won't have it either → empty values + message
+                const response = await resolveModel({
+                    model_id: 'plain-unknown-model',
+                    mode: 'discover'
+                })
+                const parsed = parseResponse(response)
+                assert.deepStrictEqual(parsed.values, {})
+                assert.ok(typeof parsed.message === 'string' && parsed.message.length > 0,
+                    'Should return descriptive message when model cannot be resolved')
+                assert.ok(parsed.message.includes('plain-unknown-model'))
+            } finally {
+                process.stderr.write = origWrite
+            }
+        })
+
+        it('discover mode returns partial live + static merge when HF partially fails', async () => {
+            const origWrite = process.stderr.write
+            process.stderr.write = () => {}
+
+            globalThis.fetch = async (url) => {
+                // Model info succeeds
+                if (url.includes('/api/models/')) {
+                    return {
+                        ok: true, status: 200,
+                        json: async () => ({ tags: ['live-tag'], gated: false })
+                    }
+                }
+                // Tokenizer and config fail
+                throw new Error('Partial failure')
+            }
+
+            try {
+                const response = await resolveModel({
+                    model_id: 'meta-llama/Llama-2-7b-chat-hf',
+                    mode: 'discover'
+                })
+                const parsed = parseResponse(response)
+                // Live tags should be present
+                assert.deepStrictEqual(parsed.values.tags, ['live-tag'])
+                // Static family should fill the gap
+                assert.strictEqual(parsed.values.family, 'llama-2')
+                assert.strictEqual(parsed.message, null)
+            } finally {
+                process.stderr.write = origWrite
+            }
+        })
+
+        it('discover mode with 429 rate limit falls back to static for cataloged model', async () => {
+            const origWrite = process.stderr.write
+            process.stderr.write = () => {}
+
+            globalThis.fetch = async () => ({ ok: false, status: 429 })
+
+            try {
+                const response = await resolveModel({
+                    model_id: 'mistralai/Mistral-7B-Instruct-v0.1',
+                    mode: 'discover'
+                })
+                const parsed = parseResponse(response)
+                assert.ok(Object.keys(parsed.values).length > 0,
+                    'Should fall back to static catalog on rate limit')
+                assert.strictEqual(parsed.values.family, 'mistral')
+            } finally {
+                process.stderr.write = origWrite
+            }
+        })
+    })
+})


### PR DESCRIPTION
*Issue #, if available:* closes #111, closes #112

*Description of changes:*
## What

Wires the model-picker MCP server into the generator so it actually
gets used during prompting, replacing the hardcoded model list and
the direct HuggingFace client calls.

## Changes

**generators/app/lib/prompts.js**
- `modelName` prompt now accepts dynamic choices via `_mcpModelChoices`
- Falls back to original hardcoded list when MCP catalog isn't available

**generators/app/lib/prompt-runner.js**
- `_queryMcpForModels()`: reads model-picker catalog to populate model
  selection choices (static, no server spawn needed)
- `_fetchAndDisplayModelInfo()`: spawns model-picker MCP server in
  discover mode for live HuggingFace metadata + catalog merge after
  model selection. Falls back to legacy path on failure.
- Logging matches base-image-picker style

## How it works

1. Before model prompt: reads `popular-models.json` catalog → 6 concrete
   model IDs become the prompt choices
2. After model selection: spawns model-picker server, calls `get_models`
   in discover mode → HuggingFace API + catalog merge → displays model info
3. If MCP server fails at any point, falls back to the old direct
   HuggingFace + model registry code path
