### PR TITLE
fix: batch-transform deploy/test/clean UX improvements

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -204,6 +204,47 @@ export default class extends Generator {
             type: Number,
             description: 'Max concurrent invocations per instance for async inference (default: 1)'
         });
+
+        // Batch transform options
+        this.option('batch-input-path', {
+            type: String,
+            description: 'S3 input path for batch transform data'
+        });
+
+        this.option('batch-output-path', {
+            type: String,
+            description: 'S3 output path for batch transform results'
+        });
+
+        this.option('batch-instance-count', {
+            type: Number,
+            description: 'Number of instances for batch transform job (default: 1)'
+        });
+
+        this.option('batch-split-type', {
+            type: String,
+            description: 'Input data split type: Line, RecordIO, None (default: Line)'
+        });
+
+        this.option('batch-strategy', {
+            type: String,
+            description: 'Batch strategy: MultiRecord, SingleRecord (default: MultiRecord)'
+        });
+
+        this.option('batch-join-source', {
+            type: String,
+            description: 'Join source: Input, None (default: None)'
+        });
+
+        this.option('batch-max-concurrent', {
+            type: Number,
+            description: 'Max concurrent transforms per instance (default: 1)'
+        });
+
+        this.option('batch-max-payload', {
+            type: Number,
+            description: 'Max payload size in MB, 0-100 (default: 6)'
+        });
     }
 
     /**
@@ -445,6 +486,12 @@ export default class extends Generator {
         } else if (!architecture) {
             // Fallback: derive from framework for backward compatibility
             architecture = this.answers.framework === 'transformers' ? 'transformers' : 'http';
+        }
+
+        // Exclude sample_model directory when not needed
+        // Transformers and diffusors don't use sample models (they load from HuggingFace Hub)
+        if (!this.answers.includeSampleModel || architecture === 'transformers' || architecture === 'diffusors') {
+            ignorePatterns.push('**/sample_model/**');
         }
 
         // Always exclude triton and diffusors source directories from initial copy (they are sources, not output)

--- a/generators/app/lib/config-manager.js
+++ b/generators/app/lib/config-manager.js
@@ -600,6 +600,94 @@ export default class ConfigManager {
                 required: false,
                 default: 1,
                 valueSpace: 'bounded'
+            },
+            batchInputPath: {
+                cliOption: 'batch-input-path',
+                envVar: 'ML_BATCH_INPUT_PATH',
+                configFile: true,
+                packageJson: false,
+                mcp: true,
+                promptable: true,
+                required: false,
+                default: null,
+                valueSpace: 'unbounded'
+            },
+            batchOutputPath: {
+                cliOption: 'batch-output-path',
+                envVar: 'ML_BATCH_OUTPUT_PATH',
+                configFile: true,
+                packageJson: false,
+                mcp: true,
+                promptable: true,
+                required: false,
+                default: null,
+                valueSpace: 'unbounded'
+            },
+            batchInstanceCount: {
+                cliOption: 'batch-instance-count',
+                envVar: null,
+                configFile: true,
+                packageJson: false,
+                mcp: false,
+                promptable: true,
+                required: false,
+                default: 1,
+                valueSpace: 'bounded'
+            },
+            batchSplitType: {
+                cliOption: 'batch-split-type',
+                envVar: null,
+                configFile: true,
+                packageJson: false,
+                mcp: false,
+                promptable: true,
+                required: false,
+                default: 'Line',
+                valueSpace: 'bounded'
+            },
+            batchStrategy: {
+                cliOption: 'batch-strategy',
+                envVar: null,
+                configFile: true,
+                packageJson: false,
+                mcp: false,
+                promptable: true,
+                required: false,
+                default: 'MultiRecord',
+                valueSpace: 'bounded'
+            },
+            batchJoinSource: {
+                cliOption: 'batch-join-source',
+                envVar: null,
+                configFile: true,
+                packageJson: false,
+                mcp: false,
+                promptable: true,
+                required: false,
+                default: 'None',
+                valueSpace: 'bounded'
+            },
+            batchMaxConcurrentTransforms: {
+                cliOption: 'batch-max-concurrent',
+                envVar: null,
+                configFile: true,
+                packageJson: false,
+                mcp: false,
+                promptable: true,
+                required: false,
+                default: 1,
+                valueSpace: 'bounded'
+            },
+            batchMaxPayloadInMB: {
+                cliOption: 'batch-max-payload',
+                envVar: null,
+                configFile: true,
+                packageJson: false,
+                mcp: false,
+                promptable: true,
+                required: false,
+                default: 6,
+                valueSpace: 'bounded'
             }
         };
     }

--- a/generators/app/lib/prompt-runner.js
+++ b/generators/app/lib/prompt-runner.js
@@ -22,6 +22,7 @@ import {
     infraRegionAndTargetPrompts,
     infraInstancePrompts,
     infraAsyncPrompts,
+    infraBatchTransformPrompts,
     infraHyperPodPrompts,
     infraBuildPrompts,
     projectPrompts,
@@ -69,10 +70,11 @@ export default class PromptRunner {
         await this._queryMcpForRegion({}, explicitConfig);
         const regionAndTargetAnswers = await this._runPhase(infraRegionAndTargetPrompts, {}, explicitConfig, existingConfig);
 
-        // 1b. Instance type — query MCP and prompt for managed-inference, async-inference, and hyperpod-eks
+        // 1b. Instance type — query MCP and prompt for managed-inference, async-inference, batch-transform, and hyperpod-eks
         let instanceAnswers = {};
         if (regionAndTargetAnswers.deploymentTarget === 'managed-inference' ||
             regionAndTargetAnswers.deploymentTarget === 'async-inference' ||
+            regionAndTargetAnswers.deploymentTarget === 'batch-transform' ||
             regionAndTargetAnswers.deploymentTarget === 'hyperpod-eks') {
             await this._queryMcpForInstance({}, explicitConfig);
             const mcpInstanceChoices = this.configManager?.mcpChoices?.instanceType;
@@ -87,6 +89,17 @@ export default class PromptRunner {
         let asyncAnswers = {};
         if (regionAndTargetAnswers.deploymentTarget === 'async-inference') {
             asyncAnswers = await this._runPhase(infraAsyncPrompts, { ...regionAndTargetAnswers }, explicitConfig, existingConfig);
+        }
+
+        // 1b-batch. Batch transform-specific prompts (only when deploymentTarget === 'batch-transform')
+        let batchTransformAnswers = {};
+        if (regionAndTargetAnswers.deploymentTarget === 'batch-transform') {
+            batchTransformAnswers = await this._runPhase(
+                infraBatchTransformPrompts,
+                { ...regionAndTargetAnswers },
+                explicitConfig,
+                existingConfig
+            );
         }
 
         // 1c. HyperPod prompts — only query MCP and prompt when deployment target is hyperpod-eks
@@ -106,6 +119,7 @@ export default class PromptRunner {
             ...regionAndTargetAnswers,
             ...instanceAnswers,
             ...asyncAnswers,
+            ...batchTransformAnswers,
             ...hyperPodAnswers,
             ...buildAnswers
         };

--- a/generators/app/lib/prompts.js
+++ b/generators/app/lib/prompts.js
@@ -611,6 +611,7 @@ const infraRegionAndTargetPrompts = [
         choices: [
             { name: 'SageMaker Managed Inference - Real Time', value: 'managed-inference' },
             { name: 'SageMaker Managed Inference - Async', value: 'async-inference' },
+            { name: 'SageMaker Managed Inference - Batch', value: 'batch-transform' },
             { name: 'SageMaker HyperPod - EKS', value: 'hyperpod-eks' }
         ],
         default: 'managed-inference'
@@ -622,7 +623,7 @@ const infraInstancePrompts = [
     {
         type: 'list',
         name: 'instanceType',
-        when: answers => answers.deploymentTarget === 'managed-inference' || answers.deploymentTarget === 'async-inference' || answers.deploymentTarget === 'hyperpod-eks',
+        when: answers => answers.deploymentTarget === 'managed-inference' || answers.deploymentTarget === 'async-inference' || answers.deploymentTarget === 'batch-transform' || answers.deploymentTarget === 'hyperpod-eks',
         message: (answers) => {
             const framework = answers.framework || answers.deploymentConfig?.split('-')[0];
             
@@ -854,6 +855,80 @@ const infraAsyncPrompts = [
     }
 ];
 
+/**
+ * Sub-phase: Batch transform-specific prompts (only when deploymentTarget === 'batch-transform')
+ * Requirements: 2.1, 2.2, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9
+ */
+const infraBatchTransformPrompts = [
+    {
+        type: 'input',
+        name: 'batchInputPath',
+        message: 'S3 input path for batch transform data (leave empty for default: s3://ml-container-creator-batch-{region}-{account-id}/{project-name}/input/):',
+        when: answers => answers.deploymentTarget === 'batch-transform'
+    },
+    {
+        type: 'input',
+        name: 'batchOutputPath',
+        message: 'S3 output path for batch transform results (leave empty for default: s3://ml-container-creator-batch-{region}-{account-id}/{project-name}/output/):',
+        when: answers => answers.deploymentTarget === 'batch-transform'
+    },
+    {
+        type: 'number',
+        name: 'batchInstanceCount',
+        message: 'How many instances should run the batch job in parallel?',
+        default: 1,
+        when: answers => answers.deploymentTarget === 'batch-transform'
+    },
+    {
+        type: 'list',
+        name: 'batchSplitType',
+        message: 'Input file format — how should SageMaker read your input files?',
+        choices: [
+            { name: 'Line — one record per line (JSON lines, CSV)', value: 'Line' },
+            { name: 'RecordIO — Amazon RecordIO format', value: 'RecordIO' },
+            { name: 'None — send each file as a single request', value: 'None' }
+        ],
+        default: 'Line',
+        when: answers => answers.deploymentTarget === 'batch-transform'
+    },
+    {
+        type: 'list',
+        name: 'batchStrategy',
+        message: 'How many records should be sent per inference request?',
+        choices: [
+            { name: 'MultiRecord — batch multiple records per request (higher throughput)', value: 'MultiRecord' },
+            { name: 'SingleRecord — one record per request (simpler, more predictable)', value: 'SingleRecord' }
+        ],
+        default: 'MultiRecord',
+        when: answers => answers.deploymentTarget === 'batch-transform'
+    },
+    {
+        type: 'list',
+        name: 'batchJoinSource',
+        message: 'Include original input data alongside predictions in the output?',
+        choices: [
+            { name: 'No — output predictions only', value: 'None' },
+            { name: 'Yes — merge input with predictions (useful for traceability)', value: 'Input' }
+        ],
+        default: 'None',
+        when: answers => answers.deploymentTarget === 'batch-transform'
+    },
+    {
+        type: 'number',
+        name: 'batchMaxConcurrentTransforms',
+        message: 'Max concurrent inference requests per instance?',
+        default: 1,
+        when: answers => answers.deploymentTarget === 'batch-transform'
+    },
+    {
+        type: 'number',
+        name: 'batchMaxPayloadInMB',
+        message: 'Max request payload size in MB (0-100)?',
+        default: 6,
+        when: answers => answers.deploymentTarget === 'batch-transform'
+    }
+];
+
 // Combined view for tests and backward compatibility
 const infrastructurePrompts = [
     ...infraRegionAndTargetPrompts,
@@ -977,6 +1052,7 @@ export {
     infraRegionAndTargetPrompts,
     infraInstancePrompts,
     infraAsyncPrompts,
+    infraBatchTransformPrompts,
     infraHyperPodPrompts,
     infraBuildPrompts,
     projectPrompts,

--- a/generators/app/lib/template-manager.js
+++ b/generators/app/lib/template-manager.js
@@ -64,7 +64,7 @@ export default class TemplateManager {
                 'diffusors-vllm-omni'
             ],
             buildTargets: ['codebuild'],
-            deploymentTargets: ['managed-inference', 'async-inference', 'hyperpod-eks'],
+            deploymentTargets: ['managed-inference', 'async-inference', 'batch-transform', 'hyperpod-eks'],
             testTypes: ['local-model-cli', 'local-model-server', 'hosted-model-endpoint'],
             awsRegions: [
                 'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2',
@@ -131,6 +131,9 @@ export default class TemplateManager {
 
         // Validate async inference specific fields
         this._validateAsyncConfig()
+
+        // Validate batch transform specific fields
+        this._validateBatchTransformConfig()
         
         // Validate instance type format (ml.*.*) - only for managed-inference
         if (this.answers.instanceType && this.answers.instanceType !== 'custom') {
@@ -225,6 +228,71 @@ export default class TemplateManager {
             const val = this.answers.asyncMaxConcurrentInvocations
             if (!Number.isInteger(val) || val < 1) {
                 throw new Error('⚠️  asyncMaxConcurrentInvocations must be an integer >= 1')
+            }
+        }
+    }
+
+    /**
+     * Validates batch transform specific configuration
+     * @private
+     * @throws {Error} If batch transform configuration is invalid
+     */
+    _validateBatchTransformConfig() {
+        if (this.answers.deploymentTarget !== 'batch-transform') return
+
+        // Validate S3 input path format if provided
+        if (this.answers.batchInputPath && this.answers.batchInputPath.trim() !== '') {
+            if (!this.answers.batchInputPath.startsWith('s3://')) {
+                throw new Error('⚠️  batchInputPath must start with "s3://". Example: s3://my-bucket/input/')
+            }
+        }
+
+        // Validate S3 output path format if provided
+        if (this.answers.batchOutputPath && this.answers.batchOutputPath.trim() !== '') {
+            if (!this.answers.batchOutputPath.startsWith('s3://')) {
+                throw new Error('⚠️  batchOutputPath must start with "s3://". Example: s3://my-bucket/output/')
+            }
+        }
+
+        // Validate instance count
+        if (this.answers.batchInstanceCount !== undefined) {
+            const val = this.answers.batchInstanceCount
+            if (!Number.isInteger(val) || val < 1) {
+                throw new Error('⚠️  batchInstanceCount must be an integer >= 1')
+            }
+        }
+
+        // Validate split type
+        const validSplitTypes = ['Line', 'RecordIO', 'None']
+        if (this.answers.batchSplitType && !validSplitTypes.includes(this.answers.batchSplitType)) {
+            throw new Error(`⚠️  batchSplitType must be one of: ${validSplitTypes.join(', ')}`)
+        }
+
+        // Validate batch strategy
+        const validStrategies = ['MultiRecord', 'SingleRecord']
+        if (this.answers.batchStrategy && !validStrategies.includes(this.answers.batchStrategy)) {
+            throw new Error(`⚠️  batchStrategy must be one of: ${validStrategies.join(', ')}`)
+        }
+
+        // Validate join source
+        const validJoinSources = ['Input', 'None']
+        if (this.answers.batchJoinSource && !validJoinSources.includes(this.answers.batchJoinSource)) {
+            throw new Error(`⚠️  batchJoinSource must be one of: ${validJoinSources.join(', ')}`)
+        }
+
+        // Validate max concurrent transforms
+        if (this.answers.batchMaxConcurrentTransforms !== undefined) {
+            const val = this.answers.batchMaxConcurrentTransforms
+            if (!Number.isInteger(val) || val < 0) {
+                throw new Error('⚠️  batchMaxConcurrentTransforms must be an integer >= 0')
+            }
+        }
+
+        // Validate max payload in MB
+        if (this.answers.batchMaxPayloadInMB !== undefined) {
+            const val = this.answers.batchMaxPayloadInMB
+            if (!Number.isInteger(val) || val < 0 || val > 100) {
+                throw new Error('⚠️  batchMaxPayloadInMB must be an integer between 0 and 100')
             }
         }
     }

--- a/generators/app/templates/do/clean
+++ b/generators/app/templates/do/clean
@@ -19,6 +19,8 @@ show_usage() {
     echo "Usage: ./do/clean [local|ecr|endpoint|codebuild|all]"
 <% } else if (deploymentTarget === 'async-inference') { %>
     echo "Usage: ./do/clean [local|ecr|endpoint|codebuild|all]"
+<% } else if (deploymentTarget === 'batch-transform') { %>
+    echo "Usage: ./do/clean [local|ecr|batch|codebuild|all]"
 <% } else if (deploymentTarget === 'hyperpod-eks') { %>
     echo "Usage: ./do/clean [local|ecr|hyperpod|codebuild|all]"
 <% } %>
@@ -30,6 +32,8 @@ show_usage() {
     echo "  endpoint  - Delete SageMaker endpoint, configuration, and model"
 <% } else if (deploymentTarget === 'async-inference') { %>
     echo "  endpoint  - Delete SageMaker async endpoint, configuration, and inference component"
+<% } else if (deploymentTarget === 'batch-transform') { %>
+    echo "  batch     - Stop running transform job and delete SageMaker model"
 <% } else if (deploymentTarget === 'hyperpod-eks') { %>
     echo "  hyperpod  - Delete HyperPod EKS deployment and services"
 <% } %>
@@ -42,6 +46,8 @@ show_usage() {
     echo "  ./do/clean endpoint   # Delete SageMaker resources only"
 <% } else if (deploymentTarget === 'async-inference') { %>
     echo "  ./do/clean endpoint   # Delete SageMaker async resources only"
+<% } else if (deploymentTarget === 'batch-transform') { %>
+    echo "  ./do/clean batch      # Stop transform job and delete model"
 <% } else if (deploymentTarget === 'hyperpod-eks') { %>
     echo "  ./do/clean hyperpod   # Delete HyperPod EKS resources only"
 <% } %>
@@ -375,6 +381,108 @@ clean_endpoint() {
     
     echo "✅ SageMaker async resources cleaned"
 }
+<% } else if (deploymentTarget === 'batch-transform') { %>
+# Function to clean SageMaker managed inference batch resources
+clean_batch() {
+    echo "🧹 Cleaning SageMaker managed inference batch resources"
+    echo "   Project: ${PROJECT_NAME}"
+    echo "   Region: ${AWS_REGION}"
+    
+    # Validate AWS credentials
+    if ! aws sts get-caller-identity &> /dev/null; then
+        echo "❌ AWS credentials not configured"
+        echo "   Run: aws configure"
+        exit 4
+    fi
+    
+    # Use names from config (set by do/deploy)
+    local TJ_NAME="${TRANSFORM_JOB_NAME:-}"
+    local SM_MODEL_NAME="${SAGEMAKER_MODEL_NAME:-}"
+
+    if [ -z "${TJ_NAME}" ] && [ -z "${SM_MODEL_NAME}" ]; then
+        echo "❌ No transform job or model name found"
+        echo "   Run ./do/deploy first, or set TRANSFORM_JOB_NAME in do/config"
+        return 1
+    fi
+
+    echo ""
+    echo "Checking for SageMaker resources..."
+
+    # Check transform job status
+    local JOB_EXISTS=false
+    local JOB_STATUS=""
+    if [ -n "${TJ_NAME}" ]; then
+        JOB_STATUS=$(aws sagemaker describe-transform-job \
+            --transform-job-name "${TJ_NAME}" \
+            --region "${AWS_REGION}" \
+            --query 'TransformJobStatus' \
+            --output text 2>/dev/null || echo "")
+        if [ -n "${JOB_STATUS}" ]; then
+            JOB_EXISTS=true
+            echo "   ✓ Transform job: ${TJ_NAME} (${JOB_STATUS})"
+        else
+            echo "ℹ️  Transform job not found: ${TJ_NAME}"
+        fi
+    fi
+
+    # Check model
+    local MODEL_EXISTS=false
+    if [ -n "${SM_MODEL_NAME}" ]; then
+        if aws sagemaker describe-model \
+            --model-name "${SM_MODEL_NAME}" \
+            --region "${AWS_REGION}" &> /dev/null; then
+            MODEL_EXISTS=true
+            echo "   ✓ SageMaker model: ${SM_MODEL_NAME}"
+        else
+            echo "ℹ️  SageMaker model not found: ${SM_MODEL_NAME}"
+        fi
+    fi
+
+    if [ "${JOB_EXISTS}" = false ] && [ "${MODEL_EXISTS}" = false ]; then
+        echo "ℹ️  No batch transform resources found to clean"
+        return 0
+    fi
+
+    if ! confirm_action "This will stop the transform job (if running) and delete the SageMaker model"; then
+        return 1
+    fi
+
+    # Stop transform job if in progress
+    if [ "${JOB_EXISTS}" = true ] && [ "${JOB_STATUS}" = "InProgress" ]; then
+        echo "🗑️  Stopping transform job: ${TJ_NAME}"
+        if aws sagemaker stop-transform-job \
+            --transform-job-name "${TJ_NAME}" \
+            --region "${AWS_REGION}" &> /dev/null; then
+            echo "⏳ Waiting for transform job to stop..."
+            aws sagemaker wait transform-job-completed-or-stopped \
+                --transform-job-name "${TJ_NAME}" \
+                --region "${AWS_REGION}" 2>/dev/null || sleep 15
+            echo "✅ Transform job stopped"
+        else
+            echo "❌ Failed to stop transform job"
+        fi
+    fi
+
+    # Delete SageMaker model
+    if [ "${MODEL_EXISTS}" = true ]; then
+        echo "🗑️  Deleting SageMaker model: ${SM_MODEL_NAME}"
+        if aws sagemaker delete-model \
+            --model-name "${SM_MODEL_NAME}" \
+            --region "${AWS_REGION}" &> /dev/null; then
+            echo "✅ SageMaker model deleted"
+        else
+            echo "❌ Failed to delete SageMaker model"
+        fi
+    fi
+
+    # Remove saved names from config
+    if grep -q "^export TRANSFORM_JOB_NAME=" "${SCRIPT_DIR}/config" 2>/dev/null; then
+        sed -i.bak '/^# Last deployed resources/d;/^export TRANSFORM_JOB_NAME=/d;/^export SAGEMAKER_MODEL_NAME=/d' "${SCRIPT_DIR}/config"
+        rm -f "${SCRIPT_DIR}/config.bak"
+    fi
+    
+    echo "✅ SageMaker managed inference batch resources cleaned"
+}
 <% } else if (deploymentTarget === 'hyperpod-eks') { %>
 # Function to clean HyperPod EKS deployment
 clean_hyperpod() {
@@ -547,8 +655,15 @@ echo "🧹 Cleanup script for ${PROJECT_NAME}"
 echo ""
 
 if [ -z "${CLEANUP_TARGET}" ]; then
+<% if (deploymentTarget === 'batch-transform') { %>
+    CLEANUP_TARGET="batch"
+<% } else if (deploymentTarget === 'hyperpod-eks') { %>
     show_usage
     exit 0
+<% } else { %>
+    show_usage
+    exit 0
+<% } %>
 fi
 
 case "${CLEANUP_TARGET}" in
@@ -565,6 +680,10 @@ case "${CLEANUP_TARGET}" in
 <% } else if (deploymentTarget === 'async-inference') { %>
     endpoint)
         clean_endpoint
+        ;;
+<% } else if (deploymentTarget === 'batch-transform') { %>
+    batch)
+        clean_batch
         ;;
 <% } else if (deploymentTarget === 'hyperpod-eks') { %>
     hyperpod)
@@ -604,6 +723,11 @@ case "${CLEANUP_TARGET}" in
         # Clean SageMaker async resources
         if clean_endpoint; then
             CLEANED_ITEMS+=("SageMaker async resources")
+        fi
+<% } else if (deploymentTarget === 'batch-transform') { %>
+        # Clean SageMaker managed inference batch resources
+        if clean_batch; then
+            CLEANED_ITEMS+=("SageMaker managed inference batch resources")
         fi
 <% } else if (deploymentTarget === 'hyperpod-eks') { %>
         # Clean HyperPod EKS resources

--- a/generators/app/templates/do/config
+++ b/generators/app/templates/do/config
@@ -76,6 +76,35 @@ export FSX_VOLUME_HANDLE="<%= fsxVolumeHandle %>"
 <% } %>
 <% } %>
 
+<% if (deploymentTarget === 'batch-transform') { %>
+# SageMaker Managed Inference - Batch configuration
+export INSTANCE_TYPE="<%= instanceType %>"
+
+# Resolve AWS account ID at runtime for default resource names
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo "UNKNOWN")
+
+<% if (batchInputPath) { %>
+export BATCH_INPUT_PATH="<%= batchInputPath %>"
+<% } else { %>
+export BATCH_INPUT_PATH="s3://ml-container-creator-batch-${AWS_REGION}-${ACCOUNT_ID}/${PROJECT_NAME}/input/"
+<% } %>
+<% if (batchOutputPath) { %>
+export BATCH_OUTPUT_PATH="<%= batchOutputPath %>"
+<% } else { %>
+export BATCH_OUTPUT_PATH="s3://ml-container-creator-batch-${AWS_REGION}-${ACCOUNT_ID}/${PROJECT_NAME}/output/"
+<% } %>
+export BATCH_INSTANCE_COUNT="<%= batchInstanceCount %>"
+export BATCH_SPLIT_TYPE="<%= batchSplitType %>"
+export BATCH_STRATEGY="<%= batchStrategy %>"
+export BATCH_JOIN_SOURCE="<%= batchJoinSource || 'None' %>"
+<% if (batchMaxConcurrentTransforms) { %>
+export BATCH_MAX_CONCURRENT_TRANSFORMS="<%= batchMaxConcurrentTransforms %>"
+<% } %>
+<% if (batchMaxPayloadInMB) { %>
+export BATCH_MAX_PAYLOAD_IN_MB="<%= batchMaxPayloadInMB %>"
+<% } %>
+<% } %>
+
 # Framework-specific configuration
 <% if (framework === 'transformers') { %>
 export MODEL_NAME="<%= modelName %>"
@@ -104,7 +133,7 @@ export ROLE_ARN="<%= roleArn %>"
 
 # Allow environment variable overrides
 export AWS_REGION=${AWS_REGION:-<%= awsRegion %>}
-<% if (deploymentTarget === 'managed-inference' || deploymentTarget === 'async-inference') { %>
+<% if (deploymentTarget === 'managed-inference' || deploymentTarget === 'async-inference' || deploymentTarget === 'batch-transform') { %>
 export INSTANCE_TYPE=${INSTANCE_TYPE:-<%= instanceType %>}
 <% } %>
 export ECR_REPOSITORY_NAME=${ECR_REPOSITORY_NAME:-ml-container-creator}
@@ -123,6 +152,12 @@ echo "   Instance: ${INSTANCE_TYPE}"
 echo "   S3 output: ${ASYNC_S3_OUTPUT_PATH}"
 echo "   SNS success: ${ASYNC_SNS_SUCCESS_TOPIC}"
 echo "   SNS error: ${ASYNC_SNS_ERROR_TOPIC}"
+<% } else if (deploymentTarget === 'batch-transform') { %>
+echo "   Instance: ${INSTANCE_TYPE} x ${BATCH_INSTANCE_COUNT}"
+echo "   S3 input: ${BATCH_INPUT_PATH}"
+echo "   S3 output: ${BATCH_OUTPUT_PATH}"
+echo "   Split type: ${BATCH_SPLIT_TYPE}"
+echo "   Strategy: ${BATCH_STRATEGY}"
 <% } else if (deploymentTarget === 'hyperpod-eks') { %>
 echo "   HyperPod cluster: ${HYPERPOD_CLUSTER_NAME}"
 echo "   Namespace: ${HYPERPOD_NAMESPACE}"

--- a/generators/app/templates/do/deploy
+++ b/generators/app/templates/do/deploy
@@ -30,6 +30,13 @@ echo "   Max concurrent: ${ASYNC_MAX_CONCURRENT_INVOCATIONS}"
 echo "   HyperPod cluster: ${HYPERPOD_CLUSTER_NAME}"
 echo "   Namespace: ${HYPERPOD_NAMESPACE}"
 echo "   Replicas: ${HYPERPOD_REPLICAS}"
+<% } else if (deploymentTarget === 'batch-transform') { %>
+echo "   Instance type: ${INSTANCE_TYPE}"
+echo "   S3 input: ${BATCH_INPUT_PATH}"
+echo "   S3 output: ${BATCH_OUTPUT_PATH}"
+echo "   Instance count: ${BATCH_INSTANCE_COUNT}"
+echo "   Split type: ${BATCH_SPLIT_TYPE}"
+echo "   Strategy: ${BATCH_STRATEGY}"
 <% } %>
 
 # Check AWS credentials
@@ -720,5 +727,352 @@ _update_config_var() {
 }
 
 _update_config_var "KUBECONFIG" "${KUBECONFIG_PATH}"
+
+<% } else if (deploymentTarget === 'batch-transform') { %>
+# ============================================================
+# SageMaker Managed Inference - Batch Deployment
+# Flow: create-model → create-transform-job → poll until completion
+# ============================================================
+
+# Validate execution role ARN
+if [ -z "${ROLE_ARN:-}" ]; then
+    echo "❌ Execution role ARN not provided"
+    echo ""
+    echo "Usage:"
+    echo "  export ROLE_ARN=arn:aws:iam::ACCOUNT_ID:role/YOUR_ROLE"
+    echo "  ./do/deploy"
+    echo ""
+    echo "Or set ROLE_ARN in do/config"
+    echo ""
+    echo "The execution role must have permissions for:"
+    echo "  • SageMaker model and transform job management"
+    echo "  • ECR image access"
+    echo "  • S3 read access for input path: ${BATCH_INPUT_PATH}"
+    echo "  • S3 write access for output path: ${BATCH_OUTPUT_PATH}"
+    echo "  • CloudWatch Logs"
+    exit 3
+fi
+
+echo "   Using execution role: ${ROLE_ARN}"
+
+# Validate S3 input path
+if [ -z "${BATCH_INPUT_PATH:-}" ]; then
+    echo "❌ S3 input path not provided"
+    echo ""
+    echo "Set BATCH_INPUT_PATH in do/config or provide via CLI:"
+    echo "  export BATCH_INPUT_PATH=s3://my-bucket/input/"
+    echo "  ./do/deploy"
+    exit 3
+fi
+
+if [[ "${BATCH_INPUT_PATH}" != s3://* ]]; then
+    echo "❌ S3 input path must start with s3://"
+    echo "   Current value: ${BATCH_INPUT_PATH}"
+    echo "   Example: s3://my-bucket/input/"
+    exit 3
+fi
+
+# Validate S3 output path
+if [ -z "${BATCH_OUTPUT_PATH:-}" ]; then
+    echo "❌ S3 output path not provided"
+    echo ""
+    echo "Set BATCH_OUTPUT_PATH in do/config or provide via CLI:"
+    echo "  export BATCH_OUTPUT_PATH=s3://my-bucket/output/"
+    echo "  ./do/deploy"
+    exit 3
+fi
+
+if [[ "${BATCH_OUTPUT_PATH}" != s3://* ]]; then
+    echo "❌ S3 output path must start with s3://"
+    echo "   Current value: ${BATCH_OUTPUT_PATH}"
+    echo "   Example: s3://my-bucket/output/"
+    exit 3
+fi
+
+# ============================================================
+# Bootstrap S3 buckets for batch transform
+# ============================================================
+
+# Extract bucket names from S3 paths
+BATCH_INPUT_BUCKET=$(echo "${BATCH_INPUT_PATH}" | sed 's|s3://||' | cut -d'/' -f1)
+BATCH_OUTPUT_BUCKET=$(echo "${BATCH_OUTPUT_PATH}" | sed 's|s3://||' | cut -d'/' -f1)
+
+<% if (!batchInputPath) { %>
+# Bootstrap default S3 input bucket (check-and-create)
+echo "🔍 Checking if S3 input bucket exists: ${BATCH_INPUT_BUCKET}"
+if ! aws s3api head-bucket --bucket "${BATCH_INPUT_BUCKET}" --region "${AWS_REGION}" 2>/dev/null; then
+    echo "📦 Creating S3 input bucket: ${BATCH_INPUT_BUCKET}"
+    if [ "${AWS_REGION}" = "us-east-1" ]; then
+        if ! aws s3api create-bucket \
+            --bucket "${BATCH_INPUT_BUCKET}" \
+            --region "${AWS_REGION}"; then
+            echo "❌ Failed to create S3 input bucket: ${BATCH_INPUT_BUCKET}"
+            echo ""
+            echo "   Check that:"
+            echo "   • Your IAM credentials have s3:CreateBucket permission"
+            echo "   • The bucket name is not already taken globally"
+            exit 4
+        fi
+    else
+        if ! aws s3api create-bucket \
+            --bucket "${BATCH_INPUT_BUCKET}" \
+            --region "${AWS_REGION}" \
+            --create-bucket-configuration LocationConstraint="${AWS_REGION}"; then
+            echo "❌ Failed to create S3 input bucket: ${BATCH_INPUT_BUCKET}"
+            echo ""
+            echo "   Check that:"
+            echo "   • Your IAM credentials have s3:CreateBucket permission"
+            echo "   • The bucket name is not already taken globally"
+            exit 4
+        fi
+    fi
+    echo "✅ S3 input bucket created: ${BATCH_INPUT_BUCKET}"
+else
+    echo "✅ S3 input bucket exists: ${BATCH_INPUT_BUCKET}"
+fi
+
+# Upload sample input file if the input prefix is empty
+EXISTING_OBJECTS=$(aws s3 ls "${BATCH_INPUT_PATH}" --region "${AWS_REGION}" 2>/dev/null | head -1 || true)
+if [ -z "${EXISTING_OBJECTS}" ]; then
+    echo "📄 Uploading sample input file to ${BATCH_INPUT_PATH}"
+<% if (framework === 'transformers' && (modelServer === 'vllm' || modelServer === 'sglang')) { %>
+    echo '{"model": "<%= modelName %>", "messages": [{"role": "user", "content": "What is machine learning?"}], "max_tokens": 50}' | aws s3 cp - "${BATCH_INPUT_PATH}sample.jsonl" --region "${AWS_REGION}"
+<% } else if (framework === 'transformers') { %>
+    echo '{"inputs": "What is machine learning?", "parameters": {"max_new_tokens": 50}}' | aws s3 cp - "${BATCH_INPUT_PATH}sample.jsonl" --region "${AWS_REGION}"
+<% } else if (framework === 'diffusors') { %>
+    echo '{"prompt": "A white cat", "n": 1, "size": "512x512"}' | aws s3 cp - "${BATCH_INPUT_PATH}sample.jsonl" --region "${AWS_REGION}"
+<% } else { %>
+    echo '{"instances": [[1.0, 2.0, 3.0, 4.0]]}' | aws s3 cp - "${BATCH_INPUT_PATH}sample.jsonl" --region "${AWS_REGION}"
+<% } %>
+    echo "✅ Sample input uploaded: ${BATCH_INPUT_PATH}sample.jsonl"
+    echo "   ⚠️  Replace this with your actual input data before running production jobs"
+fi
+<% } else { %>
+# Custom S3 input path provided — skip bucket creation
+echo "✅ Using custom S3 input path: ${BATCH_INPUT_PATH}"
+<% } %>
+
+<% if (!batchOutputPath) { %>
+# Bootstrap default S3 output bucket (check-and-create, may be same as input)
+if [ "${BATCH_OUTPUT_BUCKET}" != "${BATCH_INPUT_BUCKET}" ]; then
+    echo "🔍 Checking if S3 output bucket exists: ${BATCH_OUTPUT_BUCKET}"
+    if ! aws s3api head-bucket --bucket "${BATCH_OUTPUT_BUCKET}" --region "${AWS_REGION}" 2>/dev/null; then
+        echo "📦 Creating S3 output bucket: ${BATCH_OUTPUT_BUCKET}"
+        if [ "${AWS_REGION}" = "us-east-1" ]; then
+            if ! aws s3api create-bucket \
+                --bucket "${BATCH_OUTPUT_BUCKET}" \
+                --region "${AWS_REGION}"; then
+                echo "❌ Failed to create S3 output bucket: ${BATCH_OUTPUT_BUCKET}"
+                exit 4
+            fi
+        else
+            if ! aws s3api create-bucket \
+                --bucket "${BATCH_OUTPUT_BUCKET}" \
+                --region "${AWS_REGION}" \
+                --create-bucket-configuration LocationConstraint="${AWS_REGION}"; then
+                echo "❌ Failed to create S3 output bucket: ${BATCH_OUTPUT_BUCKET}"
+                exit 4
+            fi
+        fi
+        echo "✅ S3 output bucket created: ${BATCH_OUTPUT_BUCKET}"
+    else
+        echo "✅ S3 output bucket exists: ${BATCH_OUTPUT_BUCKET}"
+    fi
+else
+    echo "✅ S3 output bucket same as input: ${BATCH_OUTPUT_BUCKET}"
+fi
+<% } else { %>
+# Custom S3 output path provided — skip bucket creation
+echo "✅ Using custom S3 output path: ${BATCH_OUTPUT_PATH}"
+<% } %>
+
+# Generate unique names with timestamp
+TIMESTAMP=$(date +%s)
+MODEL_NAME_SM="${PROJECT_NAME}-batch-model-${TIMESTAMP}"
+TRANSFORM_JOB_NAME="${PROJECT_NAME}-batch-job-${TIMESTAMP}"
+
+# Persist names to config immediately so ./do/logs works during deployment
+_update_config_var() {
+    local var_name="$1" var_value="$2" config_file="${SCRIPT_DIR}/config"
+    if grep -q "^export ${var_name}=" "${config_file}" 2>/dev/null; then
+        sed -i.bak "s|^export ${var_name}=.*|export ${var_name}=\"${var_value}\"|" "${config_file}"
+        rm -f "${config_file}.bak"
+    else
+        echo "" >> "${config_file}"
+        echo "export ${var_name}=\"${var_value}\"" >> "${config_file}"
+    fi
+}
+
+_update_config_var "TRANSFORM_JOB_NAME" "${TRANSFORM_JOB_NAME}"
+_update_config_var "SAGEMAKER_MODEL_NAME" "${MODEL_NAME_SM}"
+
+# Step 1: Create SageMaker model
+echo "📦 Creating SageMaker model: ${MODEL_NAME_SM}"
+if ! aws sagemaker create-model \
+    --model-name "${MODEL_NAME_SM}" \
+    --primary-container "{\"Image\":\"${ECR_REPOSITORY}:${IMAGE_TAG}\"}" \
+    --execution-role-arn "${ROLE_ARN}" \
+    --region "${AWS_REGION}"; then
+
+    echo "❌ Failed to create SageMaker model"
+    echo "   Check that:"
+    echo "   • The execution role ARN is valid"
+    echo "   • The ECR image exists and is accessible"
+    echo "   • The IAM role has ecr:GetDownloadUrlForLayer permission"
+    exit 4
+fi
+
+echo "✅ SageMaker model created: ${MODEL_NAME_SM}"
+
+# Step 2: Build transform job JSON
+TRANSFORM_JOB_JSON="{
+    \"TransformJobName\": \"${TRANSFORM_JOB_NAME}\",
+    \"ModelName\": \"${MODEL_NAME_SM}\",
+    \"TransformInput\": {
+        \"DataSource\": {
+            \"S3DataSource\": {
+                \"S3DataType\": \"S3Prefix\",
+                \"S3Uri\": \"${BATCH_INPUT_PATH}\"
+            }
+        },
+        \"ContentType\": \"application/json\",
+        \"SplitType\": \"${BATCH_SPLIT_TYPE}\"
+    },
+    \"TransformOutput\": {
+        \"S3OutputPath\": \"${BATCH_OUTPUT_PATH}\"
+        $([ "${BATCH_JOIN_SOURCE:-None}" = "Input" ] && echo ",\"Accept\": \"application/json\", \"AssembleWith\": \"${BATCH_SPLIT_TYPE}\"")
+    },
+    \"TransformResources\": {
+        \"InstanceType\": \"${INSTANCE_TYPE}\",
+        \"InstanceCount\": ${BATCH_INSTANCE_COUNT}
+    },
+    \"MaxConcurrentTransforms\": ${BATCH_MAX_CONCURRENT_TRANSFORMS:-1},
+    \"MaxPayloadInMB\": ${BATCH_MAX_PAYLOAD_IN_MB:-6},
+    \"BatchStrategy\": \"${BATCH_STRATEGY}\"
+    $([ "${BATCH_JOIN_SOURCE:-None}" = "Input" ] && echo ",\"DataProcessing\": { \"JoinSource\": \"Input\" }")
+}"
+
+# Step 3: Create transform job
+echo "🚀 Creating transform job: ${TRANSFORM_JOB_NAME}"
+if ! aws sagemaker create-transform-job \
+    --cli-input-json "${TRANSFORM_JOB_JSON}" \
+    --region "${AWS_REGION}"; then
+
+    echo "❌ Failed to create transform job"
+    echo "   Check that:"
+    echo "   • The S3 input path exists and is accessible: ${BATCH_INPUT_PATH}"
+    echo "   • The S3 output path is writable: ${BATCH_OUTPUT_PATH}"
+    echo "   • The IAM role has s3:GetObject permission on the input path"
+    echo "   • The IAM role has s3:PutObject permission on the output path"
+    echo "   • The instance type is valid: ${INSTANCE_TYPE}"
+    echo "   • The instance type is available in region: ${AWS_REGION}"
+    echo "   • You have sufficient service quota for the instance type"
+    exit 4
+fi
+
+echo "✅ Transform job created: ${TRANSFORM_JOB_NAME}"
+
+# Step 4: Poll transform job status until completion or failure
+echo "⏳ Waiting for transform job to complete..."
+echo "   This may take several minutes depending on dataset size..."
+echo ""
+
+while true; do
+    JOB_STATUS=$(aws sagemaker describe-transform-job \
+        --transform-job-name "${TRANSFORM_JOB_NAME}" \
+        --region "${AWS_REGION}" \
+        --query "TransformJobStatus" \
+        --output text 2>&1) || {
+        echo "❌ Failed to describe transform job: ${TRANSFORM_JOB_NAME}"
+        exit 4
+    }
+
+    case "${JOB_STATUS}" in
+        Completed)
+            echo "✅ Transform job completed successfully!"
+            break
+            ;;
+        Failed)
+            FAILURE_REASON=$(aws sagemaker describe-transform-job \
+                --transform-job-name "${TRANSFORM_JOB_NAME}" \
+                --region "${AWS_REGION}" \
+                --query "FailureReason" \
+                --output text 2>/dev/null || echo "Unknown")
+            echo "❌ Transform job failed"
+            echo "   Reason: ${FAILURE_REASON}"
+            echo ""
+            echo "   Check CloudWatch Logs for details:"
+            echo "   https://console.aws.amazon.com/cloudwatch/home?region=${AWS_REGION}#logsV2:log-groups/log-group//aws/sagemaker/TransformJobs"
+            echo ""
+            echo "   Verify that:"
+            echo "   • The S3 input path exists and contains data: ${BATCH_INPUT_PATH}"
+            echo "   • The input data format matches the container's expected format"
+            echo "   • The container's /ping and /invocations endpoints work correctly"
+            exit 4
+            ;;
+        Stopped)
+            echo "⚠️  Transform job was stopped"
+            exit 4
+            ;;
+        InProgress)
+            echo "   $(date +%H:%M:%S) Job status: InProgress..."
+            sleep 30
+            ;;
+        *)
+            echo "   $(date +%H:%M:%S) Job status: ${JOB_STATUS}..."
+            sleep 30
+            ;;
+    esac
+done
+
+echo ""
+echo "📋 Deployment Details:"
+echo "   Transform Job: ${TRANSFORM_JOB_NAME}"
+echo "   Model: ${MODEL_NAME_SM}"
+echo "   Region: ${AWS_REGION}"
+echo "   Instance Type: ${INSTANCE_TYPE}"
+echo "   Instance Count: ${BATCH_INSTANCE_COUNT}"
+echo "   Image: ${ECR_REPOSITORY}:${IMAGE_TAG}"
+echo "   S3 Input: ${BATCH_INPUT_PATH}"
+echo "   S3 Output: ${BATCH_OUTPUT_PATH}"
+echo "   Split Type: ${BATCH_SPLIT_TYPE}"
+echo "   Strategy: ${BATCH_STRATEGY}"
+echo ""
+
+# Download results locally
+LOCAL_OUTPUT_DIR="${SCRIPT_DIR}/../batch-output"
+mkdir -p "${LOCAL_OUTPUT_DIR}"
+echo "📥 Downloading results to ${LOCAL_OUTPUT_DIR}/"
+if aws s3 sync "${BATCH_OUTPUT_PATH}" "${LOCAL_OUTPUT_DIR}/" --region "${AWS_REGION}"; then
+    DOWNLOADED=$(ls -1 "${LOCAL_OUTPUT_DIR}" 2>/dev/null | wc -l | tr -d ' ')
+    echo "✅ Downloaded ${DOWNLOADED} file(s) to ${LOCAL_OUTPUT_DIR}/"
+    echo ""
+
+    # Display first output file preview
+    FIRST_FILE=$(ls -1 "${LOCAL_OUTPUT_DIR}" 2>/dev/null | head -1)
+    if [ -n "${FIRST_FILE}" ]; then
+        echo "📄 Sample output (${FIRST_FILE}):"
+        head -5 "${LOCAL_OUTPUT_DIR}/${FIRST_FILE}"
+        LINES=$(wc -l < "${LOCAL_OUTPUT_DIR}/${FIRST_FILE}" | tr -d ' ')
+        if [ "${LINES}" -gt 5 ]; then
+            echo "   ... (${LINES} total lines)"
+        fi
+    fi
+else
+    echo "⚠️  Could not download output files"
+fi
+
+echo ""
+echo "🧪 Review results:"
+echo "   ./do/test"
+echo ""
+echo "📝 Register this deployment:"
+echo "   ./do/register"
+echo ""
+echo "📋 View logs:"
+echo "   ./do/logs"
+echo ""
+echo "🧹 Clean up when done:"
+echo "   ./do/clean"
 
 <% } %>

--- a/generators/app/templates/do/export
+++ b/generators/app/templates/do/export
@@ -42,6 +42,23 @@ CMD="${CMD} --deployment-target=${DEPLOYMENT_TARGET}"
 <% if (deploymentTarget === 'managed-inference') { %>
 # SageMaker Managed Inference
 CMD="${CMD} --instance-type=${INSTANCE_TYPE}"
+<% } else if (deploymentTarget === 'batch-transform') { %>
+# SageMaker Managed Inference - Batch
+CMD="${CMD} --instance-type=${INSTANCE_TYPE}"
+CMD="${CMD} --batch-input-path=${BATCH_INPUT_PATH}"
+CMD="${CMD} --batch-output-path=${BATCH_OUTPUT_PATH}"
+CMD="${CMD} --batch-instance-count=${BATCH_INSTANCE_COUNT}"
+CMD="${CMD} --batch-split-type=${BATCH_SPLIT_TYPE}"
+CMD="${CMD} --batch-strategy=${BATCH_STRATEGY}"
+if [ "${BATCH_JOIN_SOURCE:-None}" != "None" ]; then
+    CMD="${CMD} --batch-join-source=${BATCH_JOIN_SOURCE}"
+fi
+if [ "${BATCH_MAX_CONCURRENT_TRANSFORMS:-1}" != "1" ]; then
+    CMD="${CMD} --batch-max-concurrent=${BATCH_MAX_CONCURRENT_TRANSFORMS}"
+fi
+if [ "${BATCH_MAX_PAYLOAD_IN_MB:-6}" != "6" ]; then
+    CMD="${CMD} --batch-max-payload=${BATCH_MAX_PAYLOAD_IN_MB}"
+fi
 <% } else if (deploymentTarget === 'hyperpod-eks') { %>
 # HyperPod EKS
 CMD="${CMD} --hyperpod-cluster=${HYPERPOD_CLUSTER_NAME}"

--- a/generators/app/templates/do/logs
+++ b/generators/app/templates/do/logs
@@ -164,6 +164,80 @@ aws logs tail "${LOG_GROUP}" \
     --follow \
     --format short
 
+<% } else if (deploymentTarget === 'batch-transform') { %>
+# ============================================================
+# SageMaker Managed Inference - Batch Logs (CloudWatch)
+# ============================================================
+
+# Allow transform job name as argument or from config
+JOB_NAME="${1:-${TRANSFORM_JOB_NAME:-}}"
+
+if [ -z "${JOB_NAME}" ]; then
+    echo "❌ No transform job name provided"
+    echo ""
+    echo "Usage:"
+    echo "  ./do/logs <transform-job-name>"
+    echo "  ./do/logs                  # uses TRANSFORM_JOB_NAME from do/config"
+    echo ""
+    echo "Run ./do/deploy first to set TRANSFORM_JOB_NAME automatically."
+    exit 1
+fi
+
+LOG_GROUP="/aws/sagemaker/TransformJobs"
+
+echo "📋 Tailing logs for batch transform job: ${JOB_NAME}"
+echo "   Log group: ${LOG_GROUP}"
+echo "   Region: ${AWS_REGION}"
+echo ""
+echo "   Press Ctrl+C to stop"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Wait for log group to exist before tailing
+MAX_WAIT=300
+INTERVAL=10
+ELAPSED=0
+
+while true; do
+    if aws logs describe-log-groups \
+        --log-group-name-prefix "${LOG_GROUP}" \
+        --region "${AWS_REGION}" \
+        --query "logGroups[?logGroupName=='${LOG_GROUP}'].logGroupName" \
+        --output text 2>/dev/null | grep -q "${LOG_GROUP}"; then
+        break
+    fi
+
+    if [ "${ELAPSED}" -ge "${MAX_WAIT}" ]; then
+        echo "❌ Timed out after ${MAX_WAIT}s waiting for log group: ${LOG_GROUP}"
+        echo ""
+        echo "   The transform job may not have started logging yet."
+        echo "   Check the job status:"
+        echo "   aws sagemaker describe-transform-job --transform-job-name ${JOB_NAME} --region ${AWS_REGION}"
+        exit 1
+    fi
+
+    if [ "${ELAPSED}" -eq 0 ]; then
+        echo "⏳ Log group not found yet: ${LOG_GROUP}"
+        echo "   The transform job may still be starting up. Waiting up to ${MAX_WAIT}s..."
+        echo ""
+    fi
+
+    sleep "${INTERVAL}"
+    ELAPSED=$((ELAPSED + INTERVAL))
+    echo "   Waiting for log group... (${ELAPSED}s/${MAX_WAIT}s)"
+done
+
+echo "✅ Log group found. Tailing logs..."
+echo ""
+
+# Tail logs, filtering by transform job name
+aws logs tail "${LOG_GROUP}" \
+    --region "${AWS_REGION}" \
+    --log-stream-name-prefix "${JOB_NAME}" \
+    --follow \
+    --format short
+
 <% } else if (deploymentTarget === 'hyperpod-eks') { %>
 # ============================================================
 # HyperPod EKS Logs (kubectl)

--- a/generators/app/templates/do/register
+++ b/generators/app/templates/do/register
@@ -330,6 +330,12 @@ echo "   Model name:        ${MODEL_NAME:-N/A}"
 <% } %>
 <% if (deploymentTarget === 'managed-inference') { %>
 echo "   Instance type:     ${INSTANCE_TYPE}"
+<% } else if (deploymentTarget === 'batch-transform') { %>
+echo "   Instance:          ${INSTANCE_TYPE} x ${BATCH_INSTANCE_COUNT}"
+echo "   S3 input:          ${BATCH_INPUT_PATH}"
+echo "   S3 output:         ${BATCH_OUTPUT_PATH}"
+echo "   Split type:        ${BATCH_SPLIT_TYPE}"
+echo "   Strategy:          ${BATCH_STRATEGY}"
 <% } %>
 echo "   Region:            ${AWS_REGION}"
 echo "   Status:            ${STATUS}"
@@ -366,7 +372,7 @@ if [ -n "${MODEL_NAME:-}" ]; then
 fi
 <% } %>
 
-<% if (deploymentTarget === 'managed-inference' || deploymentTarget === 'async-inference') { %>
+<% if (deploymentTarget === 'managed-inference' || deploymentTarget === 'async-inference' || deploymentTarget === 'batch-transform') { %>
 CMD_ARGS+=("--instance-type" "${INSTANCE_TYPE}")
 <% } %>
 

--- a/generators/app/templates/do/test
+++ b/generators/app/templates/do/test
@@ -854,4 +854,270 @@ else
     echo "  ./do/register"
 fi
 
+<% } else if (deploymentTarget === 'batch-transform') { %>
+# ============================================================
+# SageMaker Managed Inference - Batch Testing
+# ============================================================
+
+# Parse arguments: local or batch test mode
+# Default to batch if no argument given (deployment target is batch-transform)
+TEST_TARGET="${1:-batch}"
+
+case "${TEST_TARGET}" in
+    local)
+        echo "🧪 Testing local container at localhost:8080"
+        echo "   Project: ${PROJECT_NAME}"
+        echo "   Framework: ${FRAMEWORK}"
+        echo "   Model server: ${MODEL_SERVER}"
+        TARGET_URL="http://localhost:8080"
+        ;;
+    batch)
+        echo "🧪 Checking batch transform job status"
+        echo "   Project: ${PROJECT_NAME}"
+        echo "   Framework: ${FRAMEWORK}"
+        echo "   Region: ${AWS_REGION}"
+        echo "   S3 input: ${BATCH_INPUT_PATH}"
+        echo "   S3 output: ${BATCH_OUTPUT_PATH}"
+        echo ""
+
+        # Get transform job name from config
+        TRANSFORM_JOB_NAME="${TRANSFORM_JOB_NAME:-}"
+        if [ -z "${TRANSFORM_JOB_NAME}" ]; then
+            echo "❌ No transform job name found"
+            echo "   Run ./do/deploy first to create a transform job"
+            exit 1
+        fi
+
+        echo "🔍 Checking transform job: ${TRANSFORM_JOB_NAME}"
+
+        if ! JOB_STATUS_JSON=$(aws sagemaker describe-transform-job \
+            --transform-job-name "${TRANSFORM_JOB_NAME}" \
+            --region "${AWS_REGION}" 2>&1); then
+            echo "❌ Failed to describe transform job"
+            echo "   Error: ${JOB_STATUS_JSON}"
+            exit 1
+        fi
+
+        JOB_STATUS=$(echo "${JOB_STATUS_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('TransformJobStatus','Unknown'))" 2>/dev/null || echo "Unknown")
+
+        case "${JOB_STATUS}" in
+            Completed)
+                echo "✅ Transform job completed successfully"
+                echo ""
+
+                # Download results locally
+                LOCAL_OUTPUT_DIR="${SCRIPT_DIR}/../batch-output"
+                mkdir -p "${LOCAL_OUTPUT_DIR}"
+                echo "📥 Downloading results to ${LOCAL_OUTPUT_DIR}/"
+                if aws s3 sync "${BATCH_OUTPUT_PATH}" "${LOCAL_OUTPUT_DIR}/" --region "${AWS_REGION}"; then
+                    DOWNLOADED=$(ls -1 "${LOCAL_OUTPUT_DIR}" 2>/dev/null | wc -l | tr -d ' ')
+                    echo "✅ Downloaded ${DOWNLOADED} file(s) to ${LOCAL_OUTPUT_DIR}/"
+                    echo ""
+
+                    # Display first output file preview
+                    FIRST_FILE=$(ls -1 "${LOCAL_OUTPUT_DIR}" 2>/dev/null | head -1)
+                    if [ -n "${FIRST_FILE}" ]; then
+                        echo "📄 Sample output (${FIRST_FILE}):"
+                        head -5 "${LOCAL_OUTPUT_DIR}/${FIRST_FILE}"
+                        LINES=$(wc -l < "${LOCAL_OUTPUT_DIR}/${FIRST_FILE}" | tr -d ' ')
+                        if [ "${LINES}" -gt 5 ]; then
+                            echo "   ... (${LINES} total lines)"
+                        fi
+                    fi
+                else
+                    echo "⚠️  Could not download output files"
+                fi
+
+                echo ""
+                echo "✅ All tests passed!"
+                echo ""
+                echo "📝 Register this deployment:"
+                echo "  ./do/register"
+                ;;
+            InProgress)
+                echo "⏳ Transform job is still in progress"
+
+                # Extract progress details
+                CREATION_TIME=$(echo "${JOB_STATUS_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('CreationTime','Unknown'))" 2>/dev/null || echo "Unknown")
+                echo "   Started: ${CREATION_TIME}"
+                echo "   Status: InProgress"
+                echo ""
+                echo "   The job is still running. Check again later:"
+                echo "   ./do/test"
+                echo ""
+                echo "   View logs:"
+                echo "   ./do/logs"
+                ;;
+            Failed)
+                echo "❌ Transform job failed"
+
+                FAILURE_REASON=$(echo "${JOB_STATUS_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('FailureReason','Unknown'))" 2>/dev/null || echo "Unknown")
+                echo "   Reason: ${FAILURE_REASON}"
+                echo ""
+                echo "   View logs for more details:"
+                echo "   ./do/logs"
+                exit 1
+                ;;
+            Stopped)
+                echo "⚠️  Transform job was stopped"
+                echo "   The job was manually stopped before completion"
+                echo ""
+                echo "   To start a new job, run:"
+                echo "   ./do/deploy"
+                ;;
+            *)
+                echo "⚠️  Transform job status: ${JOB_STATUS}"
+                echo "   Check again later: ./do/test"
+                ;;
+        esac
+        exit 0
+        ;;
+    *)
+        echo "Usage: ./do/test [local|batch]"
+        echo ""
+        echo "Test modes:"
+        echo "  local - Test local container at localhost:8080"
+        echo "  batch - Check transform job status and view results"
+        exit 1
+        ;;
+esac
+
+echo ""
+
+# Test 1: Health check (/ping)
+echo "🔍 Test 1: Health check"
+echo "   Sending GET request to ${TARGET_URL}/ping"
+
+if ! PING_RESPONSE=$(curl -s -w "\n%{http_code}" -X GET "${TARGET_URL}/ping" 2>&1); then
+    echo "❌ Health check failed: Could not connect to local container"
+    echo "   Make sure the container is running: ./do/run"
+    exit 1
+fi
+
+HTTP_CODE=$(echo "${PING_RESPONSE}" | tail -n1)
+RESPONSE_BODY=$(echo "${PING_RESPONSE}" | sed '$d')
+
+if [ "${HTTP_CODE}" = "200" ]; then
+    echo "✅ Health check passed (HTTP ${HTTP_CODE})"
+else
+    echo "❌ Health check failed (HTTP ${HTTP_CODE})"
+    echo "   Response: ${RESPONSE_BODY}"
+    exit 1
+fi
+
+echo ""
+
+# Test 2: Inference request (/invocations)
+echo "🔍 Test 2: Inference request"
+
+# Create framework-specific test payload
+case "${FRAMEWORK}" in
+    sklearn|xgboost)
+        TEST_PAYLOAD='{"instances": [[1.0, 2.0, 3.0, 4.0]]}'
+        echo "   Payload: Sample feature vector"
+        ;;
+    tensorflow)
+        TEST_PAYLOAD='{"instances": [[1.0, 2.0, 3.0, 4.0]]}'
+        echo "   Payload: Sample feature vector"
+        ;;
+    transformers)
+        case "${MODEL_SERVER}" in
+            vllm|sglang)
+                TEST_PAYLOAD='{"model": "'"${MODEL_NAME}"'", "messages": [{"role": "user", "content": "What is machine learning?"}], "max_tokens": 50, "temperature": 0.7}'
+                echo "   Payload: OpenAI-compatible chat completion request"
+                ;;
+            *)
+                TEST_PAYLOAD='{"inputs": "What is machine learning?", "parameters": {"max_new_tokens": 50, "temperature": 0.7}}'
+                echo "   Payload: HuggingFace-style text generation request"
+                ;;
+        esac
+        ;;
+    diffusors)
+        TEST_PAYLOAD='{"prompt": "A white cat", "n": 1, "size": "512x512"}'
+        echo "   Payload: OpenAI DALL-E compatible image generation request"
+        ;;
+    *)
+        echo "❌ Unknown framework: ${FRAMEWORK}"
+        exit 3
+        ;;
+esac
+
+if [ "${FRAMEWORK}" = "diffusors" ]; then
+    echo "   Sending POST request to ${TARGET_URL}/v1/images/generations"
+
+    if ! INVOKE_RESPONSE=$(curl -s -m 120 -w "\n%{http_code}" -X POST "${TARGET_URL}/v1/images/generations" \
+        -H "Content-Type: application/json" \
+        -d "${TEST_PAYLOAD}" 2>&1); then
+        echo "❌ Inference request failed: Could not connect to local container"
+        exit 1
+    fi
+
+    HTTP_CODE=$(echo "${INVOKE_RESPONSE}" | tail -n1)
+    RESPONSE_BODY=$(echo "${INVOKE_RESPONSE}" | sed '$d')
+
+    if [ "${HTTP_CODE}" = "200" ]; then
+        if echo "${RESPONSE_BODY}" | python3 -c "
+import sys, json
+resp = json.load(sys.stdin)
+assert 'data' in resp, 'Missing data array'
+assert len(resp['data']) > 0, 'Empty data array'
+assert 'b64_json' in resp['data'][0], 'Missing b64_json in data entry'
+" 2>/dev/null; then
+            echo "✅ Image generation successful (HTTP ${HTTP_CODE})"
+            echo "   Response contains valid data array with b64_json image"
+
+            # Save generated image to file
+            OUTPUT_IMAGE="${SCRIPT_DIR}/../test_output.png"
+            if echo "${RESPONSE_BODY}" | python3 -c "
+import sys, json, base64
+resp = json.load(sys.stdin)
+img_data = base64.b64decode(resp['data'][0]['b64_json'])
+with open('${OUTPUT_IMAGE}', 'wb') as f:
+    f.write(img_data)
+" 2>/dev/null; then
+                echo "   🖼️  Image saved to: ${OUTPUT_IMAGE}"
+            fi
+        else
+            echo "⚠️  Image generation returned HTTP ${HTTP_CODE} but response format unexpected"
+            echo "   Response preview: ${RESPONSE_BODY:0:200}"
+        fi
+    else
+        echo "❌ Image generation failed (HTTP ${HTTP_CODE})"
+        echo "   Response: ${RESPONSE_BODY}"
+        exit 1
+    fi
+else
+    echo "   Sending POST request to ${TARGET_URL}/invocations"
+
+    if ! INVOKE_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${TARGET_URL}/invocations" \
+        -H "Content-Type: application/json" \
+        -d "${TEST_PAYLOAD}" 2>&1); then
+        echo "❌ Inference request failed: Could not connect to local container"
+        exit 1
+    fi
+
+    HTTP_CODE=$(echo "${INVOKE_RESPONSE}" | tail -n1)
+    RESPONSE_BODY=$(echo "${INVOKE_RESPONSE}" | sed '$d')
+
+    if [ "${HTTP_CODE}" = "200" ]; then
+        echo "✅ Inference request successful (HTTP ${HTTP_CODE})"
+        echo "   Response preview: ${RESPONSE_BODY:0:200}"
+        if [ ${#RESPONSE_BODY} -gt 200 ]; then
+            echo "   (truncated, full response is ${#RESPONSE_BODY} characters)"
+        fi
+    else
+        echo "❌ Inference request failed (HTTP ${HTTP_CODE})"
+        echo "   Response: ${RESPONSE_BODY}"
+        exit 1
+    fi
+fi
+
+echo ""
+echo "✅ All tests passed!"
+echo ""
+
+echo "Next steps:"
+echo "  • Push to ECR: ./do/push"
+echo "  • Deploy batch transform: ./do/deploy"
+
 <% } %>

--- a/test/batch-transform-backward-compat.property.test.js
+++ b/test/batch-transform-backward-compat.property.test.js
@@ -1,0 +1,281 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Backward Compatibility Property-Based Tests
+ *
+ * Feature: batch-transform-endpoint, Property 7: Backward compatibility for existing deployment targets
+ *
+ * For any valid generator configuration where deploymentTarget equals managed-inference,
+ * async-inference, or hyperpod-eks, the generated project output (file set and file contents)
+ * SHALL be identical to the output produced by the generator before the batch-transform feature
+ * was added.
+ *
+ * Validates: Requirements 10.1, 10.2, 10.3
+ */
+
+import fc from 'fast-check'
+import { describe, it } from 'mocha'
+import assert from 'assert'
+import TemplateManager from '../generators/app/lib/template-manager.js'
+import ConfigManager from '../generators/app/lib/config-manager.js'
+
+const FAST_PROPERTY_CONFIG = {
+    numRuns: 100,
+    timeout: 30000,
+    verbose: false
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const EXISTING_DEPLOYMENT_TARGETS = ['managed-inference', 'async-inference', 'hyperpod-eks']
+
+const VALID_DEPLOYMENT_CONFIGS = [
+    'http-flask', 'http-fastapi',
+    'transformers-vllm', 'transformers-sglang',
+    'transformers-tensorrt-llm', 'transformers-lmi', 'transformers-djl',
+    'triton-fil', 'triton-onnxruntime', 'triton-tensorflow',
+    'triton-pytorch', 'triton-vllm', 'triton-tensorrtllm', 'triton-python',
+    'diffusors-vllm-omni'
+]
+
+/** Deployment configs safe for CPU instances (no GPU requirement) */
+const CPU_SAFE_DEPLOYMENT_CONFIGS = VALID_DEPLOYMENT_CONFIGS.filter(
+    dc => !['triton-vllm', 'triton-tensorrtllm', 'diffusors-vllm-omni'].includes(dc)
+)
+
+const VALID_AWS_REGIONS = [
+    'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2',
+    'eu-west-1', 'eu-west-2', 'eu-central-1', 'eu-north-1',
+    'ap-southeast-1', 'ap-southeast-2', 'ap-northeast-1',
+    'ca-central-1', 'sa-east-1'
+]
+
+const VALID_INSTANCE_TYPES = [
+    'ml.m5.large', 'ml.m5.xlarge', 'ml.m5.2xlarge',
+    'ml.c5.large', 'ml.c5.xlarge',
+    'ml.t3.medium', 'ml.t3.large'
+]
+
+const GPU_INSTANCE_TYPES = [
+    'ml.g5.xlarge', 'ml.g5.2xlarge', 'ml.g4dn.xlarge'
+]
+
+// ── Arbitrary generators ─────────────────────────────────────────────────────
+
+/** Generate a valid managed-inference configuration */
+const arbManagedInferenceConfig = fc.record({
+    deploymentConfig: fc.constantFrom(...CPU_SAFE_DEPLOYMENT_CONFIGS),
+    awsRegion: fc.constantFrom(...VALID_AWS_REGIONS),
+    instanceType: fc.constantFrom(...VALID_INSTANCE_TYPES),
+    deploymentTarget: fc.constant('managed-inference')
+})
+
+/** Generate a valid async-inference configuration */
+const arbAsyncInferenceConfig = fc.record({
+    deploymentConfig: fc.constantFrom(...CPU_SAFE_DEPLOYMENT_CONFIGS),
+    awsRegion: fc.constantFrom(...VALID_AWS_REGIONS),
+    instanceType: fc.constantFrom(...VALID_INSTANCE_TYPES),
+    deploymentTarget: fc.constant('async-inference')
+})
+
+/** Generate a valid hyperpod-eks configuration */
+const arbHyperPodEksConfig = fc.record({
+    deploymentConfig: fc.constantFrom(...CPU_SAFE_DEPLOYMENT_CONFIGS),
+    awsRegion: fc.constantFrom(...VALID_AWS_REGIONS),
+    deploymentTarget: fc.constant('hyperpod-eks'),
+    hyperPodCluster: fc.stringMatching(/^[a-z][a-z0-9-]{2,20}$/).filter(s => !s.endsWith('-')),
+    hyperPodNamespace: fc.constantFrom('default', 'production', 'staging'),
+    hyperPodReplicas: fc.integer({ min: 1, max: 10 })
+})
+
+/** Generate random batch-transform parameters that should be ignored for non-batch targets */
+const arbBatchParams = fc.record({
+    batchInputPath: fc.constantFrom('s3://bucket/input/', 's3://data/in/', undefined),
+    batchOutputPath: fc.constantFrom('s3://bucket/output/', 's3://data/out/', undefined),
+    batchInstanceCount: fc.constantFrom(1, 2, 5, undefined),
+    batchSplitType: fc.constantFrom('Line', 'RecordIO', 'None', undefined),
+    batchStrategy: fc.constantFrom('MultiRecord', 'SingleRecord', undefined),
+    batchJoinSource: fc.constantFrom('Input', 'None', undefined),
+    batchMaxConcurrentTransforms: fc.constantFrom(0, 1, 5, undefined),
+    batchMaxPayloadInMB: fc.constantFrom(6, 50, 100, undefined)
+})
+
+/** Generate a config for any existing deployment target */
+const arbExistingTargetConfig = fc.oneof(
+    arbManagedInferenceConfig,
+    arbAsyncInferenceConfig,
+    arbHyperPodEksConfig
+)
+
+// ── Property 7: Backward compatibility for existing deployment targets ───────
+
+describe('Feature: batch-transform-endpoint, Property 7: Backward compatibility for existing deployment targets', () => {
+
+    it('existing deployment targets pass validation with valid configurations', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 10.1, 10.2, 10.3
+         */
+        fc.assert(fc.property(
+            arbExistingTargetConfig,
+            (config) => {
+                const manager = new TemplateManager(config)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('batch-specific parameters do not interfere with existing deployment targets', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 10.1, 10.2, 10.3
+         *
+         * Even when batch-specific parameters are present in the config,
+         * validation for existing targets should pass without errors because
+         * _validateBatchTransformConfig() returns early when deploymentTarget
+         * is not 'batch-transform'.
+         */
+        fc.assert(fc.property(
+            arbExistingTargetConfig,
+            arbBatchParams,
+            (baseConfig, batchParams) => {
+                // Merge batch params into the existing target config
+                const configWithBatchParams = { ...baseConfig }
+                for (const [key, value] of Object.entries(batchParams)) {
+                    if (value !== undefined) {
+                        configWithBatchParams[key] = value
+                    }
+                }
+
+                const manager = new TemplateManager(configWithBatchParams)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('deploymentTarget defaults to managed-inference in ConfigManager', function () {
+        /**
+         * Validates: Requirements 10.1, 10.2, 10.3
+         *
+         * The default deploymentTarget must remain managed-inference to ensure
+         * backward compatibility when no explicit selection is made.
+         */
+        const mockGenerator = {
+            options: {},
+            destinationPath: () => '/tmp/nonexistent'
+        }
+        const configManager = new ConfigManager(mockGenerator)
+        const matrix = configManager.parameterMatrix
+        assert.strictEqual(
+            matrix.deploymentTarget.default,
+            'managed-inference',
+            'deploymentTarget default must be managed-inference'
+        )
+    })
+
+    it('managed-inference configs always pass validation regardless of deployment config choice', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 10.1
+         */
+        fc.assert(fc.property(
+            fc.constantFrom(...CPU_SAFE_DEPLOYMENT_CONFIGS),
+            fc.constantFrom(...VALID_AWS_REGIONS),
+            fc.constantFrom(...VALID_INSTANCE_TYPES),
+            (deploymentConfig, awsRegion, instanceType) => {
+                const config = {
+                    deploymentConfig,
+                    awsRegion,
+                    instanceType,
+                    deploymentTarget: 'managed-inference'
+                }
+                const manager = new TemplateManager(config)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('async-inference configs always pass validation regardless of deployment config choice', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 10.2
+         */
+        fc.assert(fc.property(
+            fc.constantFrom(...CPU_SAFE_DEPLOYMENT_CONFIGS),
+            fc.constantFrom(...VALID_AWS_REGIONS),
+            fc.constantFrom(...VALID_INSTANCE_TYPES),
+            (deploymentConfig, awsRegion, instanceType) => {
+                const config = {
+                    deploymentConfig,
+                    awsRegion,
+                    instanceType,
+                    deploymentTarget: 'async-inference'
+                }
+                const manager = new TemplateManager(config)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('hyperpod-eks configs always pass validation with valid cluster settings', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 10.3
+         */
+        fc.assert(fc.property(
+            fc.constantFrom(...CPU_SAFE_DEPLOYMENT_CONFIGS),
+            fc.constantFrom(...VALID_AWS_REGIONS),
+            arbHyperPodEksConfig,
+            (deploymentConfig, awsRegion, hpConfig) => {
+                const config = {
+                    ...hpConfig,
+                    deploymentConfig,
+                    awsRegion
+                }
+                const manager = new TemplateManager(config)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('GPU-requiring deployment configs still work with GPU instances for existing targets', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 10.1, 10.2
+         *
+         * GPU-requiring backends (triton-vllm, triton-tensorrtllm, diffusors-vllm-omni)
+         * should still validate correctly with GPU instances for existing targets.
+         */
+        const gpuRequiringConfigs = ['triton-vllm', 'triton-tensorrtllm', 'diffusors-vllm-omni']
+
+        fc.assert(fc.property(
+            fc.constantFrom(...gpuRequiringConfigs),
+            fc.constantFrom(...GPU_INSTANCE_TYPES),
+            fc.constantFrom(...VALID_AWS_REGIONS),
+            fc.constantFrom('managed-inference', 'async-inference'),
+            (deploymentConfig, instanceType, awsRegion, deploymentTarget) => {
+                const config = {
+                    deploymentConfig,
+                    instanceType,
+                    awsRegion,
+                    deploymentTarget
+                }
+                const manager = new TemplateManager(config)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+})

--- a/test/batch-transform-container-reuse.property.test.js
+++ b/test/batch-transform-container-reuse.property.test.js
@@ -1,0 +1,302 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Container Image Reuse Property-Based Tests
+ *
+ * Feature: batch-transform-endpoint, Property 8: Container image reuse across deployment targets
+ *
+ * For any valid generator configuration, if only the deploymentTarget is changed between
+ * managed-inference and batch-transform while all other parameters remain the same, the
+ * generated Dockerfile, serving code files, and container build scripts (do/build, do/push,
+ * do/submit) SHALL be identical.
+ *
+ * Validates: Requirements 11.1, 11.2
+ */
+
+import fc from 'fast-check'
+import { describe, it } from 'mocha'
+import assert from 'assert'
+import TemplateManager from '../generators/app/lib/template-manager.js'
+
+const FAST_PROPERTY_CONFIG = {
+    numRuns: 100,
+    timeout: 30000,
+    verbose: false
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const VALID_DEPLOYMENT_CONFIGS = [
+    'http-flask', 'http-fastapi',
+    'transformers-vllm', 'transformers-sglang',
+    'transformers-tensorrt-llm', 'transformers-lmi', 'transformers-djl',
+    'triton-fil', 'triton-onnxruntime', 'triton-tensorflow',
+    'triton-pytorch', 'triton-vllm', 'triton-tensorrtllm', 'triton-python',
+    'diffusors-vllm-omni'
+]
+
+/** Deployment configs safe for CPU instances (no GPU requirement) */
+const CPU_SAFE_DEPLOYMENT_CONFIGS = VALID_DEPLOYMENT_CONFIGS.filter(
+    dc => !['triton-vllm', 'triton-tensorrtllm', 'diffusors-vllm-omni'].includes(dc)
+)
+
+const GPU_REQUIRING_CONFIGS = ['triton-vllm', 'triton-tensorrtllm', 'diffusors-vllm-omni']
+
+const VALID_AWS_REGIONS = [
+    'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2',
+    'eu-west-1', 'eu-west-2', 'eu-central-1', 'eu-north-1',
+    'ap-southeast-1', 'ap-southeast-2', 'ap-northeast-1',
+    'ca-central-1', 'sa-east-1'
+]
+
+const CPU_INSTANCE_TYPES = [
+    'ml.m5.large', 'ml.m5.xlarge', 'ml.m5.2xlarge',
+    'ml.c5.large', 'ml.c5.xlarge',
+    'ml.t3.medium', 'ml.t3.large'
+]
+
+const GPU_INSTANCE_TYPES = [
+    'ml.g5.xlarge', 'ml.g5.2xlarge', 'ml.g4dn.xlarge'
+]
+
+// ── Arbitrary generators ─────────────────────────────────────────────────────
+
+/** Generate a base config with CPU-safe deployment config and CPU instance */
+const arbCpuSafeBaseConfig = fc.record({
+    deploymentConfig: fc.constantFrom(...CPU_SAFE_DEPLOYMENT_CONFIGS),
+    awsRegion: fc.constantFrom(...VALID_AWS_REGIONS),
+    instanceType: fc.constantFrom(...CPU_INSTANCE_TYPES)
+})
+
+/** Generate a base config with GPU-requiring deployment config and GPU instance */
+const arbGpuBaseConfig = fc.record({
+    deploymentConfig: fc.constantFrom(...GPU_REQUIRING_CONFIGS),
+    awsRegion: fc.constantFrom(...VALID_AWS_REGIONS),
+    instanceType: fc.constantFrom(...GPU_INSTANCE_TYPES)
+})
+
+/** Generate any valid base config (CPU or GPU) */
+const arbAnyBaseConfig = fc.oneof(arbCpuSafeBaseConfig, arbGpuBaseConfig)
+
+// ── Property 8: Container image reuse across deployment targets ──────────────
+
+describe('Feature: batch-transform-endpoint, Property 8: Container image reuse across deployment targets', () => {
+
+    it('both managed-inference and batch-transform pass validation with the same base configuration', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 11.1, 11.2
+         *
+         * For any valid base config (deploymentConfig, instanceType, region),
+         * both managed-inference and batch-transform should pass TemplateManager
+         * validation. This proves the same container configuration is valid for
+         * both targets — the Dockerfile, serving code, and build scripts are
+         * shared because no target-specific file exclusions exist.
+         */
+        fc.assert(fc.property(
+            arbAnyBaseConfig,
+            (baseConfig) => {
+                const managedConfig = {
+                    ...baseConfig,
+                    deploymentTarget: 'managed-inference'
+                }
+                const batchConfig = {
+                    ...baseConfig,
+                    deploymentTarget: 'batch-transform'
+                }
+
+                const managedManager = new TemplateManager(managedConfig)
+                managedManager.validate()
+
+                const batchManager = new TemplateManager(batchConfig)
+                batchManager.validate()
+
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('TemplateManager does NOT add batch-specific file exclusions or modifications to the container build', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 11.1, 11.2
+         *
+         * The TemplateManager validate() method for batch-transform does not
+         * throw errors related to container build files (Dockerfile, serving code,
+         * do/build, do/push, do/submit). This confirms that batch-transform does
+         * not introduce any container-level restrictions — the same image is used.
+         *
+         * We verify this by adding batch-specific parameters alongside the base
+         * config and confirming validation still passes without any container-related
+         * errors. The batch validation only checks batch-specific fields, not
+         * container build fields.
+         */
+        fc.assert(fc.property(
+            arbAnyBaseConfig,
+            fc.constantFrom('s3://bucket/input/', 's3://data/in/', 's3://test/input/'),
+            fc.constantFrom('s3://bucket/output/', 's3://data/out/', 's3://test/output/'),
+            fc.constantFrom('Line', 'RecordIO', 'None'),
+            fc.constantFrom('MultiRecord', 'SingleRecord'),
+            (baseConfig, inputPath, outputPath, splitType, strategy) => {
+                const batchConfig = {
+                    ...baseConfig,
+                    deploymentTarget: 'batch-transform',
+                    batchInputPath: inputPath,
+                    batchOutputPath: outputPath,
+                    batchSplitType: splitType,
+                    batchStrategy: strategy,
+                    batchInstanceCount: 1,
+                    batchJoinSource: 'None',
+                    batchMaxConcurrentTransforms: 1,
+                    batchMaxPayloadInMB: 6
+                }
+
+                const manager = new TemplateManager(batchConfig)
+                manager.validate()
+
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('both targets use the same instance type selection (verified by both passing validation with the same instanceType)', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 11.1, 11.2
+         *
+         * For any valid instance type, both managed-inference and batch-transform
+         * accept the same instanceType value. This confirms that the instance type
+         * selection is shared — batch-transform does not restrict or modify the
+         * available instance types compared to managed-inference.
+         */
+        fc.assert(fc.property(
+            fc.constantFrom(...CPU_INSTANCE_TYPES, ...GPU_INSTANCE_TYPES),
+            fc.constantFrom(...CPU_SAFE_DEPLOYMENT_CONFIGS),
+            fc.constantFrom(...VALID_AWS_REGIONS),
+            (instanceType, deploymentConfig, awsRegion) => {
+                const managedConfig = {
+                    deploymentConfig,
+                    awsRegion,
+                    instanceType,
+                    deploymentTarget: 'managed-inference'
+                }
+                const batchConfig = {
+                    deploymentConfig,
+                    awsRegion,
+                    instanceType,
+                    deploymentTarget: 'batch-transform'
+                }
+
+                const managedManager = new TemplateManager(managedConfig)
+                managedManager.validate()
+
+                const batchManager = new TemplateManager(batchConfig)
+                batchManager.validate()
+
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('GPU-requiring configs work identically for both managed-inference and batch-transform', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 11.1, 11.2
+         *
+         * GPU-requiring deployment configs (triton-vllm, triton-tensorrtllm,
+         * diffusors-vllm-omni) with GPU instances pass validation for both
+         * managed-inference and batch-transform. This confirms that GPU
+         * enforcement is identical across both targets — the same container
+         * image with GPU support works for both.
+         */
+        fc.assert(fc.property(
+            fc.constantFrom(...GPU_REQUIRING_CONFIGS),
+            fc.constantFrom(...GPU_INSTANCE_TYPES),
+            fc.constantFrom(...VALID_AWS_REGIONS),
+            (deploymentConfig, instanceType, awsRegion) => {
+                const managedConfig = {
+                    deploymentConfig,
+                    instanceType,
+                    awsRegion,
+                    deploymentTarget: 'managed-inference'
+                }
+                const batchConfig = {
+                    deploymentConfig,
+                    instanceType,
+                    awsRegion,
+                    deploymentTarget: 'batch-transform'
+                }
+
+                const managedManager = new TemplateManager(managedConfig)
+                managedManager.validate()
+
+                const batchManager = new TemplateManager(batchConfig)
+                batchManager.validate()
+
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('GPU-requiring configs with CPU instances fail identically for both targets', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 11.1, 11.2
+         *
+         * GPU-requiring deployment configs paired with CPU-only instances
+         * should fail validation for BOTH managed-inference and batch-transform
+         * with the same error. This confirms the GPU enforcement logic is
+         * shared and not target-specific.
+         */
+        fc.assert(fc.property(
+            fc.constantFrom(...GPU_REQUIRING_CONFIGS),
+            fc.constantFrom(...CPU_INSTANCE_TYPES),
+            fc.constantFrom(...VALID_AWS_REGIONS),
+            (deploymentConfig, instanceType, awsRegion) => {
+                const managedConfig = {
+                    deploymentConfig,
+                    instanceType,
+                    awsRegion,
+                    deploymentTarget: 'managed-inference'
+                }
+                const batchConfig = {
+                    deploymentConfig,
+                    instanceType,
+                    awsRegion,
+                    deploymentTarget: 'batch-transform'
+                }
+
+                let managedError = null
+                let batchError = null
+
+                try {
+                    new TemplateManager(managedConfig).validate()
+                } catch (e) {
+                    managedError = e.message
+                }
+
+                try {
+                    new TemplateManager(batchConfig).validate()
+                } catch (e) {
+                    batchError = e.message
+                }
+
+                // Both should fail
+                assert.ok(managedError, 'managed-inference should fail with GPU config + CPU instance')
+                assert.ok(batchError, 'batch-transform should fail with GPU config + CPU instance')
+
+                // Both should fail with the same error message
+                assert.strictEqual(managedError, batchError,
+                    'Both targets should produce identical GPU validation errors')
+
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+})

--- a/test/batch-transform-integration.test.js
+++ b/test/batch-transform-integration.test.js
@@ -1,0 +1,104 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Batch Transform Integration Tests
+ *
+ * Runs the actual Yeoman generator with batch-transform configuration
+ * and verifies the generated file contents.
+ *
+ * Requirements: 4.1, 5.1, 6.1, 7.1, 13.1, 14.1, 14.2, 15.1
+ */
+
+import path from 'path'
+import assert from 'yeoman-assert'
+import helpers from 'yeoman-test'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+describe('batch-transform integration: generated template content', function () {
+    this.timeout(60000)
+
+    const batchOptions = {
+        'skip-prompts': true,
+        'project-name': 'test-batch-project',
+        'deployment-config': 'http-flask',
+        'model-format': 'pkl',
+        'region': 'us-east-1',
+        'deployment-target': 'batch-transform',
+        'instance-type': 'ml.m5.large',
+        'batch-input-path': 's3://test-bucket/input/',
+        'batch-output-path': 's3://test-bucket/output/',
+        'batch-instance-count': 2,
+        'batch-split-type': 'Line',
+        'batch-strategy': 'MultiRecord',
+        'batch-join-source': 'None',
+        'batch-max-concurrent': 1,
+        'batch-max-payload': 6,
+        'build-target': 'codebuild',
+        'include-sample': false,
+        'include-testing': false
+    }
+
+    beforeEach(async function () {
+        await helpers.run(path.join(__dirname, '../generators/app'))
+            .withOptions(batchOptions)
+    })
+
+    // Requirement 7.1: do/config contains batch variables
+    it('do/config contains batch variables when deploymentTarget === batch-transform', () => {
+        assert.fileContent('do/config', 'BATCH_INPUT_PATH')
+        assert.fileContent('do/config', 'BATCH_OUTPUT_PATH')
+        assert.fileContent('do/config', 'BATCH_INSTANCE_COUNT')
+        assert.fileContent('do/config', 'BATCH_SPLIT_TYPE')
+        assert.fileContent('do/config', 'BATCH_STRATEGY')
+        assert.fileContent('do/config', 'INSTANCE_TYPE')
+    })
+
+    // Requirement 4.1: do/deploy contains create-transform-job
+    it('do/deploy contains create-transform-job when deploymentTarget === batch-transform', () => {
+        assert.fileContent('do/deploy', 'create-transform-job')
+    })
+
+    // Requirement 5.1: do/test contains describe-transform-job
+    it('do/test contains describe-transform-job when deploymentTarget === batch-transform', () => {
+        assert.fileContent('do/test', 'describe-transform-job')
+    })
+
+    // Requirement 6.1: do/clean contains batch cleanup target
+    it('do/clean contains batch cleanup target when deploymentTarget === batch-transform', () => {
+        assert.fileContent('do/clean', 'batch')
+    })
+
+    // Requirement 6.1: do/clean contains stop-transform-job
+    it('do/clean contains stop-transform-job when deploymentTarget === batch-transform', () => {
+        assert.fileContent('do/clean', 'stop-transform-job')
+    })
+
+    // Requirement 13.1: do/logs contains /aws/sagemaker/TransformJobs
+    it('do/logs contains /aws/sagemaker/TransformJobs when deploymentTarget === batch-transform', () => {
+        assert.fileContent('do/logs', '/aws/sagemaker/TransformJobs')
+    })
+
+    // Requirement 14.1: do/register summary contains BATCH_INSTANCE_COUNT
+    it('do/register summary contains BATCH_INSTANCE_COUNT when deploymentTarget === batch-transform', () => {
+        assert.fileContent('do/register', 'BATCH_INSTANCE_COUNT')
+    })
+
+    // Requirement 14.2: do/register CLI args contain --instance-type
+    it('do/register CLI args contain --instance-type when deploymentTarget === batch-transform', () => {
+        assert.fileContent('do/register', '--instance-type')
+    })
+
+    // Requirement 15.1: do/export contains --batch-input-path
+    it('do/export contains --batch-input-path when deploymentTarget === batch-transform', () => {
+        assert.fileContent('do/export', '--batch-input-path')
+    })
+
+    // Requirement 15.1: do/export contains --instance-type
+    it('do/export contains --instance-type when deploymentTarget === batch-transform', () => {
+        assert.fileContent('do/export', '--instance-type')
+    })
+})

--- a/test/batch-transform-validation.property.test.js
+++ b/test/batch-transform-validation.property.test.js
@@ -1,0 +1,533 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Template Manager Batch Transform Validation Property-Based Tests
+ *
+ * Feature: batch-transform-endpoint, Property 1: Deployment target validation accepts exactly the supported set
+ * Feature: batch-transform-endpoint, Property 2: S3 path validation
+ * Feature: batch-transform-endpoint, Property 3: Batch instance count validation
+ * Feature: batch-transform-endpoint, Property 4: Bounded enum parameter validation
+ * Feature: batch-transform-endpoint, Property 5: Max concurrent transforms validation
+ * Feature: batch-transform-endpoint, Property 6: Max payload in MB validation
+ *
+ * Validates: Requirements 1.2, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8
+ */
+
+import fc from 'fast-check'
+import { describe, it } from 'mocha'
+import assert from 'assert'
+import TemplateManager from '../generators/app/lib/template-manager.js'
+
+const FAST_PROPERTY_CONFIG = {
+    numRuns: 100,
+    timeout: 30000,
+    verbose: false
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const SUPPORTED_DEPLOYMENT_TARGETS = ['managed-inference', 'async-inference', 'batch-transform', 'hyperpod-eks']
+
+const VALID_SPLIT_TYPES = ['Line', 'RecordIO', 'None']
+const VALID_BATCH_STRATEGIES = ['MultiRecord', 'SingleRecord']
+const VALID_JOIN_SOURCES = ['Input', 'None']
+
+/** Base answers that produce a valid batch-transform config */
+const baseAnswers = {
+    projectName: 'test-project',
+    deploymentConfig: 'http-flask',
+    awsRegion: 'us-east-1',
+    deploymentTarget: 'batch-transform',
+    instanceType: 'ml.m5.large'
+}
+
+// ── Arbitrary generators ─────────────────────────────────────────────────────
+
+/** Valid S3 paths starting with s3:// */
+const arbValidS3Path = fc.stringMatching(/^s3:\/\/[a-z0-9][a-z0-9.-]{1,30}\/[a-z0-9/.-]{1,50}$/)
+
+/** Non-empty strings that do NOT start with s3:// */
+const arbInvalidS3Path = fc.string({ minLength: 1, maxLength: 60 })
+    .filter(s => s.trim() !== '' && !s.startsWith('s3://'))
+
+/** Valid instance count (integer >= 1) */
+const arbValidInstanceCount = fc.integer({ min: 1, max: 10000 })
+
+/** Invalid instance count (integer < 1 or non-integer) */
+const arbInvalidInstanceCount = fc.oneof(
+    fc.integer({ min: -1000, max: 0 }),
+    fc.double({ min: 0.1, max: 99.9, noNaN: true }).filter(v => !Number.isInteger(v))
+)
+
+/** Valid max concurrent transforms (integer >= 0) */
+const arbValidMaxConcurrent = fc.integer({ min: 0, max: 10000 })
+
+/** Invalid max concurrent transforms (integer < 0 or non-integer) */
+const arbInvalidMaxConcurrent = fc.oneof(
+    fc.integer({ min: -1000, max: -1 }),
+    fc.double({ min: 0.1, max: 99.9, noNaN: true }).filter(v => !Number.isInteger(v))
+)
+
+/** Valid max payload in MB (integer 0-100) */
+const arbValidMaxPayload = fc.integer({ min: 0, max: 100 })
+
+/** Invalid max payload in MB (outside 0-100 or non-integer) */
+const arbInvalidMaxPayload = fc.oneof(
+    fc.integer({ min: -1000, max: -1 }),
+    fc.integer({ min: 101, max: 10000 }),
+    fc.double({ min: 0.1, max: 99.9, noNaN: true }).filter(v => !Number.isInteger(v))
+)
+
+// ── Property 1: Deployment target validation ─────────────────────────────────
+
+describe('Feature: batch-transform-endpoint, Property 1: Deployment target validation accepts exactly the supported set', () => {
+
+    it('valid deployment targets always pass validation', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 1.2
+         */
+        fc.assert(fc.property(
+            fc.constantFrom(...SUPPORTED_DEPLOYMENT_TARGETS),
+            (deploymentTarget) => {
+                const answers = {
+                    deploymentConfig: 'http-flask',
+                    awsRegion: 'us-east-1',
+                    instanceType: 'ml.m5.large',
+                    deploymentTarget
+                }
+
+                // Add required fields per target
+                if (deploymentTarget === 'hyperpod-eks') {
+                    answers.hyperPodCluster = 'my-cluster'
+                    answers.hyperPodNamespace = 'default'
+                    answers.hyperPodReplicas = 1
+                    delete answers.instanceType
+                }
+
+                const manager = new TemplateManager(answers)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('invalid deployment targets always fail validation', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 1.2
+         */
+        fc.assert(fc.property(
+            fc.string({ minLength: 1, maxLength: 40 })
+                .filter(s => !SUPPORTED_DEPLOYMENT_TARGETS.includes(s)),
+            (deploymentTarget) => {
+                const answers = {
+                    deploymentConfig: 'http-flask',
+                    awsRegion: 'us-east-1',
+                    instanceType: 'ml.m5.large',
+                    deploymentTarget
+                }
+
+                const manager = new TemplateManager(answers)
+                assert.throws(
+                    () => manager.validate(),
+                    /not implemented yet for deploymentTarget/,
+                    `deploymentTarget "${deploymentTarget}" should fail validation`
+                )
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+})
+
+// ── Property 2: S3 path validation ───────────────────────────────────────────
+
+describe('Feature: batch-transform-endpoint, Property 2: S3 path validation', () => {
+
+    it('S3 input paths starting with s3:// are accepted', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.1
+         */
+        fc.assert(fc.property(
+            arbValidS3Path,
+            (s3Path) => {
+                const answers = { ...baseAnswers, batchInputPath: s3Path }
+                const manager = new TemplateManager(answers)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('S3 output paths starting with s3:// are accepted', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.2
+         */
+        fc.assert(fc.property(
+            arbValidS3Path,
+            (s3Path) => {
+                const answers = { ...baseAnswers, batchOutputPath: s3Path }
+                const manager = new TemplateManager(answers)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('non-empty S3 input paths NOT starting with s3:// are rejected', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.1
+         */
+        fc.assert(fc.property(
+            arbInvalidS3Path,
+            (s3Path) => {
+                const answers = { ...baseAnswers, batchInputPath: s3Path }
+                const manager = new TemplateManager(answers)
+                assert.throws(
+                    () => manager.validate(),
+                    /batchInputPath must start with "s3:\/\/"/,
+                    `batchInputPath "${s3Path}" should fail validation`
+                )
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('non-empty S3 output paths NOT starting with s3:// are rejected', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.2
+         */
+        fc.assert(fc.property(
+            arbInvalidS3Path,
+            (s3Path) => {
+                const answers = { ...baseAnswers, batchOutputPath: s3Path }
+                const manager = new TemplateManager(answers)
+                assert.throws(
+                    () => manager.validate(),
+                    /batchOutputPath must start with "s3:\/\/"/,
+                    `batchOutputPath "${s3Path}" should fail validation`
+                )
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('empty or null S3 paths are accepted (validation skipped)', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.1, 8.2
+         */
+        fc.assert(fc.property(
+            fc.constantFrom(null, undefined, '', '   '),
+            fc.constantFrom(null, undefined, '', '   '),
+            (inputPath, outputPath) => {
+                const answers = { ...baseAnswers }
+                if (inputPath !== undefined) {
+                    answers.batchInputPath = inputPath
+                }
+                if (outputPath !== undefined) {
+                    answers.batchOutputPath = outputPath
+                }
+                const manager = new TemplateManager(answers)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+})
+
+// ── Property 3: Batch instance count validation ──────────────────────────────
+
+describe('Feature: batch-transform-endpoint, Property 3: Batch instance count validation', () => {
+
+    it('integers >= 1 are accepted', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.3
+         */
+        fc.assert(fc.property(
+            arbValidInstanceCount,
+            (instanceCount) => {
+                const answers = { ...baseAnswers, batchInstanceCount: instanceCount }
+                const manager = new TemplateManager(answers)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('integers < 1 and non-integers are rejected', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.3
+         */
+        fc.assert(fc.property(
+            arbInvalidInstanceCount,
+            (instanceCount) => {
+                const answers = { ...baseAnswers, batchInstanceCount: instanceCount }
+                const manager = new TemplateManager(answers)
+                assert.throws(
+                    () => manager.validate(),
+                    /batchInstanceCount must be an integer >= 1/,
+                    `batchInstanceCount "${instanceCount}" should fail validation`
+                )
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('undefined batchInstanceCount is accepted (uses default)', function () {
+        /**
+         * Validates: Requirements 8.3
+         */
+        const answers = { ...baseAnswers }
+        const manager = new TemplateManager(answers)
+        manager.validate()
+    })
+})
+
+// ── Property 4: Bounded enum parameter validation ────────────────────────────
+
+describe('Feature: batch-transform-endpoint, Property 4: Bounded enum parameter validation', () => {
+
+    // ── batchSplitType ───────────────────────────────────────────────────────
+
+    it('valid batchSplitType values are accepted', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.4
+         */
+        fc.assert(fc.property(
+            fc.constantFrom(...VALID_SPLIT_TYPES),
+            (splitType) => {
+                const answers = { ...baseAnswers, batchSplitType: splitType }
+                const manager = new TemplateManager(answers)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('invalid batchSplitType values are rejected', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.4
+         */
+        fc.assert(fc.property(
+            fc.string({ minLength: 1, maxLength: 40 })
+                .filter(s => !VALID_SPLIT_TYPES.includes(s)),
+            (splitType) => {
+                const answers = { ...baseAnswers, batchSplitType: splitType }
+                const manager = new TemplateManager(answers)
+                assert.throws(
+                    () => manager.validate(),
+                    /batchSplitType must be one of/,
+                    `batchSplitType "${splitType}" should fail validation`
+                )
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    // ── batchStrategy ────────────────────────────────────────────────────────
+
+    it('valid batchStrategy values are accepted', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.5
+         */
+        fc.assert(fc.property(
+            fc.constantFrom(...VALID_BATCH_STRATEGIES),
+            (strategy) => {
+                const answers = { ...baseAnswers, batchStrategy: strategy }
+                const manager = new TemplateManager(answers)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('invalid batchStrategy values are rejected', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.5
+         */
+        fc.assert(fc.property(
+            fc.string({ minLength: 1, maxLength: 40 })
+                .filter(s => !VALID_BATCH_STRATEGIES.includes(s)),
+            (strategy) => {
+                const answers = { ...baseAnswers, batchStrategy: strategy }
+                const manager = new TemplateManager(answers)
+                assert.throws(
+                    () => manager.validate(),
+                    /batchStrategy must be one of/,
+                    `batchStrategy "${strategy}" should fail validation`
+                )
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    // ── batchJoinSource ──────────────────────────────────────────────────────
+
+    it('valid batchJoinSource values are accepted', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.6
+         */
+        fc.assert(fc.property(
+            fc.constantFrom(...VALID_JOIN_SOURCES),
+            (joinSource) => {
+                const answers = { ...baseAnswers, batchJoinSource: joinSource }
+                const manager = new TemplateManager(answers)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('invalid batchJoinSource values are rejected', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.6
+         */
+        fc.assert(fc.property(
+            fc.string({ minLength: 1, maxLength: 40 })
+                .filter(s => !VALID_JOIN_SOURCES.includes(s)),
+            (joinSource) => {
+                const answers = { ...baseAnswers, batchJoinSource: joinSource }
+                const manager = new TemplateManager(answers)
+                assert.throws(
+                    () => manager.validate(),
+                    /batchJoinSource must be one of/,
+                    `batchJoinSource "${joinSource}" should fail validation`
+                )
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+})
+
+// ── Property 5: Max concurrent transforms validation ─────────────────────────
+
+describe('Feature: batch-transform-endpoint, Property 5: Max concurrent transforms validation', () => {
+
+    it('integers >= 0 are accepted', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.7
+         */
+        fc.assert(fc.property(
+            arbValidMaxConcurrent,
+            (maxConcurrent) => {
+                const answers = { ...baseAnswers, batchMaxConcurrentTransforms: maxConcurrent }
+                const manager = new TemplateManager(answers)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('integers < 0 and non-integers are rejected', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.7
+         */
+        fc.assert(fc.property(
+            arbInvalidMaxConcurrent,
+            (maxConcurrent) => {
+                const answers = { ...baseAnswers, batchMaxConcurrentTransforms: maxConcurrent }
+                const manager = new TemplateManager(answers)
+                assert.throws(
+                    () => manager.validate(),
+                    /batchMaxConcurrentTransforms must be an integer >= 0/,
+                    `batchMaxConcurrentTransforms "${maxConcurrent}" should fail validation`
+                )
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('undefined batchMaxConcurrentTransforms is accepted (uses default)', function () {
+        /**
+         * Validates: Requirements 8.7
+         */
+        const answers = { ...baseAnswers }
+        const manager = new TemplateManager(answers)
+        manager.validate()
+    })
+})
+
+// ── Property 6: Max payload in MB validation ─────────────────────────────────
+
+describe('Feature: batch-transform-endpoint, Property 6: Max payload in MB validation', () => {
+
+    it('integers between 0 and 100 inclusive are accepted', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.8
+         */
+        fc.assert(fc.property(
+            arbValidMaxPayload,
+            (maxPayload) => {
+                const answers = { ...baseAnswers, batchMaxPayloadInMB: maxPayload }
+                const manager = new TemplateManager(answers)
+                manager.validate()
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('integers outside 0-100 and non-integers are rejected', function () {
+        this.timeout(FAST_PROPERTY_CONFIG.timeout)
+
+        /**
+         * Validates: Requirements 8.8
+         */
+        fc.assert(fc.property(
+            arbInvalidMaxPayload,
+            (maxPayload) => {
+                const answers = { ...baseAnswers, batchMaxPayloadInMB: maxPayload }
+                const manager = new TemplateManager(answers)
+                assert.throws(
+                    () => manager.validate(),
+                    /batchMaxPayloadInMB must be an integer between 0 and 100/,
+                    `batchMaxPayloadInMB "${maxPayload}" should fail validation`
+                )
+                return true
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose })
+    })
+
+    it('undefined batchMaxPayloadInMB is accepted (uses default)', function () {
+        /**
+         * Validates: Requirements 8.8
+         */
+        const answers = { ...baseAnswers }
+        const manager = new TemplateManager(answers)
+        manager.validate()
+    })
+})

--- a/test/unit/batch-transform-config-manager.test.js
+++ b/test/unit/batch-transform-config-manager.test.js
@@ -1,0 +1,346 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for batch parameter matrix entries in ConfigManager
+ *
+ * Verifies that the eight new batch parameters exist in the ConfigManager
+ * parameter matrix with correct CLI options, env vars, and defaults.
+ * Also verifies deploymentTarget defaults to 'managed-inference'.
+ *
+ * Feature: batch-transform-endpoint
+ * Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 10.4
+ */
+
+import { describe, it, afterEach } from 'mocha';
+import { strict as assert } from 'node:assert';
+import ConfigManager from '../../generators/app/lib/config-manager.js';
+import {
+    createMockGenerator,
+    createMockGeneratorWithOptions,
+    cleanupEnvVars
+} from '../helpers/mock-generator.js';
+
+describe('ConfigManager Batch Parameter Matrix Entries', () => {
+    let envVarsToCleanup = [];
+
+    afterEach(() => {
+        cleanupEnvVars(envVarsToCleanup);
+        envVarsToCleanup = [];
+    });
+
+    /**
+     * Helper: get the parameter matrix from a fresh ConfigManager instance
+     */
+    function getParameterMatrix() {
+        const mockGen = createMockGenerator();
+        const cm = new ConfigManager(mockGen);
+        return cm.parameterMatrix;
+    }
+
+    describe('batchInputPath (Requirement 3.1)', () => {
+        it('should exist in the parameter matrix', () => {
+            const matrix = getParameterMatrix();
+            assert.ok(matrix.batchInputPath, 'batchInputPath must exist in parameter matrix');
+        });
+
+        it('should have CLI option batch-input-path', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchInputPath.cliOption, 'batch-input-path');
+        });
+
+        it('should have env var ML_BATCH_INPUT_PATH', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchInputPath.envVar, 'ML_BATCH_INPUT_PATH');
+        });
+
+        it('should support config file', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchInputPath.configFile, true);
+        });
+
+        it('should default to null', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchInputPath.default, null);
+        });
+
+        it('should load from CLI option', async () => {
+            const mockGen = createMockGeneratorWithOptions({ 'batch-input-path': 's3://my-bucket/input/' });
+            const cm = new ConfigManager(mockGen);
+            const config = await cm.loadConfiguration();
+            assert.equal(config.batchInputPath, 's3://my-bucket/input/');
+        });
+
+        it('should load from environment variable', async () => {
+            process.env.ML_BATCH_INPUT_PATH = 's3://env-bucket/input/';
+            envVarsToCleanup.push('ML_BATCH_INPUT_PATH');
+
+            const mockGen = createMockGenerator();
+            const cm = new ConfigManager(mockGen);
+            const config = await cm.loadConfiguration();
+            assert.equal(config.batchInputPath, 's3://env-bucket/input/');
+        });
+    });
+
+    describe('batchOutputPath (Requirement 3.2)', () => {
+        it('should exist in the parameter matrix', () => {
+            const matrix = getParameterMatrix();
+            assert.ok(matrix.batchOutputPath, 'batchOutputPath must exist in parameter matrix');
+        });
+
+        it('should have CLI option batch-output-path', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchOutputPath.cliOption, 'batch-output-path');
+        });
+
+        it('should have env var ML_BATCH_OUTPUT_PATH', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchOutputPath.envVar, 'ML_BATCH_OUTPUT_PATH');
+        });
+
+        it('should support config file', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchOutputPath.configFile, true);
+        });
+
+        it('should default to null', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchOutputPath.default, null);
+        });
+
+        it('should load from CLI option', async () => {
+            const mockGen = createMockGeneratorWithOptions({ 'batch-output-path': 's3://my-bucket/output/' });
+            const cm = new ConfigManager(mockGen);
+            const config = await cm.loadConfiguration();
+            assert.equal(config.batchOutputPath, 's3://my-bucket/output/');
+        });
+
+        it('should load from environment variable', async () => {
+            process.env.ML_BATCH_OUTPUT_PATH = 's3://env-bucket/output/';
+            envVarsToCleanup.push('ML_BATCH_OUTPUT_PATH');
+
+            const mockGen = createMockGenerator();
+            const cm = new ConfigManager(mockGen);
+            const config = await cm.loadConfiguration();
+            assert.equal(config.batchOutputPath, 's3://env-bucket/output/');
+        });
+    });
+
+    describe('batchInstanceCount (Requirement 3.3)', () => {
+        it('should exist in the parameter matrix', () => {
+            const matrix = getParameterMatrix();
+            assert.ok(matrix.batchInstanceCount, 'batchInstanceCount must exist in parameter matrix');
+        });
+
+        it('should have CLI option batch-instance-count', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchInstanceCount.cliOption, 'batch-instance-count');
+        });
+
+        it('should have no env var', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchInstanceCount.envVar, null);
+        });
+
+        it('should support config file', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchInstanceCount.configFile, true);
+        });
+
+        it('should default to 1', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchInstanceCount.default, 1);
+        });
+
+        it('should load from CLI option', async () => {
+            const mockGen = createMockGeneratorWithOptions({ 'batch-instance-count': 4 });
+            const cm = new ConfigManager(mockGen);
+            const config = await cm.loadConfiguration();
+            assert.equal(config.batchInstanceCount, 4);
+        });
+    });
+
+    describe('batchSplitType (Requirement 3.4)', () => {
+        it('should exist in the parameter matrix', () => {
+            const matrix = getParameterMatrix();
+            assert.ok(matrix.batchSplitType, 'batchSplitType must exist in parameter matrix');
+        });
+
+        it('should have CLI option batch-split-type', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchSplitType.cliOption, 'batch-split-type');
+        });
+
+        it('should have no env var', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchSplitType.envVar, null);
+        });
+
+        it('should support config file', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchSplitType.configFile, true);
+        });
+
+        it('should default to Line', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchSplitType.default, 'Line');
+        });
+
+        it('should load from CLI option', async () => {
+            const mockGen = createMockGeneratorWithOptions({ 'batch-split-type': 'RecordIO' });
+            const cm = new ConfigManager(mockGen);
+            const config = await cm.loadConfiguration();
+            assert.equal(config.batchSplitType, 'RecordIO');
+        });
+    });
+
+    describe('batchStrategy (Requirement 3.5)', () => {
+        it('should exist in the parameter matrix', () => {
+            const matrix = getParameterMatrix();
+            assert.ok(matrix.batchStrategy, 'batchStrategy must exist in parameter matrix');
+        });
+
+        it('should have CLI option batch-strategy', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchStrategy.cliOption, 'batch-strategy');
+        });
+
+        it('should have no env var', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchStrategy.envVar, null);
+        });
+
+        it('should support config file', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchStrategy.configFile, true);
+        });
+
+        it('should default to MultiRecord', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchStrategy.default, 'MultiRecord');
+        });
+
+        it('should load from CLI option', async () => {
+            const mockGen = createMockGeneratorWithOptions({ 'batch-strategy': 'SingleRecord' });
+            const cm = new ConfigManager(mockGen);
+            const config = await cm.loadConfiguration();
+            assert.equal(config.batchStrategy, 'SingleRecord');
+        });
+    });
+
+    describe('batchJoinSource (Requirement 3.6)', () => {
+        it('should exist in the parameter matrix', () => {
+            const matrix = getParameterMatrix();
+            assert.ok(matrix.batchJoinSource, 'batchJoinSource must exist in parameter matrix');
+        });
+
+        it('should have CLI option batch-join-source', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchJoinSource.cliOption, 'batch-join-source');
+        });
+
+        it('should have no env var', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchJoinSource.envVar, null);
+        });
+
+        it('should support config file', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchJoinSource.configFile, true);
+        });
+
+        it('should default to None', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchJoinSource.default, 'None');
+        });
+
+        it('should load from CLI option', async () => {
+            const mockGen = createMockGeneratorWithOptions({ 'batch-join-source': 'Input' });
+            const cm = new ConfigManager(mockGen);
+            const config = await cm.loadConfiguration();
+            assert.equal(config.batchJoinSource, 'Input');
+        });
+    });
+
+    describe('batchMaxConcurrentTransforms (Requirement 3.7)', () => {
+        it('should exist in the parameter matrix', () => {
+            const matrix = getParameterMatrix();
+            assert.ok(matrix.batchMaxConcurrentTransforms, 'batchMaxConcurrentTransforms must exist in parameter matrix');
+        });
+
+        it('should have CLI option batch-max-concurrent', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchMaxConcurrentTransforms.cliOption, 'batch-max-concurrent');
+        });
+
+        it('should have no env var', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchMaxConcurrentTransforms.envVar, null);
+        });
+
+        it('should support config file', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchMaxConcurrentTransforms.configFile, true);
+        });
+
+        it('should default to 1', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchMaxConcurrentTransforms.default, 1);
+        });
+
+        it('should load from CLI option', async () => {
+            const mockGen = createMockGeneratorWithOptions({ 'batch-max-concurrent': 10 });
+            const cm = new ConfigManager(mockGen);
+            const config = await cm.loadConfiguration();
+            assert.equal(config.batchMaxConcurrentTransforms, 10);
+        });
+    });
+
+    describe('batchMaxPayloadInMB (Requirement 3.8)', () => {
+        it('should exist in the parameter matrix', () => {
+            const matrix = getParameterMatrix();
+            assert.ok(matrix.batchMaxPayloadInMB, 'batchMaxPayloadInMB must exist in parameter matrix');
+        });
+
+        it('should have CLI option batch-max-payload', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchMaxPayloadInMB.cliOption, 'batch-max-payload');
+        });
+
+        it('should have no env var', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchMaxPayloadInMB.envVar, null);
+        });
+
+        it('should support config file', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchMaxPayloadInMB.configFile, true);
+        });
+
+        it('should default to 6', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.batchMaxPayloadInMB.default, 6);
+        });
+
+        it('should load from CLI option', async () => {
+            const mockGen = createMockGeneratorWithOptions({ 'batch-max-payload': 50 });
+            const cm = new ConfigManager(mockGen);
+            const config = await cm.loadConfiguration();
+            assert.equal(config.batchMaxPayloadInMB, 50);
+        });
+    });
+
+    describe('deploymentTarget default (Requirement 10.4)', () => {
+        it('should default to managed-inference', () => {
+            const matrix = getParameterMatrix();
+            assert.equal(matrix.deploymentTarget.default, 'managed-inference');
+        });
+
+        it('should apply managed-inference default when no value provided', async () => {
+            const mockGen = createMockGenerator();
+            const cm = new ConfigManager(mockGen);
+            const config = await cm.loadConfiguration();
+            assert.equal(config.deploymentTarget, 'managed-inference');
+        });
+    });
+});

--- a/test/unit/batch-transform-prompt-visibility.test.js
+++ b/test/unit/batch-transform-prompt-visibility.test.js
@@ -1,0 +1,147 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for batch transform prompt visibility
+ *
+ * Tests:
+ * - Batch prompts appear when deploymentTarget === 'batch-transform'
+ * - Batch prompts are hidden for managed-inference, async-inference, and hyperpod-eks
+ * - HyperPod prompts are hidden when deploymentTarget === 'batch-transform'
+ * - Async prompts are hidden when deploymentTarget === 'batch-transform'
+ *
+ * Feature: batch-transform-endpoint
+ * Validates: Requirements 2.10, 2.11
+ */
+
+import { strict as assert } from 'node:assert';
+import {
+    infraBatchTransformPrompts,
+    infraHyperPodPrompts,
+    infraAsyncPrompts
+} from '../../generators/app/lib/prompts.js';
+
+describe('Batch Transform Prompt Visibility', () => {
+
+    const batchPromptNames = [
+        'batchInputPath',
+        'batchOutputPath',
+        'batchInstanceCount',
+        'batchSplitType',
+        'batchStrategy',
+        'batchJoinSource',
+        'batchMaxConcurrentTransforms',
+        'batchMaxPayloadInMB'
+    ];
+
+    const hyperPodPromptNames = [
+        'hyperPodCluster',
+        'hyperPodNamespace',
+        'hyperPodReplicas',
+        'fsxVolumeHandle'
+    ];
+
+    const asyncPromptNames = [
+        'asyncS3OutputPath',
+        'asyncSnsSuccessTopic',
+        'asyncSnsErrorTopic',
+        'asyncMaxConcurrentInvocations'
+    ];
+
+    function findPrompt(prompts, name) {
+        return prompts.find(p => p.name === name);
+    }
+
+    function evaluateWhen(prompt, answers) {
+        if (!prompt) return false;
+        if (typeof prompt.when === 'function') {
+            return prompt.when(answers);
+        }
+        return prompt.when !== false;
+    }
+
+    describe('infraBatchTransformPrompts exports', () => {
+        it('should export exactly 8 batch prompts', () => {
+            assert.equal(infraBatchTransformPrompts.length, 8);
+        });
+
+        it('should contain all expected prompt names', () => {
+            const names = infraBatchTransformPrompts.map(p => p.name);
+            for (const expected of batchPromptNames) {
+                assert.ok(names.includes(expected), `Missing prompt: ${expected}`);
+            }
+        });
+    });
+
+    describe('Batch prompts shown for batch-transform (Requirement 2.10)', () => {
+        const answers = { deploymentTarget: 'batch-transform' };
+
+        for (const name of batchPromptNames) {
+            it(`${name} when() should return true for batch-transform`, () => {
+                const prompt = findPrompt(infraBatchTransformPrompts, name);
+                assert.ok(prompt, `Prompt ${name} must exist`);
+                assert.equal(evaluateWhen(prompt, answers), true);
+            });
+        }
+    });
+
+    describe('Batch prompts hidden for managed-inference (Requirement 2.10)', () => {
+        const answers = { deploymentTarget: 'managed-inference' };
+
+        for (const name of batchPromptNames) {
+            it(`${name} when() should return false for managed-inference`, () => {
+                const prompt = findPrompt(infraBatchTransformPrompts, name);
+                assert.ok(prompt, `Prompt ${name} must exist`);
+                assert.equal(evaluateWhen(prompt, answers), false);
+            });
+        }
+    });
+
+    describe('Batch prompts hidden for async-inference (Requirement 2.10)', () => {
+        const answers = { deploymentTarget: 'async-inference' };
+
+        for (const name of batchPromptNames) {
+            it(`${name} when() should return false for async-inference`, () => {
+                const prompt = findPrompt(infraBatchTransformPrompts, name);
+                assert.ok(prompt, `Prompt ${name} must exist`);
+                assert.equal(evaluateWhen(prompt, answers), false);
+            });
+        }
+    });
+
+    describe('Batch prompts hidden for hyperpod-eks (Requirement 2.10)', () => {
+        const answers = { deploymentTarget: 'hyperpod-eks' };
+
+        for (const name of batchPromptNames) {
+            it(`${name} when() should return false for hyperpod-eks`, () => {
+                const prompt = findPrompt(infraBatchTransformPrompts, name);
+                assert.ok(prompt, `Prompt ${name} must exist`);
+                assert.equal(evaluateWhen(prompt, answers), false);
+            });
+        }
+    });
+
+    describe('HyperPod prompts hidden for batch-transform (Requirement 2.10)', () => {
+        const answers = { deploymentTarget: 'batch-transform' };
+
+        for (const name of hyperPodPromptNames) {
+            it(`${name} when() should return false for batch-transform`, () => {
+                const prompt = findPrompt(infraHyperPodPrompts, name);
+                assert.ok(prompt, `Prompt ${name} must exist`);
+                assert.equal(evaluateWhen(prompt, answers), false);
+            });
+        }
+    });
+
+    describe('Async prompts hidden for batch-transform (Requirement 2.11)', () => {
+        const answers = { deploymentTarget: 'batch-transform' };
+
+        for (const name of asyncPromptNames) {
+            it(`${name} when() should return false for batch-transform`, () => {
+                const prompt = findPrompt(infraAsyncPrompts, name);
+                assert.ok(prompt, `Prompt ${name} must exist`);
+                assert.equal(evaluateWhen(prompt, answers), false);
+            });
+        }
+    });
+});

--- a/test/unit/mcp-client.test.js
+++ b/test/unit/mcp-client.test.js
@@ -79,7 +79,9 @@ describe('McpClient Unit Tests', () => {
             assert.ok(names.includes('asyncS3OutputPath'));
             assert.ok(names.includes('asyncSnsSuccessTopic'));
             assert.ok(names.includes('asyncSnsErrorTopic'));
-            assert.strictEqual(names.length, 8);
+            assert.ok(names.includes('batchInputPath'));
+            assert.ok(names.includes('batchOutputPath'));
+            assert.strictEqual(names.length, 10);
         });
 
         it('should not include bounded parameters', () => {


### PR DESCRIPTION
*Issue #, if available:* closes #84

*Description of changes:*## Fix batch-transform deployment UX and SageMaker API compatibility

Follow-up fixes from real-world testing of the batch-transform deployment target.

### SageMaker API fixes

- When `JoinSource=Input`, SageMaker requires `Accept` in TransformOutput to match `ContentType` in TransformInput, and `AssembleWith` to match `SplitType`. The deploy template now adds both fields dynamically using runtime bash conditionals instead of EJS-time checks, so edits to `do/config` after generation are respected.
- `BATCH_JOIN_SOURCE` is now always exported in `do/config` (defaulting to `None`) instead of being conditionally omitted.

### S3 bootstrap

- Default S3 paths are now optional (leave empty for `s3://ml-container-creator-batch-{region}-{account-id}/{project-name}/input|output/`)
- Deploy creates the S3 bucket if it doesn't exist and uploads a framework-aware sample input file (vLLM/SGLang get OpenAI chat completion format, HuggingFace gets `{"inputs": ...}`, traditional ML gets feature vectors)
- Fixed `set -e` killing the script when `aws s3 ls` returned non-zero on an empty bucket (added `|| true`)

### UX improvements

- `./do/test` defaults to batch mode, `./do/clean` defaults to batch cleanup — no qualifier argument needed
- Both `./do/deploy` and `./do/test` download results locally to `batch-output/` via `aws s3 sync` and preview the first output file
- Instance type prompt now appears for batch-transform (was missing from the `when` condition)
- Batch prompts have descriptive messages explaining each option (e.g., "Input file format — how should SageMaker read your input files?" with "Line — one record per line (JSON lines, CSV)")
- Display name changed from "SageMaker Batch Transform" to "SageMaker Managed Inference - Batch"
