### PR TITLE
Managed Model Customization (`do/tune`) [BETA]

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -102,6 +102,15 @@ program
     .addOption(new Option('--max-loras <n>', 'Maximum concurrent LoRA adapters in GPU memory (default: 30)'))
     .addOption(new Option('--max-lora-rank <n>', 'Maximum LoRA rank (default: 64)'))
 
+    // --- Benchmarking ---
+    .addOption(new Option('--include-benchmark', 'Include SageMaker AI Benchmarking (transformers/diffusors only)'))
+    .addOption(new Option('--benchmark-concurrency <n>', 'Benchmark concurrent requests (default: 10)'))
+    .addOption(new Option('--benchmark-input-tokens <n>', 'Benchmark mean input tokens (default: 550)'))
+    .addOption(new Option('--benchmark-output-tokens <n>', 'Benchmark mean output tokens (default: 150)'))
+    .addOption(new Option('--benchmark-streaming', 'Enable streaming in benchmark (default: true)'))
+    .addOption(new Option('--benchmark-request-count <n>', 'Total benchmark requests (optional)'))
+    .addOption(new Option('--benchmark-s3-output-path <path>', 'S3 path for benchmark results'))
+
     // --- MCP & Discovery ---
     .addOption(new Option('--smart', 'Enable Bedrock-powered smart mode on MCP servers'))
     .addOption(new Option('--discover', 'Enable live registry lookups via MCP discovery'))

--- a/config/bootstrap-stack.json
+++ b/config/bootstrap-stack.json
@@ -62,6 +62,7 @@
                     "sagemaker:DescribeEndpointConfig",
                     "sagemaker:DescribeModel",
                     "sagemaker:DescribeInferenceComponent",
+                    "sagemaker:ListInferenceComponents",
                     "sagemaker:InvokeEndpoint",
                     "sagemaker:InvokeEndpointAsync"
                   ],
@@ -131,11 +132,14 @@
                   "Action": [
                     "s3:GetObject",
                     "s3:PutObject",
+                    "s3:AbortMultipartUpload",
                     "s3:ListBucket"
                   ],
                   "Resource": [
                     "arn:aws:s3:::mlcc-*",
-                    "arn:aws:s3:::mlcc-*/*"
+                    "arn:aws:s3:::mlcc-*/*",
+                    "arn:aws:s3:::ml-container-creator-*",
+                    "arn:aws:s3:::ml-container-creator-*/*"
                   ]
                 },
                 {
@@ -164,17 +168,54 @@
                   ]
                 },
                 {
+                  "Sid": "SNSPublish",
+                  "Effect": "Allow",
+                  "Action": "sns:Publish",
+                  "Resource": [
+                    { "Fn::Sub": "arn:aws:sns:*:${AWS::AccountId}:mlcc-*" },
+                    { "Fn::Sub": "arn:aws:sns:*:${AWS::AccountId}:ml-container-creator-*" }
+                  ]
+                },
+                {
                   "Sid": "QuotaAndAvailability",
                   "Effect": "Allow",
                   "Action": [
                     "service-quotas:GetServiceQuota",
                     "service-quotas:ListServiceQuotas",
-                    "ec2:DescribeCapacityReservations",
                     "sagemaker:ListTrainingPlans",
                     "sagemaker:DescribeTrainingPlan",
                     "sagemaker:ListEndpoints"
                   ],
                   "Resource": "*"
+                },
+                {
+                  "Sid": "SageMakerModelCustomization",
+                  "Effect": "Allow",
+                  "Action": [
+                    "sagemaker:CreateTrainingJob",
+                    "sagemaker:DescribeTrainingJob",
+                    "sagemaker:ListTrainingJobs",
+                    "sagemaker:StopTrainingJob",
+                    "sagemaker:CreateModelPackage",
+                    "sagemaker:CreateModelPackageGroup",
+                    "sagemaker:DescribeModelPackage",
+                    "sagemaker:DescribeModelPackageGroup",
+                    "sagemaker:ListModelPackages",
+                    "sagemaker:CallMlflowAppApi"
+                  ],
+                  "Resource": "*"
+                },
+                {
+                  "Sid": "SageMakerMLflow",
+                  "Effect": "Allow",
+                  "Action": "sagemaker-mlflow:*",
+                  "Resource": "*"
+                },
+                {
+                  "Sid": "LambdaInvokeForReward",
+                  "Effect": "Allow",
+                  "Action": "lambda:InvokeFunction",
+                  "Resource": { "Fn::Sub": "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*" }
                 }
               ]
             }
@@ -285,6 +326,26 @@
           { "Key": "mlcc:purpose", "Value": "benchmark-results" }
         ]
       }
+    },
+
+    "TuneS3Bucket": {
+      "Type": "AWS::S3::Bucket",
+      "Condition": "ShouldCreateS3Buckets",
+      "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Retain",
+      "Properties": {
+        "BucketName": { "Fn::Sub": "mlcc-tune-${AWS::AccountId}-${AWS::Region}" },
+        "VersioningConfiguration": { "Status": "Enabled" },
+        "BucketEncryption": {
+          "ServerSideEncryptionConfiguration": [
+            { "ServerSideEncryptionByDefault": { "SSEAlgorithm": "AES256" } }
+          ]
+        },
+        "Tags": [
+          { "Key": "mlcc:managed-by", "Value": "ml-container-creator" },
+          { "Key": "mlcc:purpose", "Value": "tune-datasets-and-output" }
+        ]
+      }
     }
   },
 
@@ -327,9 +388,14 @@
       "Description": "S3 bucket for benchmark results output",
       "Value": { "Ref": "BenchmarkS3Bucket" }
     },
+    "TuneS3BucketName": {
+      "Condition": "ShouldCreateS3Buckets",
+      "Description": "S3 bucket for tune datasets and output",
+      "Value": { "Ref": "TuneS3Bucket" }
+    },
     "StackVersion": {
       "Description": "Bootstrap stack template version for forward compatibility tracking",
-      "Value": "2026-05-04"
+      "Value": "2026-05-18"
     }
   }
 }

--- a/config/tune-catalog.json
+++ b/config/tune-catalog.json
@@ -1,0 +1,525 @@
+{
+  "version": "2026-07-01",
+  "models": {
+    "qwen2-5-7b-instruct": {
+      "jumpStartModelId": "qwen2-5-7b-instruct",
+      "family": "qwen-2.5",
+      "provider": "alibaba",
+      "displayName": "Alibaba Qwen 2.5 7B Instruct",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        }
+      }
+    },
+    "qwen2-5-14b-instruct": {
+      "jumpStartModelId": "qwen2-5-14b-instruct",
+      "family": "qwen-2.5",
+      "provider": "alibaba",
+      "displayName": "Alibaba Qwen 2.5 14B Instruct",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        }
+      }
+    },
+    "qwen2-5-32b-instruct": {
+      "jumpStartModelId": "qwen2-5-32b-instruct",
+      "family": "qwen-2.5",
+      "provider": "alibaba",
+      "displayName": "Alibaba Qwen 2.5 32B Instruct",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        }
+      }
+    },
+    "qwen2-5-72b-instruct": {
+      "jumpStartModelId": "qwen2-5-72b-instruct",
+      "family": "qwen-2.5",
+      "provider": "alibaba",
+      "displayName": "Alibaba Qwen 2.5 72B Instruct",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        },
+        "rlvr": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-rlvr",
+          "datasetSchema": {
+            "required": ["prompt"],
+            "types": { "prompt": "array" }
+          }
+        }
+      }
+    },
+    "qwen3-0-6b": {
+      "jumpStartModelId": "qwen3-0-6b",
+      "family": "qwen-3",
+      "provider": "alibaba",
+      "displayName": "Alibaba Qwen 3 0.6B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        }
+      }
+    },
+    "qwen3-1-7b": {
+      "jumpStartModelId": "qwen3-1-7b",
+      "family": "qwen-3",
+      "provider": "alibaba",
+      "displayName": "Alibaba Qwen 3 1.7B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        }
+      }
+    },
+    "qwen3-4b": {
+      "jumpStartModelId": "qwen3-4b",
+      "family": "qwen-3",
+      "provider": "alibaba",
+      "displayName": "Alibaba Qwen 3 4B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        }
+      }
+    },
+    "qwen3-8b": {
+      "jumpStartModelId": "qwen3-8b",
+      "family": "qwen-3",
+      "provider": "alibaba",
+      "displayName": "Alibaba Qwen 3 8B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        }
+      }
+    },
+    "qwen3-14b": {
+      "jumpStartModelId": "qwen3-14b",
+      "family": "qwen-3",
+      "provider": "alibaba",
+      "displayName": "Alibaba Qwen 3 14B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        }
+      }
+    },
+    "qwen3-32b": {
+      "jumpStartModelId": "qwen3-32b",
+      "family": "qwen-3",
+      "provider": "alibaba",
+      "displayName": "Alibaba Qwen 3 32B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        },
+        "rlvr": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-rlvr",
+          "datasetSchema": {
+            "required": ["prompt"],
+            "types": { "prompt": "array" }
+          }
+        }
+      }
+    },
+    "deepseek-r1-distill-llama-8b": {
+      "jumpStartModelId": "deepseek-r1-distill-llama-8b",
+      "family": "deepseek-r1",
+      "provider": "deepseek",
+      "displayName": "DeepSeek R1 Distill Llama 8B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        }
+      }
+    },
+    "deepseek-r1-distill-llama-70b": {
+      "jumpStartModelId": "deepseek-r1-distill-llama-70b",
+      "family": "deepseek-r1",
+      "provider": "deepseek",
+      "displayName": "DeepSeek R1 Distill Llama 70B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        }
+      }
+    },
+    "deepseek-r1-distill-qwen-1-5b": {
+      "jumpStartModelId": "deepseek-r1-distill-qwen-1-5b",
+      "family": "deepseek-r1",
+      "provider": "deepseek",
+      "displayName": "DeepSeek R1 Distill Qwen 1.5B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        }
+      }
+    },
+    "deepseek-r1-distill-qwen-7b": {
+      "jumpStartModelId": "deepseek-r1-distill-qwen-7b",
+      "family": "deepseek-r1",
+      "provider": "deepseek",
+      "displayName": "DeepSeek R1 Distill Qwen 7B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        }
+      }
+    },
+    "deepseek-r1-distill-qwen-14b": {
+      "jumpStartModelId": "deepseek-r1-distill-qwen-14b",
+      "family": "deepseek-r1",
+      "provider": "deepseek",
+      "displayName": "DeepSeek R1 Distill Qwen 14B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        }
+      }
+    },
+    "deepseek-r1-distill-qwen-32b": {
+      "jumpStartModelId": "deepseek-r1-distill-qwen-32b",
+      "family": "deepseek-r1",
+      "provider": "deepseek",
+      "displayName": "DeepSeek R1 Distill Qwen 32B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        }
+      }
+    },
+    "meta-textgeneration-llama-3-1-8b-instruct": {
+      "jumpStartModelId": "meta-textgeneration-llama-3-1-8b-instruct",
+      "family": "llama-3",
+      "provider": "meta",
+      "displayName": "Meta Llama 3.1 8B Instruct",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        },
+        "rlvr": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-rlvr",
+          "datasetSchema": {
+            "required": ["prompt"],
+            "types": { "prompt": "array" }
+          }
+        }
+      }
+    },
+    "meta-textgeneration-llama-3-2-1b-instruct": {
+      "jumpStartModelId": "meta-textgeneration-llama-3-2-1b-instruct",
+      "family": "llama-3",
+      "provider": "meta",
+      "displayName": "Meta Llama 3.2 1B Instruct",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        }
+      }
+    },
+    "meta-textgeneration-llama-3-2-3b-instruct": {
+      "jumpStartModelId": "meta-textgeneration-llama-3-2-3b-instruct",
+      "family": "llama-3",
+      "provider": "meta",
+      "displayName": "Meta Llama 3.2 3B Instruct",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        }
+      }
+    },
+    "meta-textgeneration-llama-3-3-70b-instruct": {
+      "jumpStartModelId": "meta-textgeneration-llama-3-3-70b-instruct",
+      "family": "llama-3",
+      "provider": "meta",
+      "displayName": "Meta Llama 3.3 70B Instruct",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        },
+        "rlvr": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-rlvr",
+          "datasetSchema": {
+            "required": ["prompt"],
+            "types": { "prompt": "array" }
+          }
+        },
+        "rlaif": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-rlaif",
+          "datasetSchema": {
+            "required": ["prompt"],
+            "types": { "prompt": "array" }
+          }
+        }
+      }
+    },
+    "openai-gpt-oss-20b": {
+      "jumpStartModelId": "openai-gpt-oss-20b",
+      "family": "gpt-oss",
+      "provider": "openai",
+      "displayName": "OpenAI GPT-OSS 20B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        }
+      }
+    },
+    "openai-gpt-oss-120b": {
+      "jumpStartModelId": "openai-gpt-oss-120b",
+      "family": "gpt-oss",
+      "provider": "openai",
+      "displayName": "OpenAI GPT-OSS 120B",
+      "techniques": {
+        "sft": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-sft",
+          "datasetSchema": {
+            "required": ["prompt", "completion"],
+            "types": { "prompt": "string", "completion": "string" }
+          }
+        },
+        "dpo": {
+          "trainingTypes": ["lora", "full-rank"],
+          "datasetFormat": "default-dpo",
+          "datasetSchema": {
+            "required": ["prompt", "chosen", "rejected"],
+            "types": { "prompt": "string", "chosen": "string", "rejected": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/fine-tuning.md
+++ b/docs/fine-tuning.md
@@ -1,0 +1,451 @@
+# Fine-Tuning & Customization
+
+ML Container Creator includes a `do/tune` command that wraps SageMaker AI Managed Model Customization — a serverless fine-tuning capability that eliminates instance selection and container management. You provide a dataset and technique; SageMaker handles infrastructure, optimization, and produces a deployable model artifact that feeds directly back into your project's deployment lifecycle.
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| Deployed endpoint | Endpoint must be `InService` (run `./do/deploy` first) |
+| AWS credentials | Configured via `aws configure` or environment variables |
+| Framework | `transformers` only |
+| Deployment target | Any target except `batch-transform` |
+| Bootstrapped account | Run `ml-container-creator bootstrap` to provision IAM permissions and tune S3 bucket |
+| Python SDK | `sagemaker>=2.232.0` installed in your Python environment |
+
+!!! note "Supported Models Only"
+    `do/tune` works with models in the Supported Model Catalog. If your model isn't supported, the script will tell you which models are available and suggest `do/train` for custom training workflows.
+
+## The Tune-Adapter-Deploy Feedback Loop
+
+The fine-tuning workflow follows an iterative loop: prepare your dataset, tune the model, deploy the result, test it, and iterate until you're satisfied with quality.
+
+```mermaid
+graph LR
+    A[Prepare<br>dataset] --> B[do/tune] --> C[do/adapter add<br>--from-tune] --> D[do/test] --> E{Quality<br>OK?}
+    E -->|No| A
+    E -->|Yes| F[Production]
+```
+
+### Step-by-step flow
+
+1. **Prepare your dataset** — Format training data as JSONL matching the expected schema for your technique (see [Dataset Formats](#dataset-formats) below)
+
+2. **Run `do/tune`** — Submit a managed customization job:
+   ```bash
+   ./do/tune --technique sft --dataset s3://my-bucket/train.jsonl
+   ```
+
+3. **Deploy the output** — The tune script prints context-aware next-step commands when the job completes:
+
+   For **LoRA adapter** output (default):
+   ```bash
+   ./do/adapter add tuned-sft --from-tune
+   ```
+
+   For **full merged model** output (`--training-type full-rank`):
+   ```bash
+   ./do/add-ic tuned-v1 --from-tune
+   ```
+
+4. **Test the result** — Verify the fine-tuned model behaves as expected:
+   ```bash
+   ./do/test
+   ```
+
+5. **Iterate** — If quality isn't satisfactory, adjust your dataset or hyperparameters and re-run `do/tune`. Each technique tracks its own state independently, so you can experiment with SFT and DPO in parallel without interference.
+
+## How Output Feeds Into Deployment
+
+When `do/tune` completes, it stores the output artifact path in `do/config` and detects the output type based on the training type used:
+
+| Training Type | Output Type | Config Variable | Deployment Command |
+|---|---|---|---|
+| `lora` (default) | LoRA adapter weights | `TUNE_ADAPTER_PATH_<TECHNIQUE>` | `do/adapter add --from-tune` |
+| `full-rank` | Full merged model | `TUNE_MODEL_PATH_<TECHNIQUE>` | `do/add-ic --from-tune` |
+
+The `--from-tune` flag reads the output path from `do/config` automatically — no need to copy S3 URIs manually.
+
+### Adapter output (LoRA)
+
+```bash
+# Use the latest tune output (any technique)
+./do/adapter add tuned-sft --from-tune
+
+# Use a specific technique's output
+./do/adapter add tuned-sft --from-tune sft
+
+# Or pass the S3 path explicitly
+./do/adapter add tuned-sft --weights s3://mlcc-tune-123456789012-us-east-1/output/adapter.tar.gz
+```
+
+### Full model output
+
+```bash
+# Deploy as a new inference component
+./do/add-ic tuned-v1 --from-tune
+
+# Or pass the S3 path explicitly
+./do/add-ic tuned-v1 --model-data s3://mlcc-tune-123456789012-us-east-1/output/model.tar.gz
+
+# Replace the current base model
+./do/deploy --force-ic --model-data s3://mlcc-tune-123456789012-us-east-1/output/model.tar.gz
+```
+
+### Multiple techniques
+
+Each technique's output is tracked independently. You can tune with SFT, then tune with DPO, and deploy either result:
+
+```bash
+# Tune with SFT
+./do/tune --technique sft --dataset s3://my-bucket/sft-data.jsonl
+
+# Tune with DPO (doesn't affect SFT output)
+./do/tune --technique dpo --dataset s3://my-bucket/dpo-data.jsonl
+
+# Deploy the SFT adapter
+./do/adapter add tuned-sft --from-tune sft
+
+# Or deploy the DPO adapter instead
+./do/adapter add tuned-dpo --from-tune dpo
+```
+
+## Supported Models
+
+The following model families support managed customization via `do/tune`:
+
+| Provider | Model Family | Sizes |
+|---|---|---|
+| Alibaba | Qwen 2.5 | 7B, 14B, 32B, 72B |
+| Alibaba | Qwen 3 | 0.6B, 1.7B, 4B, 8B, 14B, 32B |
+| DeepSeek | R1 Distill (Llama) | 8B, 70B |
+| DeepSeek | R1 Distill (Qwen) | 1.5B, 7B, 14B, 32B |
+| Meta | Llama 3.1 Instruct | 8B |
+| Meta | Llama 3.2 Instruct | 1B, 3B |
+| Meta | Llama 3.3 Instruct | 70B |
+| OpenAI | GPT-OSS | 20B, 120B |
+
+View the full catalog at any time:
+
+```bash
+./do/tune --list-models
+```
+
+### Unsupported model behavior
+
+If your configured model is not in the Supported Model Catalog, `do/tune` exits with a clear message:
+
+```
+❌ Model "my-custom-model-7b" is not yet supported for managed customization.
+
+   Supported model families:
+   • Alibaba Qwen 2.5 / Qwen 3
+   • DeepSeek R1 Distill
+   • Meta Llama 3.1 / 3.2 / 3.3
+   • OpenAI GPT-OSS
+
+   For custom training workflows, use do/train (coming in a future release).
+```
+
+The script validates your model at runtime against the catalog, so catalog updates take effect without regenerating your project.
+
+## Techniques
+
+`do/tune` supports four customization techniques. Each technique requires a different dataset format and produces different training dynamics.
+
+| Technique | Use Case | Dataset Format |
+|---|---|---|
+| **SFT** | Teach the model a specific style or task | Prompt/completion pairs |
+| **DPO** | Align the model with human preferences | Prompt with chosen/rejected responses |
+| **RLAIF** | Align using an AI judge | Prompts with reward prompt reference |
+| **RLVR** | Align using code-based verification | Prompts with reward function Lambda |
+
+Not all models support all techniques. Check what's available for your model:
+
+```bash
+./do/tune --list-models
+```
+
+### Training types
+
+Each model+technique combination supports one or both training types:
+
+- **`lora`** (default) — Produces lightweight LoRA adapter weights. Faster to train, smaller artifacts, deployed via `do/adapter add`.
+- **`full-rank`** — Produces a full merged model. Longer training, larger artifacts, deployed via `do/add-ic`.
+
+```bash
+# LoRA adapter (default)
+./do/tune --technique sft --dataset s3://my-bucket/train.jsonl
+
+# Full-rank fine-tuning
+./do/tune --technique sft --dataset s3://my-bucket/train.jsonl --training-type full-rank
+```
+
+## Dataset Formats
+
+Datasets must be in JSONL format (one JSON object per line). The expected schema depends on the technique and model family. The script validates the first 10 lines of your dataset before submitting the job.
+
+### SFT (Supervised Fine-Tuning)
+
+Each line contains a prompt and the desired completion:
+
+```jsonl
+{"prompt": "What is the capital of France?", "completion": "The capital of France is Paris."}
+{"prompt": "Summarize photosynthesis in one sentence.", "completion": "Photosynthesis converts sunlight, water, and CO2 into glucose and oxygen."}
+{"prompt": "Write a haiku about coding.", "completion": "Bugs in the midnight\nStack traces illuminate\nCoffee grows colder"}
+```
+
+**Required keys**: `prompt` (string), `completion` (string)
+
+### DPO (Direct Preference Optimization)
+
+Each line contains a prompt with a preferred ("chosen") and dispreferred ("rejected") response:
+
+```jsonl
+{"prompt": "Explain quantum computing", "chosen": "Quantum computing leverages quantum mechanical phenomena like superposition and entanglement to process information. Unlike classical bits that are 0 or 1, quantum bits (qubits) can exist in multiple states simultaneously.", "rejected": "Computers are really fast these days."}
+{"prompt": "What causes rain?", "chosen": "Rain forms when water vapor in the atmosphere condenses into droplets heavy enough to fall due to gravity.", "rejected": "The sky cries sometimes."}
+```
+
+**Required keys**: `prompt` (string), `chosen` (string), `rejected` (string)
+
+### RLVR (Reinforcement Learning with Verifiable Rewards)
+
+Each line contains a prompt (as a message array) and a reference to a Lambda function that scores the model's output:
+
+```jsonl
+{"prompt": [{"role": "user", "content": "Solve: 2 + 2"}], "reward_model": "arn:aws:lambda:us-east-1:123456789012:function:math-verifier"}
+{"prompt": [{"role": "user", "content": "Write a function that reverses a string in Python"}], "reward_model": "arn:aws:lambda:us-east-1:123456789012:function:code-verifier"}
+```
+
+**Required keys**: `prompt` (array of message objects), `reward_model` (string — Lambda ARN)
+
+Use the `--reward-function` flag to specify the Lambda ARN:
+
+```bash
+./do/tune --technique rlvr \
+  --dataset s3://my-bucket/prompts.jsonl \
+  --reward-function arn:aws:lambda:us-east-1:123456789012:function:my-reward
+```
+
+### RLAIF (Reinforcement Learning from AI Feedback)
+
+Same format as RLVR, but uses a reward prompt (an LLM judge) instead of a Lambda function:
+
+```jsonl
+{"prompt": [{"role": "user", "content": "Explain gravity to a 5-year-old"}], "reward_model": "s3://my-bucket/reward-prompts/clarity-judge.txt"}
+{"prompt": [{"role": "user", "content": "Write a professional email declining a meeting"}], "reward_model": "s3://my-bucket/reward-prompts/tone-judge.txt"}
+```
+
+**Required keys**: `prompt` (array of message objects), `reward_model` (string — S3 URI to reward prompt)
+
+Use the `--reward-prompt` flag to specify the reward prompt location:
+
+```bash
+./do/tune --technique rlaif \
+  --dataset s3://my-bucket/prompts.jsonl \
+  --reward-prompt s3://my-bucket/reward-prompts/clarity-judge.txt
+```
+
+### Model-specific formats
+
+Some model families may expect a different format (e.g., Converse format). The Supported Model Catalog encodes the expected schema per model family and technique. If your model requires a non-default format, the validation error message will show the expected schema.
+
+### Dataset sources
+
+Datasets can be provided from two sources:
+
+```bash
+# From S3
+./do/tune --technique sft --dataset s3://my-bucket/path/to/train.jsonl
+
+# From Hugging Face Hub
+./do/tune --technique sft --dataset hf://my-org/my-dataset
+
+# From a specific HF split
+./do/tune --technique sft --dataset hf://my-org/my-dataset/train
+```
+
+When using a Hugging Face dataset, the script downloads it to S3 automatically before submitting the job. If the dataset requires authentication, set `HF_TOKEN` in your environment or configure it via `do/secrets`.
+
+## `do/tune` vs `do/train`
+
+ML Container Creator offers two paths for model customization:
+
+| | `do/tune` (Managed Serverless) | `do/train` (Bespoke Training) |
+|---|---|---|
+| **Status** | Available now | Coming in a future release |
+| **Infrastructure** | Fully managed by SageMaker | You choose instance types and containers |
+| **Supported models** | Models in the Supported Model Catalog | Any model |
+| **Techniques** | SFT, DPO, RLAIF, RLVR | Any training script |
+| **Configuration** | Minimal — dataset + technique | Full control over training code |
+| **When to use** | Your model is supported and you want the fastest path | You need custom training logic or an unsupported model |
+
+**Recommendation**: Start with `do/tune` if your model is in the Supported Model Catalog. It's the fastest path from dataset to deployed adapter with zero infrastructure management. Fall back to `do/train` when you need custom training logic or your model isn't supported.
+
+## CLI Reference
+
+### Synopsis
+
+```bash
+./do/tune --technique <technique> --dataset <source> [options]
+./do/tune --status
+./do/tune --list-models
+./do/tune --help
+```
+
+### Required flags
+
+| Flag | Values | Description |
+|---|---|---|
+| `--technique` | `sft`, `dpo`, `rlaif`, `rlvr` | Customization technique to apply |
+| `--dataset` | S3 URI or `hf://org/name[/split]` | Training dataset location |
+
+### Training type
+
+| Flag | Values | Default | Description |
+|---|---|---|---|
+| `--training-type` | `lora`, `full-rank` | `lora` | Whether to produce LoRA adapter weights or a full merged model |
+
+### Hyperparameter overrides (all optional)
+
+| Flag | Type | Description |
+|---|---|---|
+| `--epochs` | integer | Number of training epochs (typically 1–5) |
+| `--learning-rate` | float | Learning rate (e.g., `2e-4`) |
+| `--max-seq-length` | integer | Maximum sequence length in tokens |
+| `--lora-rank` | integer | LoRA rank (e.g., 16, 32, 64). Only applies when `--training-type lora` |
+| `--lora-alpha` | integer | LoRA alpha scaling factor. Only applies when `--training-type lora` |
+| `--batch-size` | integer | Global batch size |
+
+### Evaluator flags (RLVR/RLAIF only)
+
+| Flag | Type | Description |
+|---|---|---|
+| `--reward-function` | Lambda ARN | ARN of the reward function Lambda (RLVR) |
+| `--reward-prompt` | S3 URI | S3 path to reward prompt file (RLAIF) |
+
+### Model and infrastructure overrides
+
+| Flag | Type | Description |
+|---|---|---|
+| `--model` | JumpStart model ID | Override the model to customize (defaults to `MODEL_ID` from `do/config`) |
+| `--output-bucket` | S3 bucket name | Override the output bucket (defaults to `TUNE_S3_BUCKET`) |
+| `--role` | IAM role ARN | Override the execution role |
+
+### Job control
+
+| Flag | Description |
+|---|---|
+| `--force` | Force a new job even if a previous job exists for this technique |
+| `--no-wait` | Submit the job and exit immediately without polling |
+| `--status` | Show status of all tracked tune jobs |
+| `--dry-run` | Validate inputs and show what would be submitted without creating a job |
+| `--list-models` | Print the Supported Model Catalog and exit |
+| `--help` | Show usage information |
+
+## Examples
+
+### Basic SFT with S3 dataset
+
+```bash
+./do/tune --technique sft --dataset s3://my-bucket/train.jsonl
+```
+
+### DPO with Hugging Face dataset and custom learning rate
+
+```bash
+./do/tune --technique dpo --dataset hf://my-org/preference-data --learning-rate 1e-5
+```
+
+### Full-rank fine-tuning
+
+```bash
+./do/tune --technique sft --dataset s3://my-bucket/train.jsonl --training-type full-rank
+```
+
+### Override model (tune a different model than what's deployed)
+
+```bash
+./do/tune --technique sft --dataset s3://my-bucket/train.jsonl \
+  --model meta-textgeneration-llama-3-3-70b-instruct
+```
+
+### RLVR with reward function
+
+```bash
+./do/tune --technique rlvr \
+  --dataset s3://my-bucket/prompts.jsonl \
+  --reward-function arn:aws:lambda:us-east-1:123456789012:function:my-reward
+```
+
+### Dry run (validate without submitting)
+
+```bash
+./do/tune --technique sft --dataset s3://my-bucket/train.jsonl --dry-run
+```
+
+### Force re-run after a failed job
+
+```bash
+./do/tune --technique sft --dataset s3://my-bucket/train.jsonl --force
+```
+
+## Idempotency
+
+Re-running `do/tune` with the same technique resumes or reports on the existing job rather than creating a duplicate:
+
+- **Job in progress** — Polls and displays progress until completion
+- **Job completed** — Displays results and next-step commands
+- **Job failed** — Displays the failure reason and suggests `--force` to retry
+
+Use `--force` to explicitly start a new job, overriding the previous one for that technique.
+
+## MLflow Integration
+
+When an MLflow tracking server is configured in your SageMaker domain, customization jobs automatically log training metrics, hyperparameters, and model artifacts to MLflow. The script displays the MLflow experiment URL after job submission.
+
+If no MLflow server is configured, the script proceeds without tracking and prints a note suggesting MLflow setup for experiment comparison.
+
+## Future: Bedrock Custom Model Import
+
+The output artifacts from managed customization are compatible with [Amazon Bedrock Custom Model Import](https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html). This deployment path — importing your fine-tuned model into Bedrock for serverless inference — is planned for a future release. The current workflow deploys via SageMaker endpoints using `do/adapter add` or `do/add-ic`.
+
+## Troubleshooting
+
+### "Model not yet supported"
+
+Your configured model isn't in the Supported Model Catalog. Run `./do/tune --list-models` to see available models, or use `--model` to override with a supported model ID.
+
+### Dataset validation fails
+
+The script validates the first 10 lines of your dataset. Check that:
+
+- The file is valid JSONL (one JSON object per line)
+- Each line contains the required keys for your technique
+- Values match the expected types (strings for SFT/DPO, arrays for RLVR/RLAIF prompts)
+
+The error message shows the first malformed line and the expected format.
+
+### "Technique not supported for this model"
+
+Not all models support all techniques. Run `./do/tune --list-models` to see which techniques are available for your model.
+
+### Job fails with AccessDenied
+
+Run `ml-container-creator bootstrap` to provision the required IAM permissions. The bootstrap stack adds SageMaker training, model package, and MLflow permissions.
+
+### Python SDK not installed
+
+The script requires `sagemaker>=2.232.0`. Install it:
+
+```bash
+pip install "sagemaker>=2.232.0"
+```
+
+### Job failed — how to retry
+
+When a job fails, the script displays the failure reason. Fix the underlying issue and re-run with `--force`:
+
+```bash
+./do/tune --technique sft --dataset s3://my-bucket/train.jsonl --force
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -290,6 +290,7 @@ For full details, see the [CI Integration Guide](ci-integration.md).
 - [How It Works](how-it-works.md) — Understand the generator architecture and prompt flow
 - [Configuration](configuration.md) — CLI flags, environment variables, config files, and MCP servers
 - [Deployment & Inference](deployments.md) — All deployment targets and lifecycle scripts
+- [Fine-Tuning](fine-tuning.md) — Fine-tune supported models with `do/tune` and deploy adapters
 - [Examples](EXAMPLES.md) — Walkthroughs for other architectures (Triton, diffusors, async, batch transform)
 - [CI Integration](ci-integration.md) — Automated lifecycle testing for all deployment configurations
 - [Troubleshooting](TROUBLESHOOTING.md) — Common issues and solutions

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -65,7 +65,7 @@ The target directory must be `/opt/ml/model/` for SageMaker compatibility.
 
 ### Generative Models
 
-Generative models (LLMs) are specified by HuggingFace model ID at generation time. MCC does not require a model format -- the serving framework handles downloading and loading the model into GPU memory.
+Generative models (LLMs) are specified by HuggingFace model ID at generation time. MCC does not require a model format -- the serving framework handles downloading and loading the model into GPU memory. For supported models, you can fine-tune with `do/tune` and deploy the resulting adapter or full model — see the [Fine-Tuning Guide](fine-tuning.md) for the full workflow.
 
 ```json
 {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - Secrets Management: secrets.md
       - Deployment & Inference: deployments.md
       - Benchmarking: benchmarking.md
+      - Fine-Tuning: fine-tuning.md
       - CI Integration: ci-integration.md
       - Examples: EXAMPLES.md
       - Troubleshooting: TROUBLESHOOTING.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/ml-container-creator",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/ml-container-creator",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/ml-container-creator",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Generator for SageMaker AI BYOC paradigm for predictive inference use-cases.",
   "type": "module",
   "main": "src/app.js",

--- a/src/app.js
+++ b/src/app.js
@@ -16,6 +16,7 @@ import CommentGenerator from './lib/comment-generator.js';
 import ConfigurationManager from './lib/configuration-manager.js';
 import RegistryLoader from './lib/registry-loader.js';
 import { resolvePrefixedEnvVars } from './lib/engine-prefix-resolver.js';
+import { isTuneSupported } from './lib/tune-catalog-validator.js';
 import ejs from 'ejs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -350,6 +351,12 @@ export async function writeProject(templateDir, destDir, answers, registryConfig
         ignorePatterns.push('**/do/adapters/**');
     }
 
+    // Exclude tune files when framework is NOT transformers OR deploymentTarget is batch-transform
+    if (architecture !== 'transformers' || answers.deploymentTarget === 'batch-transform') {
+        ignorePatterns.push('**/do/tune');
+        ignorePatterns.push('**/do/.tune_helper.py');
+    }
+
     // Exclude do/test when hosted-model-endpoint is not selected
     const testTypes = answers.testTypes || [];
     if (!testTypes.includes('hosted-model-endpoint')) {
@@ -451,6 +458,13 @@ export async function writeProject(templateDir, destDir, answers, registryConfig
     _copyFile(path.join(LIB_DIR, 'manifest-cli.js'), path.join(doLibDir, 'manifest-cli.js'));
     _copyFile(path.join(LIB_DIR, 'asset-manager.js'), path.join(doLibDir, 'asset-manager.js'));
     _copyFile(path.join(LIB_DIR, 'bootstrap-config.js'), path.join(doLibDir, 'bootstrap-config.js'));
+
+    // Copy tune catalog to generated project when tune is included
+    if (architecture === 'transformers' && answers.deploymentTarget !== 'batch-transform') {
+        const tuneCatalogSrc = path.join(GENERATOR_ROOT, 'config', 'tune-catalog.json');
+        const tuneCatalogDest = path.join(destDir, 'do', '.tune_catalog.json');
+        _copyFile(tuneCatalogSrc, tuneCatalogDest);
+    }
 
     // Generate .gitignore with benchmarks/ when benchmarking is enabled
     if (answers.includeBenchmark) {
@@ -740,6 +754,19 @@ async function _ensureTemplateVariables(answers, registryConfigManager = null) {
             } catch {
                 // Silently continue — template fallback handles missing value
             }
+        }
+    }
+
+    // Determine tune support based on model presence in the tune catalog.
+    // Used by the do/config template to write TUNE_SUPPORTED=true|false.
+    if (answers.tuneSupported === undefined) {
+        try {
+            const tuneCatalogPath = path.resolve(__dirname, '..', 'config', 'tune-catalog.json');
+            const tuneCatalog = JSON.parse(fs.readFileSync(tuneCatalogPath, 'utf-8'));
+            const modelId = answers.modelName || '';
+            answers.tuneSupported = isTuneSupported(modelId, tuneCatalog);
+        } catch {
+            answers.tuneSupported = false;
         }
     }
 }
@@ -1083,7 +1110,8 @@ function _setExecutablePermissions(destDir) {
         'do/optimize',
         'do/status',
         'do/add-ic',
-        'do/adapter'
+        'do/adapter',
+        'do/tune'
     ];
 
     shellScripts.forEach(script => {

--- a/src/lib/bootstrap-command-handler.js
+++ b/src/lib/bootstrap-command-handler.js
@@ -182,37 +182,79 @@ export default class BootstrapCommandHandler {
         this._displayProgress('☁️', 'Deploying bootstrap infrastructure stack...');
         const stackName = `${STACK_NAME_PREFIX}-${profileName}`;
 
+        // Check for existing bootstrap stack in this account-region (resources are singletons)
         try {
-            const stackOutputs = this._deployStack(stackName, {
-                CreateS3Buckets: createS3Buckets ? 'true' : 'false',
-                UseExistingRoleArn: useExistingRoleArn
-            }, awsProfile, region);
+            const existingStacks = this._execAws(
+                `cloudformation list-stacks --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE --query "StackSummaries[?starts_with(StackName,'${STACK_NAME_PREFIX}-')].StackName" --output json`,
+                awsProfile
+            );
+            const stacks = Array.isArray(existingStacks) ? existingStacks : [];
+            const otherStack = stacks.find(s => s !== stackName);
+            if (otherStack) {
+                console.log(`  ℹ️  Bootstrap infrastructure already exists in ${accountId}/${region} (stack: ${otherStack})`);
+                console.log('     Reusing existing resources (IAM role, ECR repo are singletons per account-region).');
+                console.log('     Use `ml-container-creator bootstrap update` to apply latest permissions.\n');
 
-            // Read outputs into profile data
-            profileData.roleArn = stackOutputs.RoleArn;
-            profileData.ecrRepositoryName = stackOutputs.EcrRepositoryName;
-            profileData.stackName = stackName;
+                // Read outputs from existing stack
+                const outputs = this._execAws(
+                    `cloudformation describe-stacks --stack-name ${otherStack} --query "Stacks[0].Outputs" --output json`,
+                    awsProfile
+                );
+                const stackOutputs = {};
+                if (Array.isArray(outputs)) {
+                    for (const o of outputs) {
+                        stackOutputs[o.OutputKey] = o.OutputValue;
+                    }
+                }
 
-            if (stackOutputs.AsyncS3BucketName) {
-                profileData.asyncS3Bucket = stackOutputs.AsyncS3BucketName;
-            }
-            if (stackOutputs.BatchS3BucketName) {
-                profileData.batchS3Bucket = stackOutputs.BatchS3BucketName;
-            }
-            if (stackOutputs.AdapterS3BucketName) {
-                profileData.adapterS3Bucket = stackOutputs.AdapterS3BucketName;
-            }
-            if (stackOutputs.BenchmarkS3BucketName) {
-                profileData.benchmarkS3Bucket = stackOutputs.BenchmarkS3BucketName;
-            }
+                profileData.roleArn = stackOutputs.RoleArn;
+                profileData.ecrRepositoryName = stackOutputs.EcrRepositoryName;
+                profileData.stackName = otherStack;
+                if (stackOutputs.AsyncS3BucketName) profileData.asyncS3Bucket = stackOutputs.AsyncS3BucketName;
+                if (stackOutputs.BatchS3BucketName) profileData.batchS3Bucket = stackOutputs.BatchS3BucketName;
+                if (stackOutputs.AdapterS3BucketName) profileData.adapterS3Bucket = stackOutputs.AdapterS3BucketName;
+                if (stackOutputs.BenchmarkS3BucketName) profileData.benchmarkS3Bucket = stackOutputs.BenchmarkS3BucketName;
 
-            console.log('  ✅ Bootstrap stack deployed successfully');
-        } catch (error) {
-            console.log(`  ❌ Stack deployment failed: ${error.message}`);
-            console.log('  Check the CloudFormation console for details:');
-            console.log(`  https://console.aws.amazon.com/cloudformation/home?region=${region}#/stacks`);
-            return;
+                // Skip stack deployment, continue to CI setup and profile save
+                console.log('  ✅ Existing bootstrap infrastructure reused');
+            }
+        } catch (_) {
+            // If list-stacks fails, proceed with normal deployment
         }
+
+        if (!profileData.stackName) {
+            try {
+                const stackOutputs = this._deployStack(stackName, {
+                    CreateS3Buckets: createS3Buckets ? 'true' : 'false',
+                    UseExistingRoleArn: useExistingRoleArn
+                }, awsProfile, region);
+
+                // Read outputs into profile data
+                profileData.roleArn = stackOutputs.RoleArn;
+                profileData.ecrRepositoryName = stackOutputs.EcrRepositoryName;
+                profileData.stackName = stackName;
+
+                if (stackOutputs.AsyncS3BucketName) {
+                    profileData.asyncS3Bucket = stackOutputs.AsyncS3BucketName;
+                }
+                if (stackOutputs.BatchS3BucketName) {
+                    profileData.batchS3Bucket = stackOutputs.BatchS3BucketName;
+                }
+                if (stackOutputs.AdapterS3BucketName) {
+                    profileData.adapterS3Bucket = stackOutputs.AdapterS3BucketName;
+                }
+                if (stackOutputs.BenchmarkS3BucketName) {
+                    profileData.benchmarkS3Bucket = stackOutputs.BenchmarkS3BucketName;
+                }
+
+                console.log('  ✅ Bootstrap stack deployed successfully');
+            } catch (error) {
+                console.log(`  ❌ Stack deployment failed: ${error.message}`);
+                console.log('  Check the CloudFormation console for details:');
+                console.log(`  https://console.aws.amazon.com/cloudformation/home?region=${region}#/stacks`);
+                return;
+            }
+        } // end if (!profileData.stackName)
 
         // Step 5: CI Infrastructure setup (separate CDK stack — unchanged)
         this._displayProgress('🧪', 'CI Testing Infrastructure...');

--- a/src/lib/tune-catalog-validator.js
+++ b/src/lib/tune-catalog-validator.js
@@ -1,0 +1,143 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tune Catalog Validator
+ *
+ * Validates model IDs, techniques, and training types against the
+ * Supported Model Catalog. Provides descriptive error messages when
+ * a requested configuration is not supported.
+ *
+ * Requirements: 1.3, 1.4, 1.5, 1.6, 4.1, 4.2, 4.3, 4.4
+ */
+
+/**
+ * Look up a model entry in the catalog by model ID.
+ * @param {string} modelId - The JumpStart model ID to look up
+ * @param {Object} catalog - The tune catalog object with a `models` map
+ * @returns {Object|null} The catalog entry for the model, or null if not found
+ */
+export function lookupModel(modelId, catalog) {
+    if (!catalog || !catalog.models) {
+        return null;
+    }
+    if (!Object.hasOwn(catalog.models, modelId)) {
+        return null;
+    }
+    return catalog.models[modelId] || null;
+}
+
+/**
+ * Check whether a model ID is present in the Supported Model Catalog.
+ * @param {string} modelId - The JumpStart model ID to check
+ * @param {Object} catalog - The tune catalog object with a `models` map
+ * @returns {boolean} True if the model is in the catalog
+ */
+export function isTuneSupported(modelId, catalog) {
+    return lookupModel(modelId, catalog) !== null;
+}
+
+/**
+ * Validate that a model ID exists in the catalog.
+ * Returns a descriptive error when the model is not supported, including
+ * the model name, supported families, and a reference to `do/train`.
+ * @param {string} modelId - The JumpStart model ID to validate
+ * @param {Object} catalog - The tune catalog object with a `models` map
+ * @returns {{ valid: boolean, error?: string }}
+ */
+export function validateModel(modelId, catalog) {
+    if (isTuneSupported(modelId, catalog)) {
+        return { valid: true };
+    }
+
+    const families = _getSupportedFamilies(catalog);
+    const familyList = families.join(', ');
+
+    return {
+        valid: false,
+        error: `Model "${modelId}" is not yet supported for managed serverless customization. ` +
+            `Supported model families: ${familyList}. ` +
+            'For custom training workflows, see `do/train`.'
+    };
+}
+
+/**
+ * Validate that a technique is supported for the given model.
+ * Returns a descriptive error listing the supported techniques when
+ * the requested technique is not available.
+ * @param {string} modelId - The JumpStart model ID
+ * @param {string} technique - The technique to validate (e.g., 'sft', 'dpo')
+ * @param {Object} catalog - The tune catalog object with a `models` map
+ * @returns {{ valid: boolean, error?: string }}
+ */
+export function validateTechnique(modelId, technique, catalog) {
+    const entry = lookupModel(modelId, catalog);
+    if (!entry) {
+        return validateModel(modelId, catalog);
+    }
+
+    const supportedTechniques = Object.keys(entry.techniques);
+    if (supportedTechniques.includes(technique)) {
+        return { valid: true };
+    }
+
+    return {
+        valid: false,
+        error: `Technique "${technique}" is not supported for model "${modelId}". ` +
+            `Supported techniques: ${supportedTechniques.join(', ')}.`
+    };
+}
+
+/**
+ * Validate that a training type is supported for the given model and technique.
+ * Returns a descriptive error listing the supported training types when
+ * the requested type is not available.
+ * @param {string} modelId - The JumpStart model ID
+ * @param {string} technique - The technique (e.g., 'sft', 'dpo')
+ * @param {string} trainingType - The training type to validate (e.g., 'lora', 'full-rank')
+ * @param {Object} catalog - The tune catalog object with a `models` map
+ * @returns {{ valid: boolean, error?: string }}
+ */
+export function validateTrainingType(modelId, technique, trainingType, catalog) {
+    const entry = lookupModel(modelId, catalog);
+    if (!entry) {
+        return validateModel(modelId, catalog);
+    }
+
+    const techniqueEntry = entry.techniques[technique];
+    if (!techniqueEntry) {
+        return validateTechnique(modelId, technique, catalog);
+    }
+
+    const supportedTypes = techniqueEntry.trainingTypes;
+    if (supportedTypes.includes(trainingType)) {
+        return { valid: true };
+    }
+
+    return {
+        valid: false,
+        error: `Training type "${trainingType}" is not supported for model "${modelId}" ` +
+            `with technique "${technique}". ` +
+            `Supported training types: ${supportedTypes.join(', ')}.`
+    };
+}
+
+/**
+ * Extract unique model family names from the catalog.
+ * @param {Object} catalog - The tune catalog object
+ * @returns {string[]} Array of unique family names
+ * @private
+ */
+function _getSupportedFamilies(catalog) {
+    if (!catalog || !catalog.models) {
+        return [];
+    }
+
+    const families = new Set();
+    for (const entry of Object.values(catalog.models)) {
+        if (entry.family) {
+            families.add(entry.family);
+        }
+    }
+    return [...families];
+}

--- a/src/lib/tune-config-state.js
+++ b/src/lib/tune-config-state.js
@@ -1,0 +1,116 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tune Config State Manager
+ *
+ * JavaScript module that mimics the bash _update_config_var() behavior
+ * from do/tune for testing purposes. Manages config variables written
+ * after job submission.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+/**
+ * Update or add a config variable in a do/config-style file.
+ * Mimics the bash _update_config_var() function:
+ * - If the variable exists (line starts with `export VAR_NAME=`), replace it
+ * - Otherwise, append a new line
+ *
+ * @param {string} configPath - Path to the config file
+ * @param {string} varName - Variable name (e.g., TUNE_JOB_NAME_SFT)
+ * @param {string} varValue - Variable value
+ */
+export function updateConfigVar(configPath, varName, varValue) {
+    let content = readFileSync(configPath, 'utf8');
+    const pattern = new RegExp(`^export ${varName}=.*$`, 'm');
+
+    if (pattern.test(content)) {
+        content = content.replace(pattern, `export ${varName}="${varValue}"`);
+    } else {
+        if (content.length > 0 && !content.endsWith('\n')) {
+            content += '\n';
+        }
+        content += `export ${varName}="${varValue}"\n`;
+    }
+
+    writeFileSync(configPath, content, 'utf8');
+}
+
+/**
+ * Read a config variable from a do/config-style file.
+ *
+ * @param {string} configPath - Path to the config file
+ * @param {string} varName - Variable name to read
+ * @returns {string|null} The variable value, or null if not found
+ */
+export function readConfigVar(configPath, varName) {
+    const content = readFileSync(configPath, 'utf8');
+    const pattern = new RegExp(`^export ${varName}="([^"]*)"`, 'm');
+    const match = content.match(pattern);
+    return match ? match[1] : null;
+}
+
+/**
+ * Simulate the config writes that happen after a successful job submission.
+ * This mirrors the behavior in do/tune's _submit_job() function.
+ *
+ * @param {string} configPath - Path to the config file
+ * @param {object} params - Submission parameters
+ * @param {string} params.technique - Technique (sft, dpo, rlaif, rlvr)
+ * @param {string} params.trainingType - Training type (lora, full-rank)
+ * @param {string} params.datasetPath - Dataset path (s3://... or hf://...)
+ * @param {string} params.jobName - Generated job name
+ */
+export function persistSubmissionState(configPath, { technique, trainingType, datasetPath, jobName }) {
+    const techniqueUpper = technique.toUpperCase();
+    updateConfigVar(configPath, `TUNE_JOB_NAME_${techniqueUpper}`, jobName);
+    updateConfigVar(configPath, 'TUNE_TECHNIQUE', technique);
+    updateConfigVar(configPath, 'TUNE_TRAINING_TYPE', trainingType);
+    updateConfigVar(configPath, 'TUNE_DATASET_PATH', datasetPath);
+}
+
+/**
+ * Simulate the config writes that happen after a job completes successfully.
+ * This mirrors the behavior in do/tune's _handle_completion() function.
+ *
+ * @param {string} configPath - Path to the config file
+ * @param {object} params - Completion parameters
+ * @param {string} params.technique - Technique (sft, dpo, rlaif, rlvr)
+ * @param {string} params.trainingType - Training type (lora, full-rank)
+ * @param {string} params.artifactPath - S3 path to the output artifact
+ * @param {string} params.outputType - Output type (adapter, full-model)
+ */
+export function persistCompletionState(configPath, { technique, trainingType, artifactPath, outputType }) {
+    const techniqueUpper = technique.toUpperCase();
+
+    if (trainingType === 'lora') {
+        updateConfigVar(configPath, `TUNE_ADAPTER_PATH_${techniqueUpper}`, artifactPath);
+    } else if (trainingType === 'full-rank') {
+        updateConfigVar(configPath, `TUNE_MODEL_PATH_${techniqueUpper}`, artifactPath);
+    }
+
+    updateConfigVar(configPath, 'TUNE_OUTPUT_PATH_LATEST', artifactPath);
+    updateConfigVar(configPath, 'TUNE_OUTPUT_TYPE_LATEST', outputType);
+}
+
+/**
+ * Generate a job name following the pattern used by do/tune.
+ * Pattern: ${projectName}-tune-${technique}-YYYYMMDD-HHMMSS
+ *
+ * @param {string} projectName - Project name
+ * @param {string} technique - Technique (sft, dpo, rlaif, rlvr)
+ * @param {Date} [timestamp] - Optional timestamp (defaults to now)
+ * @returns {string} Generated job name
+ */
+export function generateJobName(projectName, technique, timestamp = new Date()) {
+    const year = timestamp.getFullYear().toString();
+    const month = (timestamp.getMonth() + 1).toString().padStart(2, '0');
+    const day = timestamp.getDate().toString().padStart(2, '0');
+    const hours = timestamp.getHours().toString().padStart(2, '0');
+    const minutes = timestamp.getMinutes().toString().padStart(2, '0');
+    const seconds = timestamp.getSeconds().toString().padStart(2, '0');
+    const dateStr = `${year}${month}${day}`;
+    const timeStr = `${hours}${minutes}${seconds}`;
+    return `${projectName}-tune-${technique}-${dateStr}-${timeStr}`;
+}

--- a/src/lib/tune-dataset-validator.js
+++ b/src/lib/tune-dataset-validator.js
@@ -1,0 +1,279 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tune Dataset Validator
+ *
+ * Parses dataset arguments (S3 URIs and Hugging Face references) and
+ * validates JSONL dataset lines against catalog-driven schemas.
+ *
+ * Requirements: 3.1, 3.5, 3.6, 3.7, 3.8, 3.10, 3.11, 3.12
+ */
+
+/**
+ * Parse a dataset argument string into a structured object.
+ * Accepts S3 URIs (`s3://bucket/key`) or Hugging Face references
+ * (`hf://org/name` or `hf://org/name/split`).
+ *
+ * @param {string} datasetStr - The dataset argument string
+ * @returns {{ valid: boolean, type?: string, bucket?: string, key?: string, org?: string, name?: string, split?: string, error?: string }}
+ */
+export function parseDatasetArg(datasetStr) {
+    if (!datasetStr || typeof datasetStr !== 'string') {
+        return {
+            valid: false,
+            error: 'Dataset argument is required and must be a non-empty string.'
+        };
+    }
+
+    const trimmed = datasetStr.trim();
+
+    if (trimmed.startsWith('s3://')) {
+        return _parseS3Uri(trimmed);
+    }
+
+    if (trimmed.startsWith('hf://')) {
+        return _parseHfReference(trimmed);
+    }
+
+    return {
+        valid: false,
+        error: `Invalid dataset format: "${trimmed}". Expected s3://bucket/key or hf://org/name[/split].`
+    };
+}
+
+/**
+ * Validate JSONL lines against a dataset schema from the catalog.
+ * Inspects only the first 10 lines per requirement.
+ *
+ * @param {string[]} lines - Array of JSONL line strings
+ * @param {Object} schema - The datasetSchema object from the catalog
+ * @param {string[]} schema.required - Array of required top-level keys
+ * @param {Object} schema.types - Object mapping key to expected type ("string", "array", "object", "number")
+ * @returns {{ valid: boolean, error: string|null, lineNumber: number|null, malformedLine: string|null, expectedFormat: string|null }}
+ */
+export function validateDatasetFormat(lines, schema) {
+    if (!lines || !Array.isArray(lines)) {
+        return {
+            valid: false,
+            error: 'Lines must be provided as an array.',
+            lineNumber: null,
+            malformedLine: null,
+            expectedFormat: _buildExpectedFormat(schema)
+        };
+    }
+
+    if (!schema || !schema.required || !Array.isArray(schema.required)) {
+        return {
+            valid: false,
+            error: 'Schema must include a "required" array of keys.',
+            lineNumber: null,
+            malformedLine: null,
+            expectedFormat: null
+        };
+    }
+
+    const linesToInspect = lines.slice(0, 10);
+
+    for (let i = 0; i < linesToInspect.length; i++) {
+        const line = linesToInspect[i];
+        const lineNumber = i + 1;
+
+        // Skip empty lines
+        if (!line || line.trim() === '') {
+            continue;
+        }
+
+        // Try to parse as JSON
+        let parsed;
+        try {
+            parsed = JSON.parse(line);
+        } catch (e) {
+            return {
+                valid: false,
+                error: `Line ${lineNumber} is not valid JSON: ${e.message}`,
+                lineNumber,
+                malformedLine: line,
+                expectedFormat: _buildExpectedFormat(schema)
+            };
+        }
+
+        // Check that parsed value is an object
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            return {
+                valid: false,
+                error: `Line ${lineNumber} must be a JSON object.`,
+                lineNumber,
+                malformedLine: line,
+                expectedFormat: _buildExpectedFormat(schema)
+            };
+        }
+
+        // Check required keys
+        for (const key of schema.required) {
+            if (!Object.hasOwn(parsed, key)) {
+                return {
+                    valid: false,
+                    error: `Line ${lineNumber} is missing required key "${key}".`,
+                    lineNumber,
+                    malformedLine: line,
+                    expectedFormat: _buildExpectedFormat(schema)
+                };
+            }
+        }
+
+        // Check types if specified
+        if (schema.types) {
+            for (const [key, expectedType] of Object.entries(schema.types)) {
+                if (!Object.hasOwn(parsed, key)) {
+                    continue;
+                }
+
+                const value = parsed[key];
+                if (!_checkType(value, expectedType)) {
+                    return {
+                        valid: false,
+                        error: `Line ${lineNumber} has key "${key}" with wrong type. Expected "${expectedType}", got "${_getType(value)}".`,
+                        lineNumber,
+                        malformedLine: line,
+                        expectedFormat: _buildExpectedFormat(schema)
+                    };
+                }
+            }
+        }
+    }
+
+    return {
+        valid: true,
+        error: null,
+        lineNumber: null,
+        malformedLine: null,
+        expectedFormat: null
+    };
+}
+
+/**
+ * Parse an S3 URI into bucket and key components.
+ * @param {string} uri - The S3 URI (e.g., "s3://bucket/path/to/file.jsonl")
+ * @returns {Object} Parsed result
+ * @private
+ */
+function _parseS3Uri(uri) {
+    const withoutScheme = uri.slice(5); // Remove "s3://"
+    const slashIndex = withoutScheme.indexOf('/');
+
+    if (slashIndex === -1 || slashIndex === 0) {
+        return {
+            valid: false,
+            error: `Invalid S3 URI: "${uri}". Expected format: s3://bucket/key.`
+        };
+    }
+
+    const bucket = withoutScheme.slice(0, slashIndex);
+    const key = withoutScheme.slice(slashIndex + 1);
+
+    if (!bucket) {
+        return {
+            valid: false,
+            error: `Invalid S3 URI: "${uri}". Bucket name is empty.`
+        };
+    }
+
+    if (!key) {
+        return {
+            valid: false,
+            error: `Invalid S3 URI: "${uri}". Key path is empty.`
+        };
+    }
+
+    return {
+        valid: true,
+        type: 's3',
+        bucket,
+        key
+    };
+}
+
+/**
+ * Parse a Hugging Face dataset reference into org, name, and split.
+ * Defaults to 'train' split if not specified.
+ * @param {string} ref - The HF reference (e.g., "hf://org/name" or "hf://org/name/split")
+ * @returns {Object} Parsed result
+ * @private
+ */
+function _parseHfReference(ref) {
+    const withoutScheme = ref.slice(5); // Remove "hf://"
+    const parts = withoutScheme.split('/');
+
+    if (parts.length < 2 || !parts[0] || !parts[1]) {
+        return {
+            valid: false,
+            error: `Invalid Hugging Face reference: "${ref}". Expected format: hf://org/name[/split].`
+        };
+    }
+
+    const org = parts[0];
+    const name = parts[1];
+    const split = parts.length >= 3 && parts[2] ? parts[2] : 'train';
+
+    return {
+        valid: true,
+        type: 'hf',
+        org,
+        name,
+        split
+    };
+}
+
+/**
+ * Check if a value matches the expected schema type.
+ * @param {*} value - The value to check
+ * @param {string} expectedType - One of "string", "array", "object", "number"
+ * @returns {boolean} True if the value matches the expected type
+ * @private
+ */
+function _checkType(value, expectedType) {
+    switch (expectedType) {
+    case 'string':
+        return typeof value === 'string';
+    case 'number':
+        return typeof value === 'number';
+    case 'array':
+        return Array.isArray(value);
+    case 'object':
+        return typeof value === 'object' && value !== null && !Array.isArray(value);
+    default:
+        return true;
+    }
+}
+
+/**
+ * Get a human-readable type name for a value.
+ * @param {*} value - The value to describe
+ * @returns {string} The type name
+ * @private
+ */
+function _getType(value) {
+    if (value === null) return 'null';
+    if (Array.isArray(value)) return 'array';
+    return typeof value;
+}
+
+/**
+ * Build a human-readable expected format description from a schema.
+ * @param {Object} schema - The dataset schema
+ * @returns {string|null} Description of expected format
+ * @private
+ */
+function _buildExpectedFormat(schema) {
+    if (!schema || !schema.required) {
+        return null;
+    }
+
+    const fields = schema.required.map(key => {
+        const type = schema.types && schema.types[key] ? schema.types[key] : 'any';
+        return `"${key}": <${type}>`;
+    });
+
+    return `Each line must be a JSON object with: {${fields.join(', ')}}`;
+}

--- a/src/lib/tune-output-resolver.js
+++ b/src/lib/tune-output-resolver.js
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tune Output Resolver
+ *
+ * Detects output type from training type and generates context-aware
+ * next-step commands for deploying tune job artifacts.
+ *
+ * Requirements: 8.3, 8.11
+ */
+
+/**
+ * Detect the output type based on the training type used for the job.
+ * LoRA training produces adapter weights; full-rank produces a full model.
+ *
+ * @param {string} trainingType - The training type ('lora' or 'full-rank')
+ * @returns {string} The output type: 'adapter' for lora, 'full-model' for full-rank
+ */
+export function detectOutputType(trainingType) {
+    if (trainingType === 'lora') {
+        return 'adapter';
+    }
+    if (trainingType === 'full-rank') {
+        return 'full-model';
+    }
+    return 'adapter';
+}
+
+/**
+ * Generate context-aware next-step commands based on the output type.
+ *
+ * For adapter output:
+ *   - Quick path: ./do/adapter add tuned-${technique} --from-tune
+ *   - Technique-specific: ./do/adapter add tuned-${technique} --from-tune ${technique}
+ *   - Explicit path: ./do/adapter add tuned-${technique} --weights ${artifactPath}
+ *
+ * For full-model output:
+ *   - Deploy as new IC: ./do/add-ic tuned-v1 --from-tune
+ *   - Explicit path: ./do/add-ic tuned-v1 --model-data ${artifactPath}
+ *   - Replace current base: ./do/deploy --force-ic --model-data ${artifactPath}
+ *
+ * @param {string} outputType - The output type ('adapter' or 'full-model')
+ * @param {string} technique - The technique used (e.g., 'sft', 'dpo')
+ * @param {string} artifactPath - The S3 path to the output artifact
+ * @returns {string[]} Array of suggested next-step commands
+ */
+export function generateNextStepCommands(outputType, technique, artifactPath) {
+    if (outputType === 'adapter') {
+        return [
+            `./do/adapter add tuned-${technique} --from-tune`,
+            `./do/adapter add tuned-${technique} --from-tune ${technique}`,
+            `./do/adapter add tuned-${technique} --weights ${artifactPath}`
+        ];
+    }
+
+    if (outputType === 'full-model') {
+        return [
+            './do/add-ic tuned-v1 --from-tune',
+            `./do/add-ic tuned-v1 --model-data ${artifactPath}`,
+            `./do/deploy --force-ic --model-data ${artifactPath}`
+        ];
+    }
+
+    return [];
+}

--- a/templates/do/.tune_helper.py
+++ b/templates/do/.tune_helper.py
@@ -1,0 +1,768 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SageMaker Managed Model Customization helper.
+
+Subcommands:
+    submit   - Submit a new customization job
+    status   - Get job status and metrics
+    resolve  - Resolve output artifact path from job
+    stage-hf - Download HF dataset to S3
+    validate - Validate dataset format against schema
+
+All output is JSON on stdout for bash consumption.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+# ── Inline dependency check ───────────────────────────────────────────────────
+MIN_SAGEMAKER_VERSION = "2.232.0"
+
+
+def _check_sagemaker_sdk():
+    """Verify sagemaker SDK is installed with minimum version."""
+    try:
+        import sagemaker  # noqa: F401
+        from packaging.version import Version
+        if Version(sagemaker.__version__) < Version(MIN_SAGEMAKER_VERSION):
+            _error_exit(
+                f"sagemaker SDK version {sagemaker.__version__} is below minimum "
+                f"required version {MIN_SAGEMAKER_VERSION}. "
+                f"Please upgrade: pip install 'sagemaker>={MIN_SAGEMAKER_VERSION}'"
+            )
+    except ImportError:
+        _error_exit(
+            f"sagemaker Python SDK is not installed. "
+            f"Please install: pip install 'sagemaker>={MIN_SAGEMAKER_VERSION}'"
+        )
+
+
+# ── Utility functions ─────────────────────────────────────────────────────────
+
+
+def _error_exit(message):
+    """Print JSON error to stdout and exit with code 1."""
+    print(json.dumps({"error": message}))
+    sys.exit(1)
+
+
+def _output(data):
+    """Print JSON result to stdout."""
+    print(json.dumps(data))
+    sys.exit(0)
+
+
+# ── Subcommand: submit ────────────────────────────────────────────────────────
+
+
+def cmd_submit(args):
+    """Submit customization job via SFTTrainer/DPOTrainer.
+
+    Returns: {"job_name": str, "job_arn": str, "mlflow_url": str|None}
+    """
+    _check_sagemaker_sdk()
+
+    from sagemaker.modules.train.sft_trainer import SFTTrainer
+    from sagemaker.modules.train.dpo_trainer import DPOTrainer
+    from sagemaker.modules.train.common import TrainingType
+
+    # Technique → Trainer class mapping
+    TRAINER_MAP = {
+        "sft": SFTTrainer,
+        "dpo": DPOTrainer,
+        # RLAIF and RLVR use SFTTrainer with evaluator config
+        "rlaif": SFTTrainer,
+        "rlvr": SFTTrainer,
+    }
+
+    technique = args.technique
+    trainer_cls = TRAINER_MAP.get(technique)
+    if not trainer_cls:
+        _error_exit(f"Unsupported technique: {technique}")
+
+    # Resolve training type
+    training_type_map = {
+        "lora": TrainingType.LORA,
+        "full-rank": TrainingType.FULL_RANK,
+    }
+    training_type = training_type_map.get(args.training_type)
+    if not training_type:
+        _error_exit(f"Unsupported training type: {args.training_type}")
+
+    # Build hyperparameters dict from optional overrides
+    hyperparameters = {}
+    if args.epochs is not None:
+        hyperparameters["epochs"] = args.epochs
+    if args.learning_rate is not None:
+        hyperparameters["learning_rate"] = args.learning_rate
+    if args.max_seq_length is not None:
+        hyperparameters["max_seq_length"] = args.max_seq_length
+    if args.lora_rank is not None:
+        hyperparameters["lora_rank"] = args.lora_rank
+    if args.lora_alpha is not None:
+        hyperparameters["lora_alpha"] = args.lora_alpha
+    if args.batch_size is not None:
+        hyperparameters["batch_size"] = args.batch_size
+
+    # Build trainer kwargs
+    trainer_kwargs = {
+        "model_id": args.model_id,
+        "training_type": training_type,
+        "train_data_uri": args.dataset_s3_uri,
+        "output_path": f"s3://{args.output_bucket}/{args.project_name}/tune/{technique}/",
+        "role": args.role_arn,
+        "job_name": args.job_name,
+    }
+
+    # Add model package group for artifact registration
+    if args.model_package_group:
+        trainer_kwargs["model_package_group_name"] = args.model_package_group
+
+    # Add hyperparameters if any were specified
+    if hyperparameters:
+        trainer_kwargs["hyperparameters"] = hyperparameters
+
+    # Add evaluator config for RLVR/RLAIF techniques
+    if technique in ("rlvr", "rlaif"):
+        if args.reward_function:
+            trainer_kwargs["evaluator_config"] = {
+                "reward_function_arn": args.reward_function
+            }
+        elif args.reward_prompt:
+            trainer_kwargs["evaluator_config"] = {
+                "reward_prompt_s3_uri": args.reward_prompt
+            }
+
+    try:
+        trainer = trainer_cls(**trainer_kwargs)
+        trainer.train(wait=False)
+
+        # Extract job info from the trainer
+        job_name = trainer.training_job_name
+        job_arn = getattr(trainer, "training_job_arn", None)
+
+        # Attempt to get MLflow URL if available
+        mlflow_url = None
+        try:
+            mlflow_url = getattr(trainer, "mlflow_tracking_uri", None)
+        except Exception:
+            pass
+
+        _output({
+            "job_name": job_name,
+            "job_arn": job_arn or "",
+            "mlflow_url": mlflow_url,
+            "model_package_group": args.model_package_group or "",
+        })
+
+    except Exception as e:
+        error_msg = str(e)
+        # Provide helpful context for common errors
+        if "AccessDeniedException" in error_msg or "AccessDenied" in error_msg:
+            _error_exit(
+                f"Access denied when submitting training job. "
+                f"Ensure the role has sagemaker:CreateTrainingJob permission. "
+                f"Details: {error_msg}"
+            )
+        elif "ResourceLimitExceeded" in error_msg:
+            _error_exit(
+                f"Resource limit exceeded. You may need to request a quota increase. "
+                f"Details: {error_msg}"
+            )
+        elif "ValidationException" in error_msg and "license" in error_msg.lower():
+            _error_exit(
+                f"Model license not accepted. Accept the license in JumpStart before "
+                f"using this model for customization. Details: {error_msg}"
+            )
+        else:
+            _error_exit(f"Failed to submit training job: {error_msg}")
+
+
+# ── Subcommand: status ────────────────────────────────────────────────────────
+
+
+def cmd_status(args):
+    """Query job status via DescribeTrainingJob.
+
+    Returns: {"status": str, "failure_reason": str|None,
+              "metrics": dict|None, "elapsed_seconds": int}
+    """
+    import boto3
+
+    client = boto3.client("sagemaker", region_name=args.region)
+
+    try:
+        response = client.describe_training_job(TrainingJobName=args.job_name)
+    except client.exceptions.ClientError as e:
+        error_code = e.response["Error"]["Code"]
+        if error_code == "ValidationException":
+            _error_exit(f"Training job not found: {args.job_name}")
+        _error_exit(f"Failed to describe training job: {e}")
+    except Exception as e:
+        _error_exit(f"Failed to describe training job: {e}")
+
+    status = response.get("TrainingJobStatus", "Unknown")
+    failure_reason = response.get("FailureReason")
+
+    # Calculate elapsed time
+    start_time = response.get("TrainingStartTime")
+    end_time = response.get("TrainingEndTime")
+    elapsed_seconds = 0
+
+    if start_time:
+        end = end_time if end_time else time.time()
+        if hasattr(end, "timestamp"):
+            end = end.timestamp()
+        elapsed_seconds = int(end - start_time.timestamp())
+
+    # Extract final metrics if available
+    metrics = None
+    final_metrics = response.get("FinalMetricDataList")
+    if final_metrics:
+        metrics = {}
+        for metric in final_metrics:
+            metrics[metric["MetricName"]] = metric["Value"]
+
+    # Get output path if completed
+    output_path = None
+    if status == "Completed":
+        model_artifacts = response.get("ModelArtifacts", {})
+        output_path = model_artifacts.get("S3ModelArtifacts")
+
+    _output({
+        "status": status,
+        "failure_reason": failure_reason,
+        "metrics": metrics,
+        "elapsed_seconds": elapsed_seconds,
+        "output_path": output_path,
+    })
+
+
+# ── Subcommand: resolve ───────────────────────────────────────────────────────
+
+
+def cmd_resolve(args):
+    """Resolve artifact path within S3 output directory.
+
+    Returns: {"artifact_path": str, "model_package_arn": str|None,
+              "output_type": str}
+    """
+    import boto3
+
+    client = boto3.client("sagemaker", region_name=args.region)
+
+    try:
+        response = client.describe_training_job(TrainingJobName=args.job_name)
+    except Exception as e:
+        _error_exit(f"Failed to describe training job: {e}")
+
+    status = response.get("TrainingJobStatus")
+    if status != "Completed":
+        _error_exit(
+            f"Cannot resolve artifacts for job in status: {status}. "
+            f"Job must be Completed."
+        )
+
+    # Get the S3 model artifacts path
+    model_artifacts = response.get("ModelArtifacts", {})
+    artifact_path = model_artifacts.get("S3ModelArtifacts", "")
+
+    if not artifact_path:
+        _error_exit("No model artifacts found in training job output.")
+
+    # Determine output type from training type
+    output_type = "adapter" if args.training_type == "lora" else "full-model"
+
+    # Try to find model package ARN if a model package group was used
+    model_package_arn = None
+    if args.model_package_group:
+        try:
+            mp_client = boto3.client("sagemaker", region_name=args.region)
+            packages = mp_client.list_model_packages(
+                ModelPackageGroupName=args.model_package_group,
+                SortBy="CreationTime",
+                SortOrder="Descending",
+                MaxResults=1,
+            )
+            package_list = packages.get("ModelPackageSummaryList", [])
+            if package_list:
+                model_package_arn = package_list[0].get("ModelPackageArn")
+        except Exception:
+            # Model package lookup is best-effort
+            pass
+
+    _output({
+        "artifact_path": artifact_path,
+        "model_package_arn": model_package_arn,
+        "output_type": output_type,
+    })
+
+
+# ── Subcommand: stage-hf ─────────────────────────────────────────────────────
+
+
+def cmd_stage_hf(args):
+    """Download HF dataset to S3 using huggingface_hub.
+
+    Handles auth via Secrets Manager or HF_TOKEN env var.
+
+    Returns: {"s3_uri": str, "num_records": int}
+    """
+    try:
+        from huggingface_hub import hf_hub_download, HfApi
+    except ImportError:
+        _error_exit(
+            "huggingface_hub is not installed. "
+            "Please install: pip install huggingface_hub"
+        )
+
+    import boto3
+    import tempfile
+
+    # Resolve HF token: Secrets Manager first, then env var
+    hf_token = _resolve_hf_token(args.region, args.hf_secret_name)
+
+    # Parse the HF reference
+    org = args.hf_org
+    name = args.hf_name
+    split = args.hf_split or "train"
+    dataset_id = f"{org}/{name}"
+
+    # Download dataset files to a temp directory
+    try:
+        api = HfApi(token=hf_token)
+
+        # List files in the dataset repo
+        repo_files = api.list_repo_files(
+            repo_id=dataset_id,
+            repo_type="dataset",
+            token=hf_token,
+        )
+
+        # Find the appropriate data file for the split
+        data_files = _find_data_files(repo_files, split)
+        if not data_files:
+            _error_exit(
+                f"No data files found for split '{split}' in dataset {dataset_id}. "
+                f"Available files: {', '.join(repo_files[:20])}"
+            )
+
+        # Download and upload to S3
+        s3_client = boto3.client("s3", region_name=args.region)
+        s3_prefix = f"{args.project_name}/datasets/{org}/{name}/{split}"
+        num_records = 0
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for data_file in data_files:
+                local_path = hf_hub_download(
+                    repo_id=dataset_id,
+                    filename=data_file,
+                    repo_type="dataset",
+                    token=hf_token,
+                    local_dir=tmpdir,
+                )
+
+                # Count records (lines for JSONL)
+                with open(local_path, "r") as f:
+                    for line in f:
+                        if line.strip():
+                            num_records += 1
+
+                # Upload to S3
+                s3_key = f"{s3_prefix}/{os.path.basename(data_file)}"
+                s3_client.upload_file(local_path, args.output_bucket, s3_key)
+
+        s3_uri = f"s3://{args.output_bucket}/{s3_prefix}/{os.path.basename(data_files[0])}"
+
+        _output({
+            "s3_uri": s3_uri,
+            "num_records": num_records,
+        })
+
+    except Exception as e:
+        error_msg = str(e)
+        if "404" in error_msg or "not found" in error_msg.lower():
+            _error_exit(
+                f"Dataset not found: {dataset_id}. "
+                f"Check the dataset name and ensure it exists on Hugging Face Hub."
+            )
+        elif "401" in error_msg or "unauthorized" in error_msg.lower():
+            _error_exit(
+                f"Authentication failed for dataset {dataset_id}. "
+                f"Ensure HF_TOKEN is set or configured via Secrets Manager."
+            )
+        else:
+            _error_exit(f"Failed to stage HF dataset: {error_msg}")
+
+
+def _resolve_hf_token(region, secret_name=None):
+    """Resolve HF token from Secrets Manager or environment variable.
+
+    Args:
+        region: AWS region for Secrets Manager
+        secret_name: Optional Secrets Manager secret name/ARN
+
+    Returns:
+        str or None: The HF token, or None if not available
+    """
+    # Try Secrets Manager first if a secret name is provided
+    if secret_name:
+        try:
+            import boto3
+            client = boto3.client("secretsmanager", region_name=region)
+            response = client.get_secret_value(SecretId=secret_name)
+            secret_value = response.get("SecretString", "")
+            if secret_value:
+                return secret_value.strip()
+        except Exception:
+            # Fall through to env var
+            pass
+
+    # Fall back to HF_TOKEN environment variable
+    return os.environ.get("HF_TOKEN")
+
+
+def _find_data_files(repo_files, split):
+    """Find data files matching the requested split.
+
+    Looks for common patterns: data/{split}.jsonl, {split}.jsonl,
+    data/{split}-*.parquet, etc.
+
+    Args:
+        repo_files: List of file paths in the repo
+        split: The dataset split name (e.g., "train")
+
+    Returns:
+        list: Matching file paths
+    """
+    # Priority order for file matching
+    patterns = [
+        f"data/{split}.jsonl",
+        f"{split}.jsonl",
+        f"data/{split}.json",
+        f"{split}.json",
+        f"data/{split}-00000-of-",
+        f"{split}-00000-of-",
+    ]
+
+    # Exact match first
+    for pattern in patterns[:4]:
+        if pattern in repo_files:
+            return [pattern]
+
+    # Prefix match for sharded files
+    matches = []
+    for f in repo_files:
+        for pattern in patterns[4:]:
+            if pattern in f:
+                matches.append(f)
+
+    if matches:
+        return sorted(matches)
+
+    # Fallback: any JSONL file containing the split name
+    jsonl_files = [f for f in repo_files if f.endswith(".jsonl") and split in f]
+    if jsonl_files:
+        return sorted(jsonl_files)
+
+    # Last resort: any JSONL file in data/ directory
+    data_jsonl = [f for f in repo_files if f.startswith("data/") and f.endswith(".jsonl")]
+    if data_jsonl:
+        return sorted(data_jsonl)
+
+    return []
+
+
+# ── Subcommand: validate ──────────────────────────────────────────────────────
+
+
+def cmd_validate(args):
+    """Validate dataset format against expected schema.
+
+    The schema is passed as a JSON string argument.
+
+    Returns: {"valid": bool, "error": str|None, "line_number": int|None,
+              "malformed_line": str|None}
+    """
+    # Parse the schema from JSON argument
+    try:
+        schema = json.loads(args.schema)
+    except json.JSONDecodeError as e:
+        _error_exit(f"Invalid schema JSON: {e}")
+
+    required_keys = schema.get("required", [])
+    type_map = schema.get("types", {})
+
+    # Read lines from stdin or file
+    lines = []
+    if args.file and args.file != "-":
+        try:
+            with open(args.file, "r") as f:
+                for i, line in enumerate(f):
+                    lines.append(line.rstrip("\n"))
+                    if i >= 9:  # Only inspect first 10 lines
+                        break
+        except FileNotFoundError:
+            _error_exit(f"Dataset file not found: {args.file}")
+        except Exception as e:
+            _error_exit(f"Failed to read dataset file: {e}")
+    else:
+        # Read from stdin
+        for i, line in enumerate(sys.stdin):
+            lines.append(line.rstrip("\n"))
+            if i >= 9:  # Only inspect first 10 lines
+                break
+
+    # Validate each line
+    for i, line in enumerate(lines):
+        line_number = i + 1
+
+        # Skip empty lines
+        if not line or not line.strip():
+            continue
+
+        # Try to parse as JSON
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError as e:
+            _output({
+                "valid": False,
+                "error": f"Line {line_number} is not valid JSON: {e}",
+                "line_number": line_number,
+                "malformed_line": line,
+                "expected_format": _build_expected_format(schema),
+            })
+            return
+
+        # Check that parsed value is a dict
+        if not isinstance(parsed, dict):
+            _output({
+                "valid": False,
+                "error": f"Line {line_number} must be a JSON object.",
+                "line_number": line_number,
+                "malformed_line": line,
+                "expected_format": _build_expected_format(schema),
+            })
+            return
+
+        # Check required keys
+        for key in required_keys:
+            if key not in parsed:
+                _output({
+                    "valid": False,
+                    "error": f'Line {line_number} is missing required key "{key}".',
+                    "line_number": line_number,
+                    "malformed_line": line,
+                    "expected_format": _build_expected_format(schema),
+                })
+                return
+
+        # Check types if specified
+        for key, expected_type in type_map.items():
+            if key not in parsed:
+                continue
+
+            value = parsed[key]
+            if not _check_type(value, expected_type):
+                actual_type = _get_type(value)
+                _output({
+                    "valid": False,
+                    "error": (
+                        f'Line {line_number} has key "{key}" with wrong type. '
+                        f'Expected "{expected_type}", got "{actual_type}".'
+                    ),
+                    "line_number": line_number,
+                    "malformed_line": line,
+                    "expected_format": _build_expected_format(schema),
+                })
+                return
+
+    _output({
+        "valid": True,
+        "error": None,
+        "line_number": None,
+        "malformed_line": None,
+    })
+
+
+def _check_type(value, expected_type):
+    """Check if a value matches the expected schema type.
+
+    Args:
+        value: The value to check
+        expected_type: One of "string", "array", "object", "number"
+
+    Returns:
+        bool: True if the value matches the expected type
+    """
+    if expected_type == "string":
+        return isinstance(value, str)
+    elif expected_type == "number":
+        return isinstance(value, (int, float))
+    elif expected_type == "array":
+        return isinstance(value, list)
+    elif expected_type == "object":
+        return isinstance(value, dict)
+    return True
+
+
+def _get_type(value):
+    """Get a human-readable type name for a value."""
+    if value is None:
+        return "null"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    return type(value).__name__
+
+
+def _build_expected_format(schema):
+    """Build a human-readable expected format description from a schema.
+
+    Args:
+        schema: The dataset schema dict
+
+    Returns:
+        str: Description of expected format
+    """
+    required = schema.get("required", [])
+    types = schema.get("types", {})
+
+    fields = []
+    for key in required:
+        field_type = types.get(key, "any")
+        fields.append(f'"{key}": <{field_type}>')
+
+    return "Each line must be a JSON object with: {" + ", ".join(fields) + "}"
+
+
+# ── CLI argument parsing ──────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="SageMaker Managed Model Customization helper",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Subcommand to run")
+
+    # ── submit ────────────────────────────────────────────────────────────────
+    submit_parser = subparsers.add_parser("submit", help="Submit a customization job")
+    submit_parser.add_argument("--model-id", required=True, help="JumpStart model ID")
+    submit_parser.add_argument("--technique", required=True,
+                               choices=["sft", "dpo", "rlaif", "rlvr"],
+                               help="Customization technique")
+    submit_parser.add_argument("--training-type", required=True,
+                               choices=["lora", "full-rank"],
+                               help="Training type (lora or full-rank)")
+    submit_parser.add_argument("--dataset-s3-uri", required=True,
+                               help="S3 URI of the training dataset")
+    submit_parser.add_argument("--output-bucket", required=True,
+                               help="S3 bucket for output artifacts")
+    submit_parser.add_argument("--role-arn", required=True,
+                               help="IAM execution role ARN")
+    submit_parser.add_argument("--job-name", required=True,
+                               help="Unique job name")
+    submit_parser.add_argument("--project-name", required=True,
+                               help="Project name for S3 path prefix")
+    submit_parser.add_argument("--model-package-group", default=None,
+                               help="Model package group name for registration")
+    submit_parser.add_argument("--epochs", type=int, default=None,
+                               help="Number of training epochs")
+    submit_parser.add_argument("--learning-rate", type=float, default=None,
+                               help="Learning rate")
+    submit_parser.add_argument("--max-seq-length", type=int, default=None,
+                               help="Maximum sequence length")
+    submit_parser.add_argument("--lora-rank", type=int, default=None,
+                               help="LoRA rank")
+    submit_parser.add_argument("--lora-alpha", type=int, default=None,
+                               help="LoRA alpha scaling factor")
+    submit_parser.add_argument("--batch-size", type=int, default=None,
+                               help="Global batch size")
+    submit_parser.add_argument("--reward-function", default=None,
+                               help="Lambda ARN for reward function (RLVR)")
+    submit_parser.add_argument("--reward-prompt", default=None,
+                               help="S3 URI for reward prompt (RLAIF)")
+
+    # ── status ────────────────────────────────────────────────────────────────
+    status_parser = subparsers.add_parser("status", help="Get job status and metrics")
+    status_parser.add_argument("--job-name", required=True,
+                               help="Training job name")
+    status_parser.add_argument("--region", required=True,
+                               help="AWS region")
+
+    # ── resolve ───────────────────────────────────────────────────────────────
+    resolve_parser = subparsers.add_parser("resolve",
+                                           help="Resolve output artifact path")
+    resolve_parser.add_argument("--job-name", required=True,
+                                help="Training job name")
+    resolve_parser.add_argument("--region", required=True,
+                                help="AWS region")
+    resolve_parser.add_argument("--training-type", required=True,
+                                choices=["lora", "full-rank"],
+                                help="Training type used for the job")
+    resolve_parser.add_argument("--model-package-group", default=None,
+                                help="Model package group name")
+
+    # ── stage-hf ──────────────────────────────────────────────────────────────
+    stage_hf_parser = subparsers.add_parser("stage-hf",
+                                            help="Download HF dataset to S3")
+    stage_hf_parser.add_argument("--hf-org", required=True,
+                                 help="Hugging Face organization/user")
+    stage_hf_parser.add_argument("--hf-name", required=True,
+                                 help="Hugging Face dataset name")
+    stage_hf_parser.add_argument("--hf-split", default="train",
+                                 help="Dataset split (default: train)")
+    stage_hf_parser.add_argument("--output-bucket", required=True,
+                                 help="S3 bucket for staged dataset")
+    stage_hf_parser.add_argument("--project-name", required=True,
+                                 help="Project name for S3 path prefix")
+    stage_hf_parser.add_argument("--region", required=True,
+                                 help="AWS region")
+    stage_hf_parser.add_argument("--hf-secret-name", default=None,
+                                 help="Secrets Manager secret name for HF token")
+
+    # ── validate ──────────────────────────────────────────────────────────────
+    validate_parser = subparsers.add_parser("validate",
+                                            help="Validate dataset format")
+    validate_parser.add_argument("--schema", required=True,
+                                 help="JSON string of the expected dataset schema")
+    validate_parser.add_argument("--file", default="-",
+                                 help="Path to dataset file (default: stdin)")
+
+    # ── Parse and dispatch ────────────────────────────────────────────────────
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    command_map = {
+        "submit": cmd_submit,
+        "status": cmd_status,
+        "resolve": cmd_resolve,
+        "stage-hf": cmd_stage_hf,
+        "validate": cmd_validate,
+    }
+
+    handler = command_map.get(args.command)
+    if handler:
+        handler(args)
+    else:
+        _error_exit(f"Unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/do/adapter
+++ b/templates/do/adapter
@@ -29,6 +29,7 @@ _usage() {
     echo "Commands:"
     echo "  add <name> --weights <s3-uri>        Add a new LoRA adapter from S3"
     echo "  add <name> --from-hub <hf-repo-id>   Add a new LoRA adapter from HuggingFace Hub"
+    echo "  add <name> --from-tune [technique]   Add adapter from do/tune output"
     echo "  list                                  List all adapters on the endpoint"
     echo "  remove <name>                         Remove an adapter"
     echo "  update <name> --weights <new-s3-uri>  Update adapter weights from S3"
@@ -41,6 +42,8 @@ _usage() {
     echo "Examples:"
     echo "  ./do/adapter add ectsum --weights s3://my-bucket/adapters/ectsum/adapter.tar.gz"
     echo "  ./do/adapter add ectsum --from-hub predibase/llama-3.1-8b-ectsum"
+    echo "  ./do/adapter add tuned-sft --from-tune"
+    echo "  ./do/adapter add tuned-sft --from-tune sft"
     echo "  ./do/adapter list"
     echo "  ./do/adapter remove ectsum"
     echo "  ./do/adapter update ectsum --weights s3://my-bucket/adapters/ectsum-v2/adapter.tar.gz"
@@ -48,7 +51,7 @@ _usage() {
     echo ""
     echo "Adapter metadata is stored in do/adapters/<name>.conf"
     echo ""
-    echo "Note: --weights and --from-hub are mutually exclusive."
+    echo "Note: --weights, --from-hub, and --from-tune are mutually exclusive."
 }
 
 # ── Validate LoRA is enabled ──────────────────────────────────────────────────
@@ -357,6 +360,8 @@ _adapter_add() {
     local adapter_name=""
     local weights_uri=""
     local from_hub=""
+    local from_tune=""
+    local from_tune_technique=""
 
     # Parse add arguments
     shift  # remove 'add' from args
@@ -380,28 +385,45 @@ _adapter_add() {
                 from_hub="$2"
                 shift 2
                 ;;
+            --from-tune)
+                from_tune="true"
+                # Check if next argument is a technique (not another flag and not empty)
+                if [ -n "${2:-}" ] && [[ "${2}" != -* ]]; then
+                    from_tune_technique="$2"
+                    shift 2
+                else
+                    shift
+                fi
+                ;;
             --help|-h)
                 echo "Usage: ./do/adapter add <name> --weights <s3-uri>"
                 echo "       ./do/adapter add <name> --from-hub <hf-repo-id>"
+                echo "       ./do/adapter add <name> --from-tune [technique]"
                 echo ""
                 echo "Add a new LoRA adapter to the endpoint."
                 echo ""
                 echo "Arguments:"
-                echo "  <name>                    Adapter name (lowercase alphanumeric + hyphens, 1-50 chars)"
-                echo "  --weights <s3-uri>        S3 URI to adapter weights (.tar.gz)"
-                echo "  --from-hub <hf-repo-id>   Download adapter from HuggingFace Hub"
+                echo "  <name>                      Adapter name (lowercase alphanumeric + hyphens, 1-50 chars)"
+                echo "  --weights <s3-uri>          S3 URI to adapter weights (.tar.gz)"
+                echo "  --from-hub <hf-repo-id>     Download adapter from HuggingFace Hub"
+                echo "  --from-tune [technique]     Use adapter output from do/tune"
+                echo "                              Without technique: uses latest tune output"
+                echo "                              With technique (e.g., sft, dpo): uses technique-specific output"
                 echo ""
-                echo "Note: --weights and --from-hub are mutually exclusive."
+                echo "Note: --weights, --from-hub, and --from-tune are mutually exclusive."
                 echo ""
                 echo "Examples:"
                 echo "  ./do/adapter add ectsum --weights s3://bucket/adapters/ectsum/adapter.tar.gz"
                 echo "  ./do/adapter add ectsum --from-hub predibase/llama-3.1-8b-ectsum"
+                echo "  ./do/adapter add tuned-sft --from-tune"
+                echo "  ./do/adapter add tuned-sft --from-tune sft"
                 exit 0
                 ;;
             -*)
                 echo "❌ Unknown option: $1"
                 echo "   Usage: ./do/adapter add <name> --weights <s3-uri>"
                 echo "          ./do/adapter add <name> --from-hub <hf-repo-id>"
+                echo "          ./do/adapter add <name> --from-tune [technique]"
                 exit 1
                 ;;
             *)
@@ -411,6 +433,7 @@ _adapter_add() {
                     echo "❌ Unexpected argument: $1"
                     echo "   Usage: ./do/adapter add <name> --weights <s3-uri>"
                     echo "          ./do/adapter add <name> --from-hub <hf-repo-id>"
+                    echo "          ./do/adapter add <name> --from-tune [technique]"
                     exit 1
                 fi
                 shift
@@ -423,24 +446,83 @@ _adapter_add() {
         echo "❌ Adapter name is required"
         echo "   Usage: ./do/adapter add <name> --weights <s3-uri>"
         echo "          ./do/adapter add <name> --from-hub <hf-repo-id>"
+        echo "          ./do/adapter add <name> --from-tune [technique]"
         exit 1
     fi
 
     # ── Mutual exclusivity check ─────────────────────────────────────────
-    if [ -n "${weights_uri}" ] && [ -n "${from_hub}" ]; then
-        echo "❌ --weights and --from-hub are mutually exclusive"
+    local source_count=0
+    [ -n "${weights_uri}" ] && source_count=$((source_count + 1))
+    [ -n "${from_hub}" ] && source_count=$((source_count + 1))
+    [ -n "${from_tune}" ] && source_count=$((source_count + 1))
+
+    if [ "${source_count}" -gt 1 ]; then
+        echo "❌ --weights, --from-hub, and --from-tune are mutually exclusive"
         echo ""
-        echo "   Use one or the other:"
+        echo "   Use one of:"
         echo "   ./do/adapter add ${adapter_name} --weights <s3-uri>"
         echo "   ./do/adapter add ${adapter_name} --from-hub <hf-repo-id>"
+        echo "   ./do/adapter add ${adapter_name} --from-tune [technique]"
         exit 1
     fi
 
-    if [ -z "${weights_uri}" ] && [ -z "${from_hub}" ]; then
-        echo "❌ Either --weights or --from-hub is required"
+    if [ "${source_count}" -eq 0 ]; then
+        echo "❌ One of --weights, --from-hub, or --from-tune is required"
         echo "   Usage: ./do/adapter add <name> --weights <s3-uri>"
         echo "          ./do/adapter add <name> --from-hub <hf-repo-id>"
+        echo "          ./do/adapter add <name> --from-tune [technique]"
         exit 1
+    fi
+
+    # ── Resolve --from-tune to weights_uri ────────────────────────────────
+    if [ -n "${from_tune}" ]; then
+        if [ -n "${from_tune_technique}" ]; then
+            # Technique-specific: read TUNE_ADAPTER_PATH_<TECHNIQUE>
+            local technique_upper
+            technique_upper=$(echo "${from_tune_technique}" | tr '[:lower:]' '[:upper:]')
+            local tune_var="TUNE_ADAPTER_PATH_${technique_upper}"
+            local tune_path="${!tune_var:-}"
+
+            if [ -z "${tune_path}" ]; then
+                echo "❌ No adapter output found for technique: ${from_tune_technique}"
+                echo ""
+                echo "   ${tune_var} is not set in do/config."
+                echo ""
+                echo "   Run a tune job first:"
+                echo "   ./do/tune --technique ${from_tune_technique} --dataset <source>"
+                exit 1
+            fi
+
+            weights_uri="${tune_path}"
+            echo "📦 Using tune adapter output for technique '${from_tune_technique}': ${weights_uri}"
+        else
+            # No technique: read TUNE_OUTPUT_PATH_LATEST and verify type
+            if [ -z "${TUNE_OUTPUT_PATH_LATEST:-}" ]; then
+                echo "❌ No tune output found."
+                echo ""
+                echo "   TUNE_OUTPUT_PATH_LATEST is not set in do/config."
+                echo ""
+                echo "   Run a tune job first:"
+                echo "   ./do/tune --technique <technique> --dataset <source>"
+                exit 1
+            fi
+
+            # Verify output type is adapter (not full-model)
+            if [ "${TUNE_OUTPUT_TYPE_LATEST:-}" = "full-model" ]; then
+                echo "❌ Latest tune output is a full model, not an adapter."
+                echo ""
+                echo "   TUNE_OUTPUT_TYPE_LATEST=full-model"
+                echo ""
+                echo "   Full model outputs cannot be added as adapters."
+                echo "   Use do/add-ic instead:"
+                echo "   ./do/add-ic ${adapter_name} --from-tune"
+                exit 1
+            fi
+
+            weights_uri="${TUNE_OUTPUT_PATH_LATEST}"
+            echo "📦 Using latest tune adapter output: ${weights_uri}"
+        fi
+        echo ""
     fi
 
     # ── Validate HF repo ID format (if --from-hub) ───────────────────────
@@ -468,8 +550,8 @@ _adapter_add() {
         exit 1
     fi
 
-    # ── Validate S3 URI format (only when --weights is used) ─────────────
-    if [ -n "${weights_uri}" ]; then
+    # ── Validate S3 URI format (only when --weights is explicitly used) ──
+    if [ -n "${weights_uri}" ] && [ -z "${from_hub}" ] && [ -z "${from_tune}" ]; then
         if ! echo "${weights_uri}" | grep -qE '^s3://.*\.tar\.gz$'; then
             echo "❌ Invalid S3 URI: ${weights_uri}"
             echo ""
@@ -495,6 +577,9 @@ _adapter_add() {
     echo "🔌 Adding adapter: ${adapter_name}"
     if [ -n "${from_hub}" ]; then
         echo "   Source: HuggingFace Hub (${from_hub})"
+    elif [ -n "${from_tune}" ]; then
+        echo "   Source: do/tune output"
+        echo "   Weights: ${weights_uri}"
     else
         echo "   Weights: ${weights_uri}"
     fi
@@ -593,6 +678,14 @@ export ADAPTER_HF_REPO="${from_hub}"
 EOF
     fi
 
+    # Add tune-specific metadata if --from-tune was used
+    if [ -n "${from_tune}" ]; then
+        cat >> "${SCRIPT_DIR}/adapters/${adapter_name}.conf" <<EOF
+export ADAPTER_SOURCE="tune"
+export ADAPTER_TUNE_TECHNIQUE="${from_tune_technique:-latest}"
+EOF
+    fi
+
     echo ""
     echo "✅ Adapter added successfully!"
     echo ""
@@ -602,6 +695,8 @@ EOF
     echo "   Weights: ${weights_uri}"
     if [ -n "${from_hub}" ]; then
         echo "   Source: HuggingFace Hub (${from_hub})"
+    elif [ -n "${from_tune}" ]; then
+        echo "   Source: do/tune (${from_tune_technique:-latest})"
     fi
     echo "   Created: ${created_at}"
     echo ""

--- a/templates/do/add-ic
+++ b/templates/do/add-ic
@@ -4,6 +4,10 @@
 #
 # Add a new inference component to this project.
 # Creates a new IC config file in do/ic/ and deploys it immediately.
+#
+# Usage:
+#   ./do/add-ic [name] [--from-tune] [--model-data <s3-uri>]
+#   ./do/add-ic --help
 
 set -e
 set -u
@@ -12,38 +16,157 @@ set -o pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/config"
 
+# ============================================================
+# Usage
+# ============================================================
+_usage() {
+    echo "Usage: ./do/add-ic [name] [options]"
+    echo ""
+    echo "Add a new inference component to this project."
+    echo ""
+    echo "Arguments:"
+    echo "  [name]                     IC name (optional, prompted if not provided)"
+    echo ""
+    echo "Options:"
+    echo "  --from-tune                Use model output from do/tune (reads TUNE_OUTPUT_PATH_LATEST)"
+    echo "  --model-data <s3-uri>      S3 URI to model data (tar.gz or model directory)"
+    echo "  --help, -h                 Show this help message"
+    echo ""
+    echo "Note: --from-tune and --model-data are mutually exclusive."
+    echo ""
+    echo "Examples:"
+    echo "  ./do/add-ic                                    # Interactive mode"
+    echo "  ./do/add-ic tuned-v1 --from-tune               # Use latest tune output"
+    echo "  ./do/add-ic tuned-v1 --model-data s3://bucket/model.tar.gz"
+    echo ""
+}
+
+# ============================================================
+# Parse arguments
+# ============================================================
+IC_NAME=""
+FROM_TUNE=""
+MODEL_DATA=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --from-tune)
+            FROM_TUNE="true"
+            shift
+            ;;
+        --model-data)
+            if [ -z "${2:-}" ]; then
+                echo "❌ --model-data requires an S3 URI argument"
+                echo "   Usage: ./do/add-ic <name> --model-data <s3-uri>"
+                exit 1
+            fi
+            MODEL_DATA="$2"
+            shift 2
+            ;;
+        --help|-h)
+            _usage
+            exit 0
+            ;;
+        -*)
+            echo "❌ Unknown option: $1"
+            _usage
+            exit 1
+            ;;
+        *)
+            if [ -z "${IC_NAME}" ]; then
+                IC_NAME="$1"
+            else
+                echo "❌ Unexpected argument: $1"
+                _usage
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+# ============================================================
+# Mutual exclusivity check
+# ============================================================
+if [ -n "${FROM_TUNE}" ] && [ -n "${MODEL_DATA}" ]; then
+    echo "❌ --from-tune and --model-data are mutually exclusive"
+    echo ""
+    echo "   Use one of:"
+    echo "   ./do/add-ic <name> --from-tune"
+    echo "   ./do/add-ic <name> --model-data <s3-uri>"
+    exit 1
+fi
+
+# ============================================================
+# Resolve --from-tune to MODEL_DATA
+# ============================================================
+if [ -n "${FROM_TUNE}" ]; then
+    if [ -z "${TUNE_OUTPUT_PATH_LATEST:-}" ]; then
+        echo "❌ No tune output found."
+        echo ""
+        echo "   TUNE_OUTPUT_PATH_LATEST is not set in do/config."
+        echo ""
+        echo "   Run a tune job first:"
+        echo "   ./do/tune --technique <technique> --dataset <source>"
+        exit 1
+    fi
+
+    MODEL_DATA="${TUNE_OUTPUT_PATH_LATEST}"
+    echo "📦 Using tune output: ${MODEL_DATA}"
+    echo ""
+fi
+
 echo "➕ Add New Inference Component"
 echo "   Project: ${PROJECT_NAME}"
+if [ -n "${MODEL_DATA}" ]; then
+    echo "   Model data: ${MODEL_DATA}"
+fi
 echo ""
 
 # ============================================================
-# Prompt for IC name
+# Prompt for IC name (if not provided as argument)
 # ============================================================
-while true; do
-    read -p "IC name (lowercase alphanumeric + hyphens): " IC_NAME
+if [ -z "${IC_NAME}" ]; then
+    while true; do
+        read -p "IC name (lowercase alphanumeric + hyphens): " IC_NAME
 
-    # Validate: non-empty
-    if [ -z "${IC_NAME}" ]; then
-        echo "   ❌ IC name cannot be empty."
-        continue
-    fi
+        # Validate: non-empty
+        if [ -z "${IC_NAME}" ]; then
+            echo "   ❌ IC name cannot be empty."
+            continue
+        fi
 
-    # Validate: lowercase alphanumeric + hyphens only
+        # Validate: lowercase alphanumeric + hyphens only
+        if ! echo "${IC_NAME}" | grep -qE '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
+            echo "   ❌ IC name must be lowercase alphanumeric with hyphens (e.g., 'llama-70b')."
+            echo "      Must start and end with a letter or number."
+            continue
+        fi
+
+        # Validate: no collision with existing config
+        if [ -f "${SCRIPT_DIR}/ic/${IC_NAME}.conf" ]; then
+            echo "   ❌ IC config already exists: do/ic/${IC_NAME}.conf"
+            echo "      Choose a different name or edit the existing config."
+            continue
+        fi
+
+        break
+    done
+else
+    # Validate provided IC name
     if ! echo "${IC_NAME}" | grep -qE '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
-        echo "   ❌ IC name must be lowercase alphanumeric with hyphens (e.g., 'llama-70b')."
-        echo "      Must start and end with a letter or number."
-        continue
+        echo "❌ Invalid IC name: ${IC_NAME}"
+        echo "   IC name must be lowercase alphanumeric with hyphens (e.g., 'llama-70b')."
+        echo "   Must start and end with a letter or number."
+        exit 1
     fi
 
-    # Validate: no collision with existing config
     if [ -f "${SCRIPT_DIR}/ic/${IC_NAME}.conf" ]; then
-        echo "   ❌ IC config already exists: do/ic/${IC_NAME}.conf"
-        echo "      Choose a different name or edit the existing config."
-        continue
+        echo "❌ IC config already exists: do/ic/${IC_NAME}.conf"
+        echo "   Choose a different name or edit the existing config."
+        exit 1
     fi
-
-    break
-done
+fi
 
 # ============================================================
 # Prompt for image tag
@@ -107,6 +230,16 @@ export IC_GPU_COUNT=${IC_GPU_COUNT}
 export IC_COPY_COUNT=${IC_COPY_COUNT}
 export IC_MIN_MEMORY_MB=${IC_MIN_MEMORY_MB}
 export IC_STARTUP_TIMEOUT=900
+EOF
+
+# Add model data if provided (from --from-tune or --model-data)
+if [ -n "${MODEL_DATA}" ]; then
+    cat >> "${IC_CONF_PATH}" <<EOF
+export IC_MODEL_DATA="${MODEL_DATA}"
+EOF
+fi
+
+cat >> "${IC_CONF_PATH}" <<EOF
 
 # Optional overrides:
 # export IC_MODEL_NAME="my-model-v2"
@@ -120,6 +253,9 @@ echo "   Image tag:  ${IC_IMAGE_TAG}"
 echo "   GPU count:  ${IC_GPU_COUNT}"
 echo "   Copy count: ${IC_COPY_COUNT}"
 echo "   Memory MB:  ${IC_MIN_MEMORY_MB}"
+if [ -n "${MODEL_DATA}" ]; then
+    echo "   Model data: ${MODEL_DATA}"
+fi
 echo ""
 
 # ============================================================

--- a/templates/do/config
+++ b/templates/do/config
@@ -188,6 +188,12 @@ export NGC_API_KEY_ARN="<%= ngcTokenArn %>"
 <% } else if (ngcApiKey) { %>
 export NGC_API_KEY="<%= ngcApiKey %>"
 <% } %>
+
+<% if (deploymentTarget !== 'batch-transform') { %>
+# Managed Model Customization (do/tune)
+export TUNE_SUPPORTED=<%= (typeof tuneSupported !== 'undefined' && tuneSupported) ? 'true' : 'false' %>
+export TUNE_S3_BUCKET="mlcc-tune-$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo 'UNKNOWN')-${AWS_REGION}"
+<% } %>
 <% } %>
 
 <% if (framework === 'diffusors') { %>

--- a/templates/do/tune
+++ b/templates/do/tune
@@ -1,0 +1,1143 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# do/tune — SageMaker AI Managed Model Customization
+# Wraps SageMaker managed fine-tuning for supported foundation models.
+# Supports SFT, DPO, RLAIF, and RLVR techniques.
+
+set -e
+set -u
+set -o pipefail
+
+# ── Source project configuration ──────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config"
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+CATALOG_FILE="${SCRIPT_DIR}/.tune_catalog.json"
+HELPER_SCRIPT="${SCRIPT_DIR}/.tune_helper.py"
+POLL_INTERVAL=60
+
+# ── CLI Variables (set by _parse_args) ────────────────────────────────────────
+ARG_TECHNIQUE=""
+ARG_DATASET=""
+ARG_TRAINING_TYPE="lora"
+ARG_MODEL=""
+ARG_EPOCHS=""
+ARG_LEARNING_RATE=""
+ARG_MAX_SEQ_LENGTH=""
+ARG_LORA_RANK=""
+ARG_LORA_ALPHA=""
+ARG_BATCH_SIZE=""
+ARG_REWARD_FUNCTION=""
+ARG_REWARD_PROMPT=""
+ARG_OUTPUT_BUCKET=""
+ARG_ROLE=""
+ARG_FORCE=false
+ARG_NO_WAIT=false
+ARG_STATUS=false
+ARG_HELP=false
+ARG_DRY_RUN=false
+ARG_LIST_MODELS=false
+
+
+# ── _parse_args() ─────────────────────────────────────────────────────────────
+# Parse all CLI flags into variables.
+_parse_args() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --technique)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --technique requires a value (sft, dpo, rlaif, rlvr)"
+                    exit 1
+                fi
+                ARG_TECHNIQUE="$2"; shift 2 ;;
+            --dataset)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --dataset requires a value (s3://... or hf://...)"
+                    exit 1
+                fi
+                ARG_DATASET="$2"; shift 2 ;;
+            --training-type)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --training-type requires a value (lora, full-rank)"
+                    exit 1
+                fi
+                ARG_TRAINING_TYPE="$2"; shift 2 ;;
+            --model)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --model requires a JumpStart model ID"
+                    exit 1
+                fi
+                ARG_MODEL="$2"; shift 2 ;;
+            --epochs)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --epochs requires an integer value"
+                    exit 1
+                fi
+                ARG_EPOCHS="$2"; shift 2 ;;
+            --learning-rate)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --learning-rate requires a float value"
+                    exit 1
+                fi
+                ARG_LEARNING_RATE="$2"; shift 2 ;;
+            --max-seq-length)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --max-seq-length requires an integer value"
+                    exit 1
+                fi
+                ARG_MAX_SEQ_LENGTH="$2"; shift 2 ;;
+            --lora-rank)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --lora-rank requires an integer value"
+                    exit 1
+                fi
+                ARG_LORA_RANK="$2"; shift 2 ;;
+            --lora-alpha)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --lora-alpha requires an integer value"
+                    exit 1
+                fi
+                ARG_LORA_ALPHA="$2"; shift 2 ;;
+            --batch-size)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --batch-size requires an integer value"
+                    exit 1
+                fi
+                ARG_BATCH_SIZE="$2"; shift 2 ;;
+            --reward-function)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --reward-function requires a Lambda ARN"
+                    exit 1
+                fi
+                ARG_REWARD_FUNCTION="$2"; shift 2 ;;
+            --reward-prompt)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --reward-prompt requires an S3 URI"
+                    exit 1
+                fi
+                ARG_REWARD_PROMPT="$2"; shift 2 ;;
+            --output-bucket)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --output-bucket requires a bucket name"
+                    exit 1
+                fi
+                ARG_OUTPUT_BUCKET="$2"; shift 2 ;;
+            --role)
+                if [ -z "${2:-}" ]; then
+                    echo "❌ --role requires an IAM role ARN"
+                    exit 1
+                fi
+                ARG_ROLE="$2"; shift 2 ;;
+            --force) ARG_FORCE=true; shift ;;
+            --no-wait) ARG_NO_WAIT=true; shift ;;
+            --status) ARG_STATUS=true; shift ;;
+            --help|-h) ARG_HELP=true; shift ;;
+            --dry-run) ARG_DRY_RUN=true; shift ;;
+            --list-models) ARG_LIST_MODELS=true; shift ;;
+            *)
+                echo "❌ Unknown option: $1"
+                echo "   Run ./do/tune --help for usage."
+                exit 1
+                ;;
+        esac
+    done
+}
+
+
+# ── _show_help() ──────────────────────────────────────────────────────────────
+_show_help() {
+    echo "Usage: ./do/tune --technique <technique> --dataset <source> [options]"
+    echo "       ./do/tune --status"
+    echo "       ./do/tune --list-models"
+    echo "       ./do/tune --help"
+    echo ""
+    echo "SageMaker AI Managed Model Customization — fine-tune supported foundation"
+    echo "models using SFT, DPO, RLAIF, or RLVR without managing infrastructure."
+    echo ""
+    echo "Required:"
+    echo "  --technique <t>       Customization technique: sft, dpo, rlaif, rlvr"
+    echo "  --dataset <source>    Dataset: s3://bucket/path.jsonl or hf://org/name[/split]"
+    echo ""
+    echo "Training type:"
+    echo "  --training-type <t>   lora (default) or full-rank"
+    echo ""
+    echo "Hyperparameter overrides (optional):"
+    echo "  --epochs <n>          Number of training epochs"
+    echo "  --learning-rate <f>   Learning rate (e.g., 2e-4)"
+    echo "  --max-seq-length <n>  Maximum sequence length in tokens"
+    echo "  --lora-rank <n>       LoRA rank (e.g., 16, 32, 64)"
+    echo "  --lora-alpha <n>      LoRA alpha scaling factor"
+    echo "  --batch-size <n>      Global batch size"
+    echo ""
+    echo "Evaluator (RLVR/RLAIF only):"
+    echo "  --reward-function <arn>  Lambda ARN for reward function"
+    echo "  --reward-prompt <uri>    S3 URI for reward prompt file"
+    echo ""
+    echo "Overrides:"
+    echo "  --model <id>          Override model (defaults to MODEL_ID from do/config)"
+    echo "  --output-bucket <b>   Override output bucket (defaults to TUNE_S3_BUCKET)"
+    echo "  --role <arn>          Override execution role (defaults to ROLE_ARN)"
+    echo ""
+    echo "Job control:"
+    echo "  --force               Force new job even if one exists for this technique"
+    echo "  --no-wait             Submit and exit without polling for completion"
+    echo "  --status              Show status of all tracked tune jobs"
+    echo ""
+    echo "Informational:"
+    echo "  --help, -h            Show this help message"
+    echo "  --dry-run             Validate inputs and show what would be submitted"
+    echo "  --list-models         Print supported models, techniques, and training types"
+    echo ""
+    echo "Examples:"
+    echo "  ./do/tune --technique sft --dataset s3://my-bucket/train.jsonl"
+    echo "  ./do/tune --technique dpo --dataset hf://my-org/pref-data --learning-rate 1e-5"
+    echo "  ./do/tune --technique sft --dataset s3://bucket/data.jsonl --training-type full-rank"
+    echo "  ./do/tune --status"
+    echo "  ./do/tune --technique sft --dataset s3://bucket/data.jsonl --dry-run"
+    exit 0
+}
+
+# ── _show_status() ────────────────────────────────────────────────────────────
+# Display status of all tracked tune jobs from do/config.
+_show_status() {
+    echo "📊 Tune Job Status"
+    echo ""
+
+    local found_any=false
+    for technique in sft dpo rlaif rlvr; do
+        local var_name="TUNE_JOB_NAME_$(echo "${technique}" | tr '[:lower:]' '[:upper:]')"
+        local job_name="${!var_name:-}"
+
+        if [ -n "${job_name}" ]; then
+            found_any=true
+            echo "   ${technique^^}:"
+            echo "     Job: ${job_name}"
+
+            # Query status via Python helper
+            local status_json
+            status_json=$(python3 "${HELPER_SCRIPT}" status \
+                --job-name "${job_name}" \
+                --region "${AWS_REGION}" 2>/dev/null) || status_json='{"status":"Unknown","error":"Failed to query"}'
+
+            local status
+            status=$(echo "${status_json}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status','Unknown'))" 2>/dev/null) || status="Unknown"
+
+            local elapsed
+            elapsed=$(echo "${status_json}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('elapsed_seconds',0))" 2>/dev/null) || elapsed="0"
+
+            echo "     Status: ${status}"
+            if [ "${elapsed}" != "0" ]; then
+                local mins=$((elapsed / 60))
+                local secs=$((elapsed % 60))
+                echo "     Elapsed: ${mins}m ${secs}s"
+            fi
+
+            # Show output path if completed
+            local output_var="TUNE_ADAPTER_PATH_$(echo "${technique}" | tr '[:lower:]' '[:upper:]')"
+            local model_var="TUNE_MODEL_PATH_$(echo "${technique}" | tr '[:lower:]' '[:upper:]')"
+            if [ -n "${!output_var:-}" ]; then
+                echo "     Output (adapter): ${!output_var}"
+            elif [ -n "${!model_var:-}" ]; then
+                echo "     Output (model): ${!model_var}"
+            fi
+            echo ""
+        fi
+    done
+
+    if [ "${found_any}" = false ]; then
+        echo "   No tune jobs tracked. Run ./do/tune --technique <t> --dataset <d> to start."
+    fi
+
+    exit 0
+}
+
+# ── _list_models() ────────────────────────────────────────────────────────────
+# Print the Supported Model Catalog.
+_list_models() {
+    if [ ! -f "${CATALOG_FILE}" ]; then
+        echo "❌ Catalog file not found: ${CATALOG_FILE}"
+        exit 1
+    fi
+
+    echo "📋 Supported Models for Managed Customization"
+    echo ""
+
+    python3 -c "
+import json, sys
+
+with open('${CATALOG_FILE}') as f:
+    catalog = json.load(f)
+
+models = catalog.get('models', {})
+# Group by family
+families = {}
+for model_id, entry in models.items():
+    family = entry.get('family', 'unknown')
+    if family not in families:
+        families[family] = []
+    families[family].append(entry)
+
+for family in sorted(families.keys()):
+    entries = families[family]
+    provider = entries[0].get('provider', '')
+    print(f'  {family} ({provider}):')
+    for entry in entries:
+        techniques = list(entry.get('techniques', {}).keys())
+        print(f'    • {entry[\"displayName\"]}')
+        print(f'      ID: {entry[\"jumpStartModelId\"]}')
+        for t in techniques:
+            tc = entry['techniques'][t]
+            types = ', '.join(tc.get('trainingTypes', []))
+            print(f'      {t}: [{types}]')
+    print()
+" 2>/dev/null || {
+        echo "❌ Failed to parse catalog. Ensure python3 is available."
+        exit 1
+    }
+
+    exit 0
+}
+
+
+# ── _update_config_var() ──────────────────────────────────────────────────────
+# Write or update a variable in do/config.
+# Usage: _update_config_var VAR_NAME "value"
+_update_config_var() {
+    local var_name="$1"
+    local var_value="$2"
+    local config_file="${SCRIPT_DIR}/config"
+
+    if grep -q "^export ${var_name}=" "${config_file}" 2>/dev/null; then
+        sed -i.bak "s|^export ${var_name}=.*|export ${var_name}=\"${var_value}\"|" "${config_file}"
+        rm -f "${config_file}.bak"
+    else
+        echo "export ${var_name}=\"${var_value}\"" >> "${config_file}"
+    fi
+}
+
+# ── _validate_model() ─────────────────────────────────────────────────────────
+# Read MODEL_ID from do/config (or --model override), check against catalog.
+# Sets RESOLVED_MODEL_ID on success.
+_validate_model() {
+    # Resolve model ID: --model override, MODEL_ID from config, or MODEL_NAME fallback
+    if [ -n "${ARG_MODEL}" ]; then
+        RESOLVED_MODEL_ID="${ARG_MODEL}"
+    elif [ -n "${MODEL_ID:-}" ]; then
+        RESOLVED_MODEL_ID="${MODEL_ID}"
+    elif [ -n "${MODEL_NAME:-}" ]; then
+        RESOLVED_MODEL_ID="${MODEL_NAME}"
+    else
+        echo "❌ No model configured"
+        echo "   Set MODEL_ID in do/config or use --model <id>"
+        exit 1
+    fi
+
+    if [ ! -f "${CATALOG_FILE}" ]; then
+        echo "❌ Catalog file not found: ${CATALOG_FILE}"
+        echo "   The tune catalog is required for model validation."
+        exit 1
+    fi
+
+    # Check if model is in catalog using python3 for JSON parsing
+    local result
+    result=$(python3 -c "
+import json, sys
+
+with open('${CATALOG_FILE}') as f:
+    catalog = json.load(f)
+
+model_id = '${RESOLVED_MODEL_ID}'
+models = catalog.get('models', {})
+
+if model_id in models:
+    print('SUPPORTED')
+else:
+    # Collect unique families
+    families = sorted(set(e.get('family', '') for e in models.values() if e.get('family')))
+    print('UNSUPPORTED|' + '|'.join(families))
+" 2>/dev/null) || {
+        echo "❌ Failed to validate model against catalog"
+        echo "   Ensure python3 is available."
+        exit 1
+    }
+
+    if [ "${result}" = "SUPPORTED" ]; then
+        return 0
+    fi
+
+    # Model not supported — extract families from result
+    local families
+    families=$(echo "${result}" | cut -d'|' -f2- | tr '|' ', ')
+
+    echo "❌ Model \"${RESOLVED_MODEL_ID}\" is not yet supported for managed serverless customization."
+    echo "   Supported model families: ${families}"
+    echo ""
+    echo "   Additional model support and custom training workflows are expected in future releases."
+    echo "   For custom training workflows, see \`do/train\`."
+    exit 1
+}
+
+# ── _validate_technique() ─────────────────────────────────────────────────────
+# Check that the technique is supported for the resolved model.
+_validate_technique() {
+    local technique="${ARG_TECHNIQUE}"
+
+    # Validate technique value
+    case "${technique}" in
+        sft|dpo|rlaif|rlvr) ;;
+        *)
+            echo "❌ Invalid technique: ${technique}"
+            echo "   Valid techniques: sft, dpo, rlaif, rlvr"
+            exit 1
+            ;;
+    esac
+
+    # Check catalog for model+technique support
+    local result
+    result=$(python3 -c "
+import json, sys
+
+with open('${CATALOG_FILE}') as f:
+    catalog = json.load(f)
+
+model_id = '${RESOLVED_MODEL_ID}'
+technique = '${technique}'
+entry = catalog['models'][model_id]
+techniques = entry.get('techniques', {})
+
+if technique in techniques:
+    print('SUPPORTED')
+else:
+    supported = list(techniques.keys())
+    print('UNSUPPORTED|' + '|'.join(supported))
+" 2>/dev/null) || {
+        echo "❌ Failed to validate technique against catalog"
+        exit 1
+    }
+
+    if [ "${result}" = "SUPPORTED" ]; then
+        return 0
+    fi
+
+    local supported
+    supported=$(echo "${result}" | cut -d'|' -f2- | tr '|' ', ')
+
+    echo "❌ Technique \"${technique}\" is not supported for model \"${RESOLVED_MODEL_ID}\"."
+    echo "   Supported techniques: ${supported}"
+    exit 1
+}
+
+# ── _validate_training_type() ─────────────────────────────────────────────────
+# Check that the training type is supported for the model+technique.
+_validate_training_type() {
+    local technique="${ARG_TECHNIQUE}"
+    local training_type="${ARG_TRAINING_TYPE}"
+
+    # Validate training type value
+    case "${training_type}" in
+        lora|full-rank) ;;
+        *)
+            echo "❌ Invalid training type: ${training_type}"
+            echo "   Valid training types: lora, full-rank"
+            exit 1
+            ;;
+    esac
+
+    # Check catalog for model+technique+training_type support
+    local result
+    result=$(python3 -c "
+import json, sys
+
+with open('${CATALOG_FILE}') as f:
+    catalog = json.load(f)
+
+model_id = '${RESOLVED_MODEL_ID}'
+technique = '${technique}'
+training_type = '${training_type}'
+entry = catalog['models'][model_id]
+technique_entry = entry['techniques'][technique]
+training_types = technique_entry.get('trainingTypes', [])
+
+if training_type in training_types:
+    print('SUPPORTED')
+else:
+    print('UNSUPPORTED|' + '|'.join(training_types))
+" 2>/dev/null) || {
+        echo "❌ Failed to validate training type against catalog"
+        exit 1
+    }
+
+    if [ "${result}" = "SUPPORTED" ]; then
+        return 0
+    fi
+
+    local supported
+    supported=$(echo "${result}" | cut -d'|' -f2- | tr '|' ', ')
+
+    echo "❌ Training type \"${training_type}\" is not supported for model \"${RESOLVED_MODEL_ID}\" with technique \"${technique}\"."
+    echo "   Supported training types: ${supported}"
+    exit 1
+}
+
+
+# ── _validate_dataset() ───────────────────────────────────────────────────────
+# Check S3 existence or delegate HF staging to Python helper.
+# Sets RESOLVED_DATASET_S3_URI on success.
+_validate_dataset() {
+    local dataset="${ARG_DATASET}"
+
+    if [ -z "${dataset}" ]; then
+        echo "❌ --dataset is required"
+        echo "   Provide an S3 URI (s3://bucket/path.jsonl) or HF reference (hf://org/name)"
+        exit 1
+    fi
+
+    # Determine dataset type
+    if [[ "${dataset}" == s3://* ]]; then
+        # S3 dataset — verify existence
+        if ! aws s3 ls "${dataset}" --region "${AWS_REGION}" >/dev/null 2>&1; then
+            echo "❌ Dataset not found or not accessible: ${dataset}"
+            echo "   Verify the S3 URI is correct and you have read permissions."
+            echo "   Check: aws s3 ls ${dataset} --region ${AWS_REGION}"
+            exit 1
+        fi
+        RESOLVED_DATASET_S3_URI="${dataset}"
+
+        # Validate format by downloading first 10 lines
+        local schema_json
+        schema_json=$(_get_dataset_schema)
+
+        local sample_data
+        sample_data=$(aws s3 cp "${dataset}" - --region "${AWS_REGION}" 2>/dev/null | head -10)
+
+        if [ -n "${sample_data}" ]; then
+            local validate_result
+            validate_result=$(echo "${sample_data}" | python3 "${HELPER_SCRIPT}" validate \
+                --schema "${schema_json}" 2>/dev/null) || validate_result='{"valid":false,"error":"Validation failed"}'
+
+            local is_valid
+            is_valid=$(echo "${validate_result}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('valid', False))" 2>/dev/null) || is_valid="False"
+
+            if [ "${is_valid}" != "True" ]; then
+                local error_msg
+                error_msg=$(echo "${validate_result}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('error','Unknown format error'))" 2>/dev/null) || error_msg="Unknown format error"
+                local malformed_line
+                malformed_line=$(echo "${validate_result}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('malformed_line','') or '')" 2>/dev/null) || malformed_line=""
+                local expected_format
+                expected_format=$(echo "${validate_result}" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('expected_format','') or '')" 2>/dev/null) || expected_format=""
+
+                echo "❌ Dataset format validation failed"
+                echo "   ${error_msg}"
+                if [ -n "${malformed_line}" ]; then
+                    echo ""
+                    echo "   Malformed line: ${malformed_line}"
+                fi
+                if [ -n "${expected_format}" ]; then
+                    echo ""
+                    echo "   ${expected_format}"
+                fi
+                exit 1
+            fi
+        fi
+
+    elif [[ "${dataset}" == hf://* ]]; then
+        # Hugging Face dataset — parse reference and stage to S3
+        local hf_path="${dataset#hf://}"
+        local hf_org hf_name hf_split
+
+        # Parse org/name/split
+        hf_org=$(echo "${hf_path}" | cut -d'/' -f1)
+        hf_name=$(echo "${hf_path}" | cut -d'/' -f2)
+        hf_split=$(echo "${hf_path}" | cut -d'/' -f3-)
+
+        if [ -z "${hf_org}" ] || [ -z "${hf_name}" ]; then
+            echo "❌ Invalid HF dataset reference: ${dataset}"
+            echo "   Expected format: hf://org/name or hf://org/name/split"
+            exit 1
+        fi
+
+        local output_bucket
+        output_bucket=$(_resolve_output_bucket)
+
+        echo "📦 Staging Hugging Face dataset: ${hf_org}/${hf_name}"
+        if [ -n "${hf_split}" ]; then
+            echo "   Split: ${hf_split}"
+        else
+            echo "   Split: train (default)"
+        fi
+
+        # Build stage-hf arguments
+        local stage_args=(
+            --hf-org "${hf_org}"
+            --hf-name "${hf_name}"
+            --output-bucket "${output_bucket}"
+            --project-name "${PROJECT_NAME}"
+            --region "${AWS_REGION}"
+        )
+        if [ -n "${hf_split}" ]; then
+            stage_args+=(--hf-split "${hf_split}")
+        fi
+        if [ -n "${HF_TOKEN_ARN:-}" ]; then
+            stage_args+=(--hf-secret-name "${HF_TOKEN_ARN}")
+        fi
+
+        local stage_result
+        stage_result=$(python3 "${HELPER_SCRIPT}" stage-hf "${stage_args[@]}" 2>/dev/null) || {
+            local error_msg
+            error_msg=$(echo "${stage_result}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error','Failed to stage dataset'))" 2>/dev/null) || error_msg="Failed to stage HF dataset"
+            echo "❌ ${error_msg}"
+            exit 1
+        }
+
+        # Check for error in response
+        local has_error
+        has_error=$(echo "${stage_result}" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if 'error' in d else 'no')" 2>/dev/null) || has_error="yes"
+
+        if [ "${has_error}" = "yes" ]; then
+            local error_msg
+            error_msg=$(echo "${stage_result}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error','Unknown error'))" 2>/dev/null) || error_msg="Unknown error"
+            echo "❌ ${error_msg}"
+            exit 1
+        fi
+
+        RESOLVED_DATASET_S3_URI=$(echo "${stage_result}" | python3 -c "import sys,json; print(json.load(sys.stdin)['s3_uri'])" 2>/dev/null)
+        local num_records
+        num_records=$(echo "${stage_result}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('num_records',0))" 2>/dev/null) || num_records="0"
+
+        echo "   ✅ Staged to: ${RESOLVED_DATASET_S3_URI}"
+        echo "   Records: ${num_records}"
+        echo ""
+
+    else
+        echo "❌ Invalid dataset format: ${dataset}"
+        echo "   Expected: s3://bucket/path.jsonl or hf://org/name[/split]"
+        exit 1
+    fi
+}
+
+# ── _get_dataset_schema() ─────────────────────────────────────────────────────
+# Get the dataset schema JSON for the current model+technique from the catalog.
+_get_dataset_schema() {
+    python3 -c "
+import json, sys
+
+with open('${CATALOG_FILE}') as f:
+    catalog = json.load(f)
+
+model_id = '${RESOLVED_MODEL_ID}'
+technique = '${ARG_TECHNIQUE}'
+entry = catalog['models'][model_id]
+schema = entry['techniques'][technique].get('datasetSchema', {})
+print(json.dumps(schema))
+" 2>/dev/null
+}
+
+# ── _resolve_output_bucket() ──────────────────────────────────────────────────
+# Resolve the S3 output bucket from --output-bucket, TUNE_S3_BUCKET, or fallback.
+_resolve_output_bucket() {
+    if [ -n "${ARG_OUTPUT_BUCKET}" ]; then
+        echo "${ARG_OUTPUT_BUCKET}"
+    elif [ -n "${TUNE_S3_BUCKET:-}" ]; then
+        echo "${TUNE_S3_BUCKET}"
+    elif [ -n "${ADAPTER_S3_BUCKET:-}" ]; then
+        echo "${ADAPTER_S3_BUCKET}"
+    else
+        echo "mlcc-tune-$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo 'UNKNOWN')-${AWS_REGION}"
+    fi
+}
+
+
+# ── _check_idempotency() ──────────────────────────────────────────────────────
+# Check TUNE_JOB_NAME_<TECHNIQUE> in config, query status if exists.
+# Returns 0 if a new job should be created, 1 if existing job was handled.
+_check_idempotency() {
+    local technique_upper
+    technique_upper=$(echo "${ARG_TECHNIQUE}" | tr '[:lower:]' '[:upper:]')
+    local var_name="TUNE_JOB_NAME_${technique_upper}"
+    local existing_job="${!var_name:-}"
+
+    if [ -z "${existing_job}" ] || [ "${ARG_FORCE}" = true ]; then
+        return 0  # No existing job or --force: proceed with new job
+    fi
+
+    echo "🔍 Found existing ${ARG_TECHNIQUE^^} job: ${existing_job}"
+
+    # Query status via Python helper
+    local status_json
+    status_json=$(python3 "${HELPER_SCRIPT}" status \
+        --job-name "${existing_job}" \
+        --region "${AWS_REGION}" 2>/dev/null) || {
+        echo "   ⚠️  Could not query job status — proceeding with new job"
+        return 0
+    }
+
+    # Check for error response
+    local has_error
+    has_error=$(echo "${status_json}" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if 'error' in d else 'no')" 2>/dev/null) || has_error="no"
+
+    if [ "${has_error}" = "yes" ]; then
+        echo "   ⚠️  Could not query job status — proceeding with new job"
+        return 0
+    fi
+
+    local status
+    status=$(echo "${status_json}" | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])" 2>/dev/null) || status="Unknown"
+
+    case "${status}" in
+        InProgress|Starting)
+            echo "   Status: ${status}"
+            echo "   (use --force to start a new job instead)"
+            echo ""
+            # Resume polling
+            _poll_job "${existing_job}"
+            _handle_completion "${existing_job}"
+            return 1
+            ;;
+        Completed)
+            echo "   Status: Completed"
+            echo "   (use --force to start a new job)"
+            echo ""
+            _handle_completion "${existing_job}"
+            return 1
+            ;;
+        Failed)
+            local failure_reason
+            failure_reason=$(echo "${status_json}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('failure_reason','') or 'Unknown')" 2>/dev/null) || failure_reason="Unknown"
+            echo "   Status: Failed"
+            echo "   Reason: ${failure_reason}"
+            echo ""
+            echo "   Re-run with --force to start a new job."
+            exit 2
+            ;;
+        Stopped)
+            echo "   Status: Stopped"
+            echo "   Re-run with --force to start a new job."
+            exit 2
+            ;;
+        *)
+            echo "   Status: ${status}"
+            echo "   Proceeding with new job..."
+            return 0
+            ;;
+    esac
+}
+
+# ── _submit_job() ─────────────────────────────────────────────────────────────
+# Invoke Python helper with all args to submit the customization job.
+# Sets JOB_NAME on success.
+_submit_job() {
+    local output_bucket
+    output_bucket=$(_resolve_output_bucket)
+
+    local role_arn
+    if [ -n "${ARG_ROLE}" ]; then
+        role_arn="${ARG_ROLE}"
+    elif [ -n "${ROLE_ARN:-}" ]; then
+        role_arn="${ROLE_ARN}"
+    else
+        # Try to resolve from SageMaker execution role
+        role_arn="${SAGEMAKER_ROLE_ARN:-}"
+        if [ -z "${role_arn}" ]; then
+            echo "❌ No execution role configured"
+            echo "   Set ROLE_ARN in do/config or use --role <arn>"
+            exit 1
+        fi
+    fi
+
+    # Generate unique job name
+    local timestamp
+    timestamp=$(date +%Y%m%d-%H%M%S)
+    JOB_NAME="${PROJECT_NAME}-tune-${ARG_TECHNIQUE}-${timestamp}"
+
+    echo "🚀 Submitting ${ARG_TECHNIQUE^^} customization job"
+    echo "   Job name: ${JOB_NAME}"
+    echo "   Model: ${RESOLVED_MODEL_ID}"
+    echo "   Technique: ${ARG_TECHNIQUE}"
+    echo "   Training type: ${ARG_TRAINING_TYPE}"
+    echo "   Dataset: ${RESOLVED_DATASET_S3_URI}"
+    echo "   Output bucket: ${output_bucket}"
+    echo ""
+
+    # Build submit arguments
+    local submit_args=(
+        --model-id "${RESOLVED_MODEL_ID}"
+        --technique "${ARG_TECHNIQUE}"
+        --training-type "${ARG_TRAINING_TYPE}"
+        --dataset-s3-uri "${RESOLVED_DATASET_S3_URI}"
+        --output-bucket "${output_bucket}"
+        --role-arn "${role_arn}"
+        --job-name "${JOB_NAME}"
+        --project-name "${PROJECT_NAME}"
+    )
+
+    # Add model package group
+    submit_args+=(--model-package-group "${PROJECT_NAME}-tune-models")
+
+    # Add optional hyperparameters
+    if [ -n "${ARG_EPOCHS}" ]; then
+        submit_args+=(--epochs "${ARG_EPOCHS}")
+    fi
+    if [ -n "${ARG_LEARNING_RATE}" ]; then
+        submit_args+=(--learning-rate "${ARG_LEARNING_RATE}")
+    fi
+    if [ -n "${ARG_MAX_SEQ_LENGTH}" ]; then
+        submit_args+=(--max-seq-length "${ARG_MAX_SEQ_LENGTH}")
+    fi
+    if [ -n "${ARG_LORA_RANK}" ]; then
+        submit_args+=(--lora-rank "${ARG_LORA_RANK}")
+    fi
+    if [ -n "${ARG_LORA_ALPHA}" ]; then
+        submit_args+=(--lora-alpha "${ARG_LORA_ALPHA}")
+    fi
+    if [ -n "${ARG_BATCH_SIZE}" ]; then
+        submit_args+=(--batch-size "${ARG_BATCH_SIZE}")
+    fi
+    if [ -n "${ARG_REWARD_FUNCTION}" ]; then
+        submit_args+=(--reward-function "${ARG_REWARD_FUNCTION}")
+    fi
+    if [ -n "${ARG_REWARD_PROMPT}" ]; then
+        submit_args+=(--reward-prompt "${ARG_REWARD_PROMPT}")
+    fi
+
+    # Invoke Python helper
+    local submit_result
+    submit_result=$(python3 "${HELPER_SCRIPT}" submit "${submit_args[@]}" 2>/dev/null) || {
+        echo "❌ Failed to submit customization job"
+        echo "   Ensure the SageMaker Python SDK is installed: pip install 'sagemaker>=2.232.0'"
+        exit 1
+    }
+
+    # Check for error in response
+    local has_error
+    has_error=$(echo "${submit_result}" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if 'error' in d else 'no')" 2>/dev/null) || has_error="yes"
+
+    if [ "${has_error}" = "yes" ]; then
+        local error_msg
+        error_msg=$(echo "${submit_result}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error','Unknown error'))" 2>/dev/null) || error_msg="Unknown error"
+        echo "❌ ${error_msg}"
+        exit 1
+    fi
+
+    # Extract job name from response (may differ from our generated name)
+    local returned_job_name
+    returned_job_name=$(echo "${submit_result}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('job_name',''))" 2>/dev/null) || returned_job_name=""
+    if [ -n "${returned_job_name}" ]; then
+        JOB_NAME="${returned_job_name}"
+    fi
+
+    # Display MLflow URL if available
+    local mlflow_url
+    mlflow_url=$(echo "${submit_result}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('mlflow_url','') or '')" 2>/dev/null) || mlflow_url=""
+    if [ -n "${mlflow_url}" ]; then
+        echo "   📈 MLflow tracking: ${mlflow_url}"
+    fi
+
+    echo "✅ Job submitted: ${JOB_NAME}"
+    echo ""
+
+    # Store state in do/config
+    local technique_upper
+    technique_upper=$(echo "${ARG_TECHNIQUE}" | tr '[:lower:]' '[:upper:]')
+    _update_config_var "TUNE_JOB_NAME_${technique_upper}" "${JOB_NAME}"
+    _update_config_var "TUNE_TECHNIQUE" "${ARG_TECHNIQUE}"
+    _update_config_var "TUNE_TRAINING_TYPE" "${ARG_TRAINING_TYPE}"
+    _update_config_var "TUNE_DATASET_PATH" "${ARG_DATASET}"
+}
+
+
+# ── _poll_job() ───────────────────────────────────────────────────────────────
+# Poll every 60s, display status/elapsed/step, handle Ctrl+C gracefully.
+# Exits cleanly on interrupt without stopping the remote job.
+_poll_job() {
+    local job_name="${1:-${JOB_NAME}}"
+
+    echo "⏳ Polling job status every ${POLL_INTERVAL}s..."
+    echo "   (Ctrl+C to exit — job continues in background)"
+    echo ""
+
+    # Trap SIGINT for graceful exit
+    trap '_handle_interrupt "${job_name}"' INT
+
+    while true; do
+        local status_json
+        status_json=$(python3 "${HELPER_SCRIPT}" status \
+            --job-name "${job_name}" \
+            --region "${AWS_REGION}" 2>/dev/null) || {
+            echo "   ⚠️  Failed to query status (will retry)"
+            sleep "${POLL_INTERVAL}"
+            continue
+        }
+
+        local status
+        status=$(echo "${status_json}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status','Unknown'))" 2>/dev/null) || status="Unknown"
+
+        local elapsed
+        elapsed=$(echo "${status_json}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('elapsed_seconds',0))" 2>/dev/null) || elapsed="0"
+
+        local mins=$((elapsed / 60))
+        local secs=$((elapsed % 60))
+
+        case "${status}" in
+            Completed)
+                echo "   ✅ $(date +%H:%M:%S) Status: Completed (${mins}m ${secs}s)"
+                # Restore default signal handling
+                trap - INT
+                return 0
+                ;;
+            Failed)
+                local failure_reason
+                failure_reason=$(echo "${status_json}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('failure_reason','') or 'Unknown')" 2>/dev/null) || failure_reason="Unknown"
+                echo "   ❌ $(date +%H:%M:%S) Status: Failed (${mins}m ${secs}s)"
+                echo "      Reason: ${failure_reason}"
+                trap - INT
+                exit 2
+                ;;
+            Stopped)
+                echo "   ⚠️  $(date +%H:%M:%S) Status: Stopped (${mins}m ${secs}s)"
+                trap - INT
+                exit 2
+                ;;
+            *)
+                echo "   $(date +%H:%M:%S) Status: ${status} (${mins}m ${secs}s)"
+                sleep "${POLL_INTERVAL}"
+                ;;
+        esac
+    done
+}
+
+# ── _handle_interrupt() ───────────────────────────────────────────────────────
+# Handle Ctrl+C during polling — exit cleanly without stopping the remote job.
+_handle_interrupt() {
+    local job_name="${1:-}"
+    echo ""
+    echo ""
+    echo "⚠️  Interrupted — job continues running in background"
+    echo "   Job: ${job_name}"
+    echo ""
+    echo "   Resume monitoring: ./do/tune --technique ${ARG_TECHNIQUE} --dataset ${ARG_DATASET}"
+    echo "   Check status:      ./do/tune --status"
+    exit 130
+}
+
+# ── _handle_completion() ──────────────────────────────────────────────────────
+# Store output paths, detect output type, print next-step commands.
+_handle_completion() {
+    local job_name="${1:-${JOB_NAME}}"
+    local technique_upper
+    technique_upper=$(echo "${ARG_TECHNIQUE}" | tr '[:lower:]' '[:upper:]')
+
+    # Resolve artifact path via Python helper
+    local resolve_args=(
+        --job-name "${job_name}"
+        --region "${AWS_REGION}"
+        --training-type "${ARG_TRAINING_TYPE}"
+    )
+    resolve_args+=(--model-package-group "${PROJECT_NAME}-tune-models")
+
+    local resolve_result
+    resolve_result=$(python3 "${HELPER_SCRIPT}" resolve "${resolve_args[@]}" 2>/dev/null) || {
+        echo "⚠️  Could not resolve output artifacts"
+        echo "   Check job output manually:"
+        echo "   python3 ${HELPER_SCRIPT} resolve --job-name ${job_name} --region ${AWS_REGION} --training-type ${ARG_TRAINING_TYPE}"
+        return 0
+    }
+
+    # Check for error
+    local has_error
+    has_error=$(echo "${resolve_result}" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if 'error' in d else 'no')" 2>/dev/null) || has_error="yes"
+
+    if [ "${has_error}" = "yes" ]; then
+        local error_msg
+        error_msg=$(echo "${resolve_result}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error',''))" 2>/dev/null) || error_msg=""
+        if [ -n "${error_msg}" ]; then
+            echo "   ⚠️  ${error_msg}"
+        fi
+        return 0
+    fi
+
+    # Extract results
+    local artifact_path
+    artifact_path=$(echo "${resolve_result}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('artifact_path',''))" 2>/dev/null) || artifact_path=""
+
+    local output_type
+    output_type=$(echo "${resolve_result}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('output_type',''))" 2>/dev/null) || output_type=""
+
+    local model_package_arn
+    model_package_arn=$(echo "${resolve_result}" | python3 -c "import sys,json; print(json.load(sys.stdin).get('model_package_arn','') or '')" 2>/dev/null) || model_package_arn=""
+
+    # Display results
+    echo "🎉 Customization complete!"
+    echo ""
+    echo "   Output type: ${output_type}"
+    echo "   Artifact: ${artifact_path}"
+    if [ -n "${model_package_arn}" ]; then
+        echo "   Model Package: ${model_package_arn}"
+    fi
+    echo ""
+
+    # Store output paths in config
+    if [ "${output_type}" = "adapter" ]; then
+        _update_config_var "TUNE_ADAPTER_PATH_${technique_upper}" "${artifact_path}"
+    else
+        _update_config_var "TUNE_MODEL_PATH_${technique_upper}" "${artifact_path}"
+    fi
+    _update_config_var "TUNE_OUTPUT_PATH_LATEST" "${artifact_path}"
+    _update_config_var "TUNE_OUTPUT_TYPE_LATEST" "${output_type}"
+
+    # Print next-step commands
+    echo "📋 Next steps:"
+    echo ""
+    if [ "${output_type}" = "adapter" ]; then
+        echo "   Deploy as LoRA adapter:"
+        echo "     ./do/adapter add tuned-${ARG_TECHNIQUE} --from-tune"
+        echo "     ./do/adapter add tuned-${ARG_TECHNIQUE} --from-tune ${ARG_TECHNIQUE}"
+        echo "     ./do/adapter add tuned-${ARG_TECHNIQUE} --weights ${artifact_path}"
+    else
+        echo "   Deploy as new inference component:"
+        echo "     ./do/add-ic tuned-v1 --from-tune"
+        echo "     ./do/add-ic tuned-v1 --model-data ${artifact_path}"
+        echo "     ./do/deploy --force-ic --model-data ${artifact_path}"
+    fi
+    echo ""
+}
+
+
+# ── _dry_run() ────────────────────────────────────────────────────────────────
+# Validate all inputs and show what would be submitted without creating a job.
+_dry_run() {
+    local output_bucket
+    output_bucket=$(_resolve_output_bucket)
+
+    local role_arn
+    if [ -n "${ARG_ROLE}" ]; then
+        role_arn="${ARG_ROLE}"
+    elif [ -n "${ROLE_ARN:-}" ]; then
+        role_arn="${ROLE_ARN}"
+    else
+        role_arn="${SAGEMAKER_ROLE_ARN:-<not configured>}"
+    fi
+
+    local timestamp
+    timestamp=$(date +%Y%m%d-%H%M%S)
+    local job_name="${PROJECT_NAME}-tune-${ARG_TECHNIQUE}-${timestamp}"
+
+    echo "🔍 Dry run — validation passed, would submit:"
+    echo ""
+    echo "   Job name:      ${job_name}"
+    echo "   Model:         ${RESOLVED_MODEL_ID}"
+    echo "   Technique:     ${ARG_TECHNIQUE}"
+    echo "   Training type: ${ARG_TRAINING_TYPE}"
+    echo "   Dataset:       ${RESOLVED_DATASET_S3_URI}"
+    echo "   Output bucket: ${output_bucket}"
+    echo "   Role:          ${role_arn}"
+    echo "   Package group: ${PROJECT_NAME}-tune-models"
+
+    if [ -n "${ARG_EPOCHS}" ]; then
+        echo "   Epochs:        ${ARG_EPOCHS}"
+    fi
+    if [ -n "${ARG_LEARNING_RATE}" ]; then
+        echo "   Learning rate: ${ARG_LEARNING_RATE}"
+    fi
+    if [ -n "${ARG_MAX_SEQ_LENGTH}" ]; then
+        echo "   Max seq len:   ${ARG_MAX_SEQ_LENGTH}"
+    fi
+    if [ -n "${ARG_LORA_RANK}" ]; then
+        echo "   LoRA rank:     ${ARG_LORA_RANK}"
+    fi
+    if [ -n "${ARG_LORA_ALPHA}" ]; then
+        echo "   LoRA alpha:    ${ARG_LORA_ALPHA}"
+    fi
+    if [ -n "${ARG_BATCH_SIZE}" ]; then
+        echo "   Batch size:    ${ARG_BATCH_SIZE}"
+    fi
+    if [ -n "${ARG_REWARD_FUNCTION}" ]; then
+        echo "   Reward fn:     ${ARG_REWARD_FUNCTION}"
+    fi
+    if [ -n "${ARG_REWARD_PROMPT}" ]; then
+        echo "   Reward prompt: ${ARG_REWARD_PROMPT}"
+    fi
+
+    echo ""
+    echo "   ✅ All validations passed. Remove --dry-run to submit."
+    exit 0
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MAIN
+# ══════════════════════════════════════════════════════════════════════════════
+
+_parse_args "$@"
+
+# Handle informational flags first
+if [ "${ARG_HELP}" = true ]; then
+    _show_help
+fi
+
+if [ "${ARG_LIST_MODELS}" = true ]; then
+    _list_models
+fi
+
+if [ "${ARG_STATUS}" = true ]; then
+    _show_status
+fi
+
+# Validate required arguments for job submission
+if [ -z "${ARG_TECHNIQUE}" ]; then
+    echo "❌ --technique is required"
+    echo "   Usage: ./do/tune --technique <sft|dpo|rlaif|rlvr> --dataset <source>"
+    echo "   Run ./do/tune --help for full usage."
+    exit 1
+fi
+
+if [ -z "${ARG_DATASET}" ]; then
+    echo "❌ --dataset is required"
+    echo "   Usage: ./do/tune --technique ${ARG_TECHNIQUE} --dataset <s3://... or hf://...>"
+    echo "   Run ./do/tune --help for full usage."
+    exit 1
+fi
+
+# Check runtime support
+if [ "${TUNE_SUPPORTED:-}" = "false" ]; then
+    echo "⚠️  Managed customization is not supported for the configured model."
+    echo "   Checking catalog for current support..."
+    echo ""
+fi
+
+# Validate Python availability
+if ! command -v python3 &>/dev/null; then
+    echo "❌ python3 is required but not found"
+    echo "   Install Python 3 to use managed model customization."
+    exit 1
+fi
+
+# Run validations
+echo "🔧 SageMaker AI Managed Model Customization"
+echo ""
+
+_validate_model
+_validate_technique
+_validate_training_type
+_validate_dataset
+
+# Check idempotency (may exit early if existing job is handled)
+if _check_idempotency; then
+    # No existing job or --force: proceed with submission
+
+    if [ "${ARG_DRY_RUN}" = true ]; then
+        _dry_run
+    fi
+
+    _submit_job
+
+    if [ "${ARG_NO_WAIT}" = true ]; then
+        echo "   --no-wait specified. Job running in background."
+        echo "   Check status: ./do/tune --status"
+        exit 0
+    fi
+
+    _poll_job
+    _handle_completion
+fi

--- a/test/integration/lora-adapter-from-hub.test.js
+++ b/test/integration/lora-adapter-from-hub.test.js
@@ -349,7 +349,7 @@ describe('Feature: lora-adapter-lifecycle — --from-hub and search integration 
         it('checks for mutual exclusivity in add subcommand', () => {
             const addSection = getAddSection();
             assert.ok(
-                addSection.includes('--weights and --from-hub are mutually exclusive'),
+                addSection.includes('--weights, --from-hub, and --from-tune are mutually exclusive'),
                 'Must show mutual exclusivity error in add'
             );
         });
@@ -378,7 +378,7 @@ describe('Feature: lora-adapter-lifecycle — --from-hub and search integration 
         it('requires at least one of --weights or --from-hub', () => {
             const addSection = getAddSection();
             assert.ok(
-                addSection.includes('Either --weights or --from-hub is required'),
+                addSection.includes('One of --weights, --from-hub, or --from-tune is required'),
                 'Must require at least one source option'
             );
         });

--- a/test/integration/tune-from-tune-integration.test.js
+++ b/test/integration/tune-from-tune-integration.test.js
@@ -1,0 +1,370 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration tests for --from-tune flag in do/adapter add and do/add-ic.
+ *
+ * Tests that the rendered scripts contain correct logic for:
+ * - do/adapter add --from-tune reads TUNE_OUTPUT_PATH_LATEST from config
+ * - do/adapter add --from-tune sft reads technique-specific TUNE_ADAPTER_PATH_SFT
+ * - do/adapter add --from-tune errors when output type is full-model
+ * - do/add-ic --from-tune reads TUNE_OUTPUT_PATH_LATEST from config
+ *
+ * Feature: managed-model-customization
+ * Validates: Requirements 8.8, 8.9, 8.10
+ */
+
+import { describe, it, before, after } from 'mocha';
+import assert from 'node:assert';
+import fs from 'fs';
+import { runGenerator } from '../helpers/run-generator.js';
+
+describe('Feature: managed-model-customization — --from-tune integration (Req 8.8, 8.9, 8.10)', function () {
+    this.timeout(120000);
+
+    let result;
+    let adapterScript;
+    let addIcScript;
+
+    before(() => {
+        result = runGenerator({
+            'deployment-config': 'transformers-vllm',
+            'model-name': 'meta-llama/Llama-3.1-8B-Instruct',
+            'enable-lora': true,
+            'region': 'us-east-1',
+            'instance-type': 'ml.g5.xlarge'
+        });
+
+        // Read the rendered scripts
+        const adapterPath = result.file('do/adapter');
+        adapterScript = fs.readFileSync(adapterPath, 'utf8');
+
+        const addIcPath = result.file('do/add-ic');
+        addIcScript = fs.readFileSync(addIcPath, 'utf8');
+    });
+
+    after(() => {
+        if (result) result.cleanup();
+    });
+
+    // ── Helper to extract the _adapter_add section ───────────────────────
+
+    function getAdapterAddSection() {
+        const start = adapterScript.indexOf('_adapter_add()');
+        const end = adapterScript.indexOf('\n_adapter_list()');
+        if (start === -1) {
+            return adapterScript;
+        }
+        return end === -1 ? adapterScript.substring(start) : adapterScript.substring(start, end);
+    }
+
+    // ── do/adapter add --from-tune reads correct config variable ─────────
+
+    describe('do/adapter add --from-tune reads TUNE_OUTPUT_PATH_LATEST', () => {
+
+        it('parses --from-tune flag in argument parsing', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('--from-tune)'),
+                'Must parse --from-tune flag in argument parsing'
+            );
+        });
+
+        it('reads TUNE_OUTPUT_PATH_LATEST when no technique is specified', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('TUNE_OUTPUT_PATH_LATEST'),
+                'Must read TUNE_OUTPUT_PATH_LATEST from config'
+            );
+        });
+
+        it('sets weights_uri from TUNE_OUTPUT_PATH_LATEST', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('weights_uri="${TUNE_OUTPUT_PATH_LATEST}"'),
+                'Must set weights_uri from TUNE_OUTPUT_PATH_LATEST'
+            );
+        });
+
+        it('shows error when TUNE_OUTPUT_PATH_LATEST is not set', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('TUNE_OUTPUT_PATH_LATEST:-') &&
+                addSection.includes('No tune output found'),
+                'Must show error when TUNE_OUTPUT_PATH_LATEST is not set'
+            );
+        });
+
+        it('suggests running do/tune when no output is available', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('./do/tune --technique'),
+                'Must suggest running do/tune when no output is available'
+            );
+        });
+
+        it('displays the resolved tune output path', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('Using latest tune adapter output'),
+                'Must display the resolved tune output path'
+            );
+        });
+    });
+
+    // ── do/adapter add --from-tune sft reads technique-specific path ─────
+
+    describe('do/adapter add --from-tune sft reads technique-specific path', () => {
+
+        it('checks for optional technique argument after --from-tune', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('from_tune_technique'),
+                'Must support optional technique argument after --from-tune'
+            );
+        });
+
+        it('converts technique to uppercase for variable lookup', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('tr \'[:lower:]\' \'[:upper:]\''),
+                'Must convert technique to uppercase for variable name'
+            );
+        });
+
+        it('constructs TUNE_ADAPTER_PATH_<TECHNIQUE> variable name', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('TUNE_ADAPTER_PATH_${technique_upper}'),
+                'Must construct TUNE_ADAPTER_PATH_<TECHNIQUE> variable name'
+            );
+        });
+
+        it('reads technique-specific adapter path using indirect variable reference', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('${!tune_var:-}'),
+                'Must use indirect variable reference to read technique-specific path'
+            );
+        });
+
+        it('shows error when technique-specific path is not set', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('No adapter output found for technique'),
+                'Must show error when technique-specific path is not set'
+            );
+        });
+
+        it('includes technique name in error message', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('${from_tune_technique}'),
+                'Must include technique name in error message'
+            );
+        });
+
+        it('includes variable name in error message for debugging', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('${tune_var} is not set'),
+                'Must include variable name in error message'
+            );
+        });
+
+        it('displays the resolved technique-specific path', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('Using tune adapter output for technique'),
+                'Must display the resolved technique-specific path'
+            );
+        });
+    });
+
+    // ── do/adapter add --from-tune errors when output type is full-model ─
+
+    describe('do/adapter add --from-tune errors when output type is full-model', () => {
+
+        it('checks TUNE_OUTPUT_TYPE_LATEST before using latest output', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('TUNE_OUTPUT_TYPE_LATEST'),
+                'Must check TUNE_OUTPUT_TYPE_LATEST'
+            );
+        });
+
+        it('compares output type against full-model', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('"full-model"'),
+                'Must compare output type against "full-model"'
+            );
+        });
+
+        it('shows error explaining output is a full model', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('Latest tune output is a full model, not an adapter'),
+                'Must show error explaining output is a full model'
+            );
+        });
+
+        it('shows TUNE_OUTPUT_TYPE_LATEST=full-model in error details', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('TUNE_OUTPUT_TYPE_LATEST=full-model'),
+                'Must show the current output type value in error'
+            );
+        });
+
+        it('suggests using do/add-ic --from-tune instead', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('do/add-ic') && addSection.includes('--from-tune'),
+                'Must suggest using do/add-ic --from-tune instead'
+            );
+        });
+
+        it('exits with error code 1 when output type is full-model', () => {
+            const addSection = getAdapterAddSection();
+            // Find the full-model error section and verify exit 1 follows
+            const fullModelIdx = addSection.indexOf('Latest tune output is a full model');
+            assert.ok(fullModelIdx > 0, 'Must have full-model error message');
+            const afterError = addSection.substring(fullModelIdx, fullModelIdx + 500);
+            assert.ok(
+                afterError.includes('exit 1'),
+                'Must exit with error code 1 when output type is full-model'
+            );
+        });
+    });
+
+    // ── do/add-ic --from-tune reads TUNE_OUTPUT_PATH_LATEST ──────────────
+
+    describe('do/add-ic --from-tune reads TUNE_OUTPUT_PATH_LATEST', () => {
+
+        it('parses --from-tune flag in argument parsing', () => {
+            assert.ok(
+                addIcScript.includes('--from-tune)'),
+                'Must parse --from-tune flag in argument parsing'
+            );
+        });
+
+        it('reads TUNE_OUTPUT_PATH_LATEST from config', () => {
+            assert.ok(
+                addIcScript.includes('TUNE_OUTPUT_PATH_LATEST'),
+                'Must read TUNE_OUTPUT_PATH_LATEST from config'
+            );
+        });
+
+        it('sets MODEL_DATA from TUNE_OUTPUT_PATH_LATEST', () => {
+            assert.ok(
+                addIcScript.includes('MODEL_DATA="${TUNE_OUTPUT_PATH_LATEST}"'),
+                'Must set MODEL_DATA from TUNE_OUTPUT_PATH_LATEST'
+            );
+        });
+
+        it('shows error when TUNE_OUTPUT_PATH_LATEST is not set', () => {
+            assert.ok(
+                addIcScript.includes('TUNE_OUTPUT_PATH_LATEST:-') &&
+                addIcScript.includes('No tune output found'),
+                'Must show error when TUNE_OUTPUT_PATH_LATEST is not set'
+            );
+        });
+
+        it('suggests running do/tune when no output is available', () => {
+            assert.ok(
+                addIcScript.includes('./do/tune --technique'),
+                'Must suggest running do/tune when no output is available'
+            );
+        });
+
+        it('displays the resolved tune output path', () => {
+            assert.ok(
+                addIcScript.includes('Using tune output'),
+                'Must display the resolved tune output path'
+            );
+        });
+
+        it('--from-tune and --model-data are mutually exclusive', () => {
+            assert.ok(
+                addIcScript.includes('--from-tune and --model-data are mutually exclusive'),
+                'Must enforce mutual exclusivity between --from-tune and --model-data'
+            );
+        });
+
+        it('exits with error when both --from-tune and --model-data are provided', () => {
+            // Find the actual error check (with ❌ prefix), not the usage text
+            const mutualIdx = addIcScript.indexOf('❌ --from-tune and --model-data are mutually exclusive');
+            assert.ok(mutualIdx > 0, 'Must have mutual exclusivity error check');
+            const afterError = addIcScript.substring(mutualIdx, mutualIdx + 400);
+            assert.ok(
+                afterError.includes('exit 1'),
+                'Must exit with error code 1 when both flags are provided'
+            );
+        });
+
+        it('includes --from-tune in usage/help text', () => {
+            assert.ok(
+                addIcScript.includes('--from-tune') &&
+                addIcScript.includes('TUNE_OUTPUT_PATH_LATEST'),
+                'Must document --from-tune in help text'
+            );
+        });
+
+        it('does not check TUNE_OUTPUT_TYPE_LATEST (works for both types)', () => {
+            // add-ic should NOT gate on output type - it works for both adapter and full-model
+            // Verify it does not reject based on output type
+            const fromTuneSection = addIcScript.substring(
+                addIcScript.indexOf('Resolve --from-tune'),
+                addIcScript.indexOf('Add New Inference Component')
+            );
+            assert.ok(
+                !fromTuneSection.includes('TUNE_OUTPUT_TYPE_LATEST'),
+                'add-ic must NOT check TUNE_OUTPUT_TYPE_LATEST (works for both types)'
+            );
+        });
+    });
+
+    // ── Generated project structure ──────────────────────────────────────
+
+    describe('Generated project has --from-tune support in both scripts', () => {
+
+        it('do/adapter script is present', () => {
+            result.assertFile('do/adapter');
+        });
+
+        it('do/add-ic script is present', () => {
+            result.assertFile('do/add-ic');
+        });
+
+        it('do/adapter includes --from-tune in usage text', () => {
+            assert.ok(
+                adapterScript.includes('--from-tune'),
+                'do/adapter must include --from-tune in usage'
+            );
+        });
+
+        it('do/add-ic includes --from-tune in usage text', () => {
+            assert.ok(
+                addIcScript.includes('--from-tune'),
+                'do/add-ic must include --from-tune in usage'
+            );
+        });
+
+        it('do/adapter stores ADAPTER_SOURCE="tune" in conf when --from-tune is used', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('ADAPTER_SOURCE') && addSection.includes('"tune"'),
+                'Must store ADAPTER_SOURCE="tune" in conf file'
+            );
+        });
+
+        it('do/adapter stores ADAPTER_TUNE_TECHNIQUE in conf when --from-tune is used', () => {
+            const addSection = getAdapterAddSection();
+            assert.ok(
+                addSection.includes('ADAPTER_TUNE_TECHNIQUE'),
+                'Must store ADAPTER_TUNE_TECHNIQUE in conf file'
+            );
+        });
+    });
+});

--- a/test/property/tune-catalog-validation.property.test.js
+++ b/test/property/tune-catalog-validation.property.test.js
@@ -1,0 +1,294 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tune Catalog Validation Property-Based Tests
+ *
+ * Property 5: Catalog schema validity
+ *
+ * For any entry in the Supported_Model_Catalog, it SHALL have:
+ * a non-empty jumpStartModelId, a non-empty techniques object where
+ * each technique key is one of [sft, dpo, rlaif, rlvr], each technique
+ * has a non-empty trainingTypes array containing only [lora, full-rank],
+ * and each technique has a non-empty datasetFormat string with a
+ * corresponding datasetSchema.
+ *
+ * Feature: managed-model-customization, Property 5: Catalog schema validity
+ * Validates: Requirements 2.2, 2.3, 2.4, 2.5
+ */
+
+import fc from 'fast-check';
+import { describe, it, before } from 'mocha';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const PROPERTY_CONFIG = { numRuns: 100, timeout: 30000, verbose: false };
+
+// ── Catalog loading ──────────────────────────────────────────────────────────
+
+const catalogPath = resolve(__dirname, '../../config/tune-catalog.json');
+const catalog = JSON.parse(readFileSync(catalogPath, 'utf8'));
+
+const VALID_TECHNIQUES = ['sft', 'dpo', 'rlaif', 'rlvr'];
+const VALID_TRAINING_TYPES = ['lora', 'full-rank'];
+
+// ── Property tests ───────────────────────────────────────────────────────────
+
+describe('Feature: managed-model-customization, Property 5: Catalog schema validity', () => {
+
+    let modelKeys;
+
+    before(() => {
+        modelKeys = Object.keys(catalog.models);
+    });
+
+    it('every catalog entry has a non-empty jumpStartModelId', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.constantFrom(...modelKeys),
+            (modelKey) => {
+                const entry = catalog.models[modelKey];
+                assert.ok(entry.jumpStartModelId,
+                    `Model "${modelKey}" must have a non-empty jumpStartModelId`);
+                assert.strictEqual(typeof entry.jumpStartModelId, 'string',
+                    `Model "${modelKey}" jumpStartModelId must be a string`);
+                assert.ok(entry.jumpStartModelId.length > 0,
+                    `Model "${modelKey}" jumpStartModelId must not be empty`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('every technique key is one of sft|dpo|rlaif|rlvr', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.constantFrom(...modelKeys),
+            (modelKey) => {
+                const entry = catalog.models[modelKey];
+                const techniques = Object.keys(entry.techniques);
+                assert.ok(techniques.length > 0,
+                    `Model "${modelKey}" must have at least one technique`);
+                for (const technique of techniques) {
+                    assert.ok(VALID_TECHNIQUES.includes(technique),
+                        `Model "${modelKey}" has invalid technique "${technique}". Must be one of: ${VALID_TECHNIQUES.join(', ')}`);
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('every technique has a non-empty trainingTypes array containing only lora|full-rank', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.constantFrom(...modelKeys),
+            (modelKey) => {
+                const entry = catalog.models[modelKey];
+                for (const [technique, config] of Object.entries(entry.techniques)) {
+                    assert.ok(Array.isArray(config.trainingTypes),
+                        `Model "${modelKey}" technique "${technique}" trainingTypes must be an array`);
+                    assert.ok(config.trainingTypes.length > 0,
+                        `Model "${modelKey}" technique "${technique}" trainingTypes must not be empty`);
+                    for (const tt of config.trainingTypes) {
+                        assert.ok(VALID_TRAINING_TYPES.includes(tt),
+                            `Model "${modelKey}" technique "${technique}" has invalid trainingType "${tt}". Must be one of: ${VALID_TRAINING_TYPES.join(', ')}`);
+                    }
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('every technique has a non-empty datasetFormat string with a corresponding datasetSchema', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.constantFrom(...modelKeys),
+            (modelKey) => {
+                const entry = catalog.models[modelKey];
+                for (const [technique, config] of Object.entries(entry.techniques)) {
+                    // datasetFormat must be a non-empty string
+                    assert.strictEqual(typeof config.datasetFormat, 'string',
+                        `Model "${modelKey}" technique "${technique}" datasetFormat must be a string`);
+                    assert.ok(config.datasetFormat.length > 0,
+                        `Model "${modelKey}" technique "${technique}" datasetFormat must not be empty`);
+
+                    // datasetSchema must exist and be an object
+                    assert.ok(config.datasetSchema !== null && config.datasetSchema !== undefined,
+                        `Model "${modelKey}" technique "${technique}" must have a datasetSchema`);
+                    assert.strictEqual(typeof config.datasetSchema, 'object',
+                        `Model "${modelKey}" technique "${technique}" datasetSchema must be an object`);
+                    assert.ok(!Array.isArray(config.datasetSchema),
+                        `Model "${modelKey}" technique "${technique}" datasetSchema must not be an array`);
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});
+
+// ── Property 3: Unsupported model produces descriptive exit message ──────────
+// Validates: Requirements 1.4, 4.2
+
+import { validateModel, isTuneSupported, validateTechnique, validateTrainingType } from '../../src/lib/tune-catalog-validator.js';
+
+describe('Feature: managed-model-customization, Property 3: Unsupported model produces descriptive exit message', () => {
+
+    let modelKeys;
+    let families;
+
+    before(() => {
+        modelKeys = Object.keys(catalog.models);
+        const familySet = new Set();
+        for (const entry of Object.values(catalog.models)) {
+            if (entry.family) {
+                familySet.add(entry.family);
+            }
+        }
+        families = [...familySet];
+    });
+
+    it('error contains model ID, "not yet supported", at least one family, and do/train reference', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.string({ minLength: 1, maxLength: 50 }).filter(s => !modelKeys.includes(s)),
+            (randomModelId) => {
+                const result = validateModel(randomModelId, catalog);
+
+                // Must be invalid
+                assert.strictEqual(result.valid, false,
+                    `Model "${randomModelId}" should not be valid`);
+
+                // Error must contain the model ID
+                assert.ok(result.error.includes(randomModelId),
+                    `Error must contain the model ID "${randomModelId}"`);
+
+                // Error must contain "not yet supported"
+                assert.ok(result.error.includes('not yet supported'),
+                    'Error must contain "not yet supported"');
+
+                // Error must contain at least one supported family name
+                const containsFamily = families.some(f => result.error.includes(f));
+                assert.ok(containsFamily,
+                    `Error must contain at least one supported family name. Families: ${families.join(', ')}. Error: ${result.error}`);
+
+                // Error must reference do/train
+                assert.ok(result.error.includes('do/train'),
+                    'Error must reference do/train');
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});
+
+// ── Property 4: TUNE_SUPPORTED matches catalog membership ───────────────────
+// Validates: Requirements 1.5
+
+describe('Feature: managed-model-customization, Property 4: TUNE_SUPPORTED matches catalog membership', () => {
+
+    let modelKeys;
+
+    before(() => {
+        modelKeys = Object.keys(catalog.models);
+    });
+
+    it('isTuneSupported returns true for catalog members', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.constantFrom(...Object.keys(catalog.models)),
+            (modelId) => {
+                assert.strictEqual(isTuneSupported(modelId, catalog), true,
+                    `Model "${modelId}" is in catalog so isTuneSupported must return true`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('isTuneSupported returns false for non-members', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.string({ minLength: 1, maxLength: 50 }).filter(s => !modelKeys.includes(s)),
+            (modelId) => {
+                assert.strictEqual(isTuneSupported(modelId, catalog), false,
+                    `Model "${modelId}" is NOT in catalog so isTuneSupported must return false`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});
+
+// ── Property 9: Unsupported technique exits with supported list ─────────────
+// Validates: Requirements 4.3
+
+describe('Feature: managed-model-customization, Property 9: Unsupported technique exits with supported list', () => {
+
+    it('error lists all supported techniques for the model when technique is unsupported', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.constantFrom(...Object.keys(catalog.models)),
+            fc.string({ minLength: 1, maxLength: 30 }),
+            (modelId, technique) => {
+                const entry = catalog.models[modelId];
+                const supportedTechniques = Object.keys(entry.techniques);
+
+                // Only test when the technique is NOT supported
+                fc.pre(!supportedTechniques.includes(technique));
+
+                const result = validateTechnique(modelId, technique, catalog);
+
+                // Must be invalid
+                assert.strictEqual(result.valid, false,
+                    `Technique "${technique}" should not be valid for model "${modelId}"`);
+
+                // Error must list all supported techniques for this model
+                for (const supported of supportedTechniques) {
+                    assert.ok(result.error.includes(supported),
+                        `Error must list supported technique "${supported}" for model "${modelId}". Error: ${result.error}`);
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});
+
+// ── Property 10: Unsupported training type exits with supported list ────────
+// Validates: Requirements 4.4
+
+describe('Feature: managed-model-customization, Property 10: Unsupported training type exits with supported list', () => {
+
+    let modelTechniquePairs;
+
+    before(() => {
+        modelTechniquePairs = [];
+        for (const [modelId, entry] of Object.entries(catalog.models)) {
+            for (const technique of Object.keys(entry.techniques)) {
+                modelTechniquePairs.push({ modelId, technique });
+            }
+        }
+    });
+
+    it('error lists supported training types when training type is unsupported', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.constantFrom(...Object.entries(catalog.models).flatMap(
+                ([modelId, entry]) => Object.keys(entry.techniques).map(t => ({ modelId, technique: t }))
+            )),
+            fc.string({ minLength: 1, maxLength: 30 }),
+            (pair, trainingType) => {
+                const { modelId, technique } = pair;
+                const entry = catalog.models[modelId];
+                const supportedTypes = entry.techniques[technique].trainingTypes;
+
+                // Only test when the training type is NOT supported
+                fc.pre(!supportedTypes.includes(trainingType));
+
+                const result = validateTrainingType(modelId, technique, trainingType, catalog);
+
+                // Must be invalid
+                assert.strictEqual(result.valid, false,
+                    `Training type "${trainingType}" should not be valid for model "${modelId}" technique "${technique}"`);
+
+                // Error must list all supported training types for this model+technique
+                for (const supported of supportedTypes) {
+                    assert.ok(result.error.includes(supported),
+                        `Error must list supported training type "${supported}" for model "${modelId}" technique "${technique}". Error: ${result.error}`);
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});

--- a/test/property/tune-config-state.property.test.js
+++ b/test/property/tune-config-state.property.test.js
@@ -1,0 +1,634 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tune Config State Property-Based Tests
+ *
+ * Property 11: Config persistence after job submission
+ *
+ * For any successful job submission with technique T, training type TT,
+ * and dataset path D, the config file SHALL contain:
+ * TUNE_JOB_NAME_<T> matching the job name pattern,
+ * TUNE_TECHNIQUE=<T>, TUNE_TRAINING_TYPE=<TT>, and TUNE_DATASET_PATH=<D>.
+ *
+ * Feature: managed-model-customization, Property 11: Config persistence after job submission
+ * Validates: Requirements 5.6, 5.7, 5.8, 5.9
+ */
+
+import fc from 'fast-check';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import assert from 'node:assert';
+import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+    updateConfigVar,
+    readConfigVar,
+    persistSubmissionState,
+    generateJobName
+} from '../../src/lib/tune-config-state.js';
+
+const PROPERTY_CONFIG = { numRuns: 100, timeout: 30000, verbose: false };
+
+// ── Generators ───────────────────────────────────────────────────────────────
+
+const techniqueArb = fc.constantFrom('sft', 'dpo', 'rlaif', 'rlvr');
+
+const trainingTypeArb = fc.constantFrom('lora', 'full-rank');
+
+const projectNameArb = fc.stringMatching(/^[a-z][a-z0-9-]{2,20}$/);
+
+const s3DatasetPathArb = fc.tuple(
+    fc.stringMatching(/^[a-z0-9][a-z0-9.-]{2,20}$/),
+    fc.stringMatching(/^[a-z0-9][a-z0-9/_.-]{1,30}\.jsonl$/)
+).map(([bucket, key]) => `s3://${bucket}/${key}`);
+
+const hfDatasetPathArb = fc.tuple(
+    fc.stringMatching(/^[a-z][a-z0-9-]{1,15}$/),
+    fc.stringMatching(/^[a-z][a-z0-9_-]{1,20}$/)
+).map(([org, name]) => `hf://${org}/${name}`);
+
+const datasetPathArb = fc.oneof(s3DatasetPathArb, hfDatasetPathArb);
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+let tempDir;
+let configPath;
+
+function setupTempConfig(initialContent = '') {
+    tempDir = join(tmpdir(), `tune-config-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tempDir, { recursive: true });
+    configPath = join(tempDir, 'config');
+    writeFileSync(configPath, initialContent, 'utf8');
+}
+
+function cleanupTempConfig() {
+    try {
+        unlinkSync(configPath);
+    } catch (e) {
+        // ignore
+    }
+}
+
+// ── Property 11: Config persistence after job submission ─────────────────────
+
+describe('Feature: managed-model-customization, Property 11: Config persistence after job submission', () => {
+
+    beforeEach(() => {
+        setupTempConfig('#!/bin/bash\n# do/config\nexport PROJECT_NAME="test-project"\n');
+    });
+
+    afterEach(() => {
+        cleanupTempConfig();
+    });
+
+    it('config contains correct TUNE_JOB_NAME_<T> after submission', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArb,
+            trainingTypeArb,
+            datasetPathArb,
+            projectNameArb,
+            (technique, trainingType, datasetPath, projectName) => {
+                // Reset config for each iteration
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                const jobName = generateJobName(projectName, technique);
+
+                persistSubmissionState(configPath, {
+                    technique,
+                    trainingType,
+                    datasetPath,
+                    jobName
+                });
+
+                const techniqueUpper = technique.toUpperCase();
+                const storedJobName = readConfigVar(configPath, `TUNE_JOB_NAME_${techniqueUpper}`);
+
+                assert.strictEqual(storedJobName, jobName,
+                    `TUNE_JOB_NAME_${techniqueUpper} must equal the job name "${jobName}", got "${storedJobName}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('config contains correct TUNE_TECHNIQUE after submission', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArb,
+            trainingTypeArb,
+            datasetPathArb,
+            projectNameArb,
+            (technique, trainingType, datasetPath, projectName) => {
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                const jobName = generateJobName(projectName, technique);
+
+                persistSubmissionState(configPath, {
+                    technique,
+                    trainingType,
+                    datasetPath,
+                    jobName
+                });
+
+                const storedTechnique = readConfigVar(configPath, 'TUNE_TECHNIQUE');
+
+                assert.strictEqual(storedTechnique, technique,
+                    `TUNE_TECHNIQUE must equal "${technique}", got "${storedTechnique}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('config contains correct TUNE_TRAINING_TYPE after submission', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArb,
+            trainingTypeArb,
+            datasetPathArb,
+            projectNameArb,
+            (technique, trainingType, datasetPath, projectName) => {
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                const jobName = generateJobName(projectName, technique);
+
+                persistSubmissionState(configPath, {
+                    technique,
+                    trainingType,
+                    datasetPath,
+                    jobName
+                });
+
+                const storedTrainingType = readConfigVar(configPath, 'TUNE_TRAINING_TYPE');
+
+                assert.strictEqual(storedTrainingType, trainingType,
+                    `TUNE_TRAINING_TYPE must equal "${trainingType}", got "${storedTrainingType}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('config contains correct TUNE_DATASET_PATH after submission', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArb,
+            trainingTypeArb,
+            datasetPathArb,
+            projectNameArb,
+            (technique, trainingType, datasetPath, projectName) => {
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                const jobName = generateJobName(projectName, technique);
+
+                persistSubmissionState(configPath, {
+                    technique,
+                    trainingType,
+                    datasetPath,
+                    jobName
+                });
+
+                const storedDatasetPath = readConfigVar(configPath, 'TUNE_DATASET_PATH');
+
+                assert.strictEqual(storedDatasetPath, datasetPath,
+                    `TUNE_DATASET_PATH must equal "${datasetPath}", got "${storedDatasetPath}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('all four config vars are present simultaneously after submission', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArb,
+            trainingTypeArb,
+            datasetPathArb,
+            projectNameArb,
+            (technique, trainingType, datasetPath, projectName) => {
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                const jobName = generateJobName(projectName, technique);
+
+                persistSubmissionState(configPath, {
+                    technique,
+                    trainingType,
+                    datasetPath,
+                    jobName
+                });
+
+                const techniqueUpper = technique.toUpperCase();
+
+                // All four must be present
+                const storedJobName = readConfigVar(configPath, `TUNE_JOB_NAME_${techniqueUpper}`);
+                const storedTechnique = readConfigVar(configPath, 'TUNE_TECHNIQUE');
+                const storedTrainingType = readConfigVar(configPath, 'TUNE_TRAINING_TYPE');
+                const storedDatasetPath = readConfigVar(configPath, 'TUNE_DATASET_PATH');
+
+                assert.strictEqual(storedJobName, jobName,
+                    `TUNE_JOB_NAME_${techniqueUpper} must be "${jobName}"`);
+                assert.strictEqual(storedTechnique, technique,
+                    `TUNE_TECHNIQUE must be "${technique}"`);
+                assert.strictEqual(storedTrainingType, trainingType,
+                    `TUNE_TRAINING_TYPE must be "${trainingType}"`);
+                assert.strictEqual(storedDatasetPath, datasetPath,
+                    `TUNE_DATASET_PATH must be "${datasetPath}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('config vars are correctly updated on re-submission (overwrite)', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArb,
+            trainingTypeArb,
+            datasetPathArb,
+            projectNameArb,
+            trainingTypeArb,
+            datasetPathArb,
+            (technique, trainingType1, datasetPath1, projectName, trainingType2, datasetPath2) => {
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                // First submission
+                const jobName1 = generateJobName(projectName, technique, new Date(2025, 0, 15, 10, 30, 0));
+                persistSubmissionState(configPath, {
+                    technique,
+                    trainingType: trainingType1,
+                    datasetPath: datasetPath1,
+                    jobName: jobName1
+                });
+
+                // Second submission (same technique, different params)
+                const jobName2 = generateJobName(projectName, technique, new Date(2025, 0, 15, 11, 45, 0));
+                persistSubmissionState(configPath, {
+                    technique,
+                    trainingType: trainingType2,
+                    datasetPath: datasetPath2,
+                    jobName: jobName2
+                });
+
+                const techniqueUpper = technique.toUpperCase();
+
+                // Config should reflect the SECOND submission
+                const storedJobName = readConfigVar(configPath, `TUNE_JOB_NAME_${techniqueUpper}`);
+                const storedTechnique = readConfigVar(configPath, 'TUNE_TECHNIQUE');
+                const storedTrainingType = readConfigVar(configPath, 'TUNE_TRAINING_TYPE');
+                const storedDatasetPath = readConfigVar(configPath, 'TUNE_DATASET_PATH');
+
+                assert.strictEqual(storedJobName, jobName2,
+                    `TUNE_JOB_NAME_${techniqueUpper} must be updated to "${jobName2}"`);
+                assert.strictEqual(storedTechnique, technique,
+                    `TUNE_TECHNIQUE must be "${technique}"`);
+                assert.strictEqual(storedTrainingType, trainingType2,
+                    `TUNE_TRAINING_TYPE must be updated to "${trainingType2}"`);
+                assert.strictEqual(storedDatasetPath, datasetPath2,
+                    `TUNE_DATASET_PATH must be updated to "${datasetPath2}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});
+
+// ── Property 12: Job name follows naming pattern ─────────────────────────────
+
+/**
+ * Property 12: Job name follows naming pattern
+ *
+ * For any project name P and technique T, the generated job name SHALL match
+ * the regex pattern `^${P}-tune-${T}-\d{8}-\d{6}$` (project-tune-technique-YYYYMMDD-HHMMSS).
+ *
+ * Feature: managed-model-customization, Property 12: Job name follows naming pattern
+ * Validates: Requirements 6.7
+ */
+
+describe('Feature: managed-model-customization, Property 12: Job name follows naming pattern', () => {
+
+    // Generator for valid timestamps (reasonable date range, excluding invalid dates)
+    const timestampArb = fc.date({
+        min: new Date(2020, 0, 1),
+        max: new Date(2035, 11, 31)
+    }).filter(d => !isNaN(d.getTime()));
+
+    it('generated job name matches pattern ^${P}-tune-${T}-YYYYMMDD-HHMMSS$', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            projectNameArb,
+            techniqueArb,
+            timestampArb,
+            (projectName, technique, timestamp) => {
+                const jobName = generateJobName(projectName, technique, timestamp);
+
+                const pattern = new RegExp(`^${projectName}-tune-${technique}-\\d{8}-\\d{6}$`);
+
+                assert.ok(pattern.test(jobName),
+                    `Job name "${jobName}" must match pattern "^${projectName}-tune-${technique}-\\d{8}-\\d{6}$"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('job name date segment matches the provided timestamp', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            projectNameArb,
+            techniqueArb,
+            timestampArb,
+            (projectName, technique, timestamp) => {
+                const jobName = generateJobName(projectName, technique, timestamp);
+
+                // Extract the date and time segments from the job name
+                const parts = jobName.split('-tune-')[1];
+                const afterTechnique = parts.split(`${technique}-`)[1];
+                const dateStr = afterTechnique.slice(0, 8);
+                const timeStr = afterTechnique.slice(9, 15);
+
+                const expectedYear = timestamp.getFullYear().toString();
+                const expectedMonth = (timestamp.getMonth() + 1).toString().padStart(2, '0');
+                const expectedDay = timestamp.getDate().toString().padStart(2, '0');
+                const expectedHours = timestamp.getHours().toString().padStart(2, '0');
+                const expectedMinutes = timestamp.getMinutes().toString().padStart(2, '0');
+                const expectedSeconds = timestamp.getSeconds().toString().padStart(2, '0');
+
+                const expectedDate = `${expectedYear}${expectedMonth}${expectedDay}`;
+                const expectedTime = `${expectedHours}${expectedMinutes}${expectedSeconds}`;
+
+                assert.strictEqual(dateStr, expectedDate,
+                    `Date segment "${dateStr}" must equal "${expectedDate}" for timestamp ${timestamp.toISOString()}`);
+                assert.strictEqual(timeStr, expectedTime,
+                    `Time segment "${timeStr}" must equal "${expectedTime}" for timestamp ${timestamp.toISOString()}`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('job name structure is exactly: projectName-tune-technique-YYYYMMDD-HHMMSS', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            projectNameArb,
+            techniqueArb,
+            timestampArb,
+            (projectName, technique, timestamp) => {
+                const jobName = generateJobName(projectName, technique, timestamp);
+
+                // Verify the job name can be decomposed into its expected parts
+                const expectedPrefix = `${projectName}-tune-${technique}-`;
+                assert.ok(jobName.startsWith(expectedPrefix),
+                    `Job name "${jobName}" must start with "${expectedPrefix}"`);
+
+                // The suffix after the prefix should be exactly 15 chars: YYYYMMDD-HHMMSS
+                const suffix = jobName.slice(expectedPrefix.length);
+                assert.strictEqual(suffix.length, 15,
+                    `Timestamp suffix "${suffix}" must be exactly 15 characters (YYYYMMDD-HHMMSS), got ${suffix.length}`);
+
+                // Verify the dash separator is in the right position
+                assert.strictEqual(suffix[8], '-',
+                    `Character at position 8 of suffix "${suffix}" must be a dash separator`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});
+
+// ── Property 13: Technique state isolation ───────────────────────────────────
+
+/**
+ * Property 13: Technique state isolation
+ *
+ * For any two different techniques T1 and T2, submitting or completing a job
+ * for T2 SHALL NOT modify the values of TUNE_JOB_NAME_<T1>,
+ * TUNE_ADAPTER_PATH_<T1>, or TUNE_MODEL_PATH_<T1> in the config.
+ *
+ * Feature: managed-model-customization, Property 13: Technique state isolation
+ * Validates: Requirements 6.8, 8.13, 8.14
+ */
+
+describe('Feature: managed-model-customization, Property 13: Technique state isolation', () => {
+
+    beforeEach(() => {
+        setupTempConfig('#!/bin/bash\n# do/config\nexport PROJECT_NAME="test-project"\n');
+    });
+
+    afterEach(() => {
+        cleanupTempConfig();
+    });
+
+    // Generator for two distinct techniques
+    const distinctTechniquePairArb = fc.tuple(techniqueArb, techniqueArb)
+        .filter(([t1, t2]) => t1 !== t2);
+
+    // Generator for a random S3 artifact path
+    const artifactPathArb = fc.tuple(
+        fc.stringMatching(/^[a-z0-9][a-z0-9.-]{2,15}$/),
+        fc.stringMatching(/^[a-z0-9][a-z0-9/_-]{2,20}$/)
+    ).map(([bucket, key]) => `s3://${bucket}/output/${key}/model.tar.gz`);
+
+    it('submitting for T2 does not modify TUNE_JOB_NAME_<T1>', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            distinctTechniquePairArb,
+            trainingTypeArb,
+            datasetPathArb,
+            projectNameArb,
+            trainingTypeArb,
+            datasetPathArb,
+            ([t1, t2], trainingType1, datasetPath1, projectName, trainingType2, datasetPath2) => {
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                // Submit job for T1
+                const jobName1 = generateJobName(projectName, t1, new Date(2025, 0, 10, 8, 0, 0));
+                persistSubmissionState(configPath, {
+                    technique: t1,
+                    trainingType: trainingType1,
+                    datasetPath: datasetPath1,
+                    jobName: jobName1
+                });
+
+                // Record T1's per-technique job name
+                const t1Upper = t1.toUpperCase();
+                const t1JobNameBefore = readConfigVar(configPath, `TUNE_JOB_NAME_${t1Upper}`);
+
+                // Submit job for T2
+                const jobName2 = generateJobName(projectName, t2, new Date(2025, 0, 10, 9, 0, 0));
+                persistSubmissionState(configPath, {
+                    technique: t2,
+                    trainingType: trainingType2,
+                    datasetPath: datasetPath2,
+                    jobName: jobName2
+                });
+
+                // Verify T1's job name is unchanged
+                const t1JobNameAfter = readConfigVar(configPath, `TUNE_JOB_NAME_${t1Upper}`);
+                assert.strictEqual(t1JobNameAfter, t1JobNameBefore,
+                    `TUNE_JOB_NAME_${t1Upper} must not change after submitting for ${t2}. ` +
+                    `Was "${t1JobNameBefore}", now "${t1JobNameAfter}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('submitting for T2 does not modify TUNE_ADAPTER_PATH_<T1>', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            distinctTechniquePairArb,
+            artifactPathArb,
+            trainingTypeArb,
+            datasetPathArb,
+            projectNameArb,
+            ([t1, t2], adapterPath, trainingType2, datasetPath2, projectName) => {
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                // Simulate T1 having a completed adapter path
+                const t1Upper = t1.toUpperCase();
+                updateConfigVar(configPath, `TUNE_ADAPTER_PATH_${t1Upper}`, adapterPath);
+
+                // Also set T1's job name (as would exist after submission)
+                const jobName1 = generateJobName(projectName, t1, new Date(2025, 0, 10, 8, 0, 0));
+                updateConfigVar(configPath, `TUNE_JOB_NAME_${t1Upper}`, jobName1);
+
+                // Record T1's adapter path before T2 submission
+                const t1AdapterBefore = readConfigVar(configPath, `TUNE_ADAPTER_PATH_${t1Upper}`);
+
+                // Submit job for T2
+                const jobName2 = generateJobName(projectName, t2, new Date(2025, 0, 10, 9, 0, 0));
+                persistSubmissionState(configPath, {
+                    technique: t2,
+                    trainingType: trainingType2,
+                    datasetPath: datasetPath2,
+                    jobName: jobName2
+                });
+
+                // Verify T1's adapter path is unchanged
+                const t1AdapterAfter = readConfigVar(configPath, `TUNE_ADAPTER_PATH_${t1Upper}`);
+                assert.strictEqual(t1AdapterAfter, t1AdapterBefore,
+                    `TUNE_ADAPTER_PATH_${t1Upper} must not change after submitting for ${t2}. ` +
+                    `Was "${t1AdapterBefore}", now "${t1AdapterAfter}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('submitting for T2 does not modify TUNE_MODEL_PATH_<T1>', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            distinctTechniquePairArb,
+            artifactPathArb,
+            trainingTypeArb,
+            datasetPathArb,
+            projectNameArb,
+            ([t1, t2], modelPath, trainingType2, datasetPath2, projectName) => {
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                // Simulate T1 having a completed model path
+                const t1Upper = t1.toUpperCase();
+                updateConfigVar(configPath, `TUNE_MODEL_PATH_${t1Upper}`, modelPath);
+
+                // Also set T1's job name (as would exist after submission)
+                const jobName1 = generateJobName(projectName, t1, new Date(2025, 0, 10, 8, 0, 0));
+                updateConfigVar(configPath, `TUNE_JOB_NAME_${t1Upper}`, jobName1);
+
+                // Record T1's model path before T2 submission
+                const t1ModelBefore = readConfigVar(configPath, `TUNE_MODEL_PATH_${t1Upper}`);
+
+                // Submit job for T2
+                const jobName2 = generateJobName(projectName, t2, new Date(2025, 0, 10, 9, 0, 0));
+                persistSubmissionState(configPath, {
+                    technique: t2,
+                    trainingType: trainingType2,
+                    datasetPath: datasetPath2,
+                    jobName: jobName2
+                });
+
+                // Verify T1's model path is unchanged
+                const t1ModelAfter = readConfigVar(configPath, `TUNE_MODEL_PATH_${t1Upper}`);
+                assert.strictEqual(t1ModelAfter, t1ModelBefore,
+                    `TUNE_MODEL_PATH_${t1Upper} must not change after submitting for ${t2}. ` +
+                    `Was "${t1ModelBefore}", now "${t1ModelAfter}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('sequential submissions across multiple techniques preserve all per-technique state', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            projectNameArb,
+            fc.array(
+                fc.tuple(techniqueArb, trainingTypeArb, datasetPathArb),
+                { minLength: 2, maxLength: 6 }
+            ),
+            (projectName, submissions) => {
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                // Track expected per-technique job names
+                const expectedJobNames = {};
+
+                // Execute all submissions sequentially
+                submissions.forEach(([technique, trainingType, datasetPath], idx) => {
+                    const timestamp = new Date(2025, 0, 10, 8 + idx, 0, 0);
+                    const jobName = generateJobName(projectName, technique, timestamp);
+
+                    persistSubmissionState(configPath, {
+                        technique,
+                        trainingType,
+                        datasetPath,
+                        jobName
+                    });
+
+                    // Track the latest job name per technique
+                    expectedJobNames[technique.toUpperCase()] = jobName;
+                });
+
+                // Verify each technique's job name matches its last submission
+                for (const [techniqueUpper, expectedJobName] of Object.entries(expectedJobNames)) {
+                    const actual = readConfigVar(configPath, `TUNE_JOB_NAME_${techniqueUpper}`);
+                    assert.strictEqual(actual, expectedJobName,
+                        `TUNE_JOB_NAME_${techniqueUpper} must be "${expectedJobName}" ` +
+                        `(the last submission for that technique), got "${actual}"`);
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('per-technique adapter and model paths survive submissions for other techniques', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            distinctTechniquePairArb,
+            artifactPathArb,
+            artifactPathArb,
+            trainingTypeArb,
+            datasetPathArb,
+            projectNameArb,
+            ([t1, t2], adapterPath, modelPath, trainingType2, datasetPath2, projectName) => {
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                const t1Upper = t1.toUpperCase();
+
+                // Set up T1 with both adapter and model paths (simulating completed jobs)
+                const jobName1 = generateJobName(projectName, t1, new Date(2025, 0, 10, 8, 0, 0));
+                updateConfigVar(configPath, `TUNE_JOB_NAME_${t1Upper}`, jobName1);
+                updateConfigVar(configPath, `TUNE_ADAPTER_PATH_${t1Upper}`, adapterPath);
+                updateConfigVar(configPath, `TUNE_MODEL_PATH_${t1Upper}`, modelPath);
+
+                // Record all T1 per-technique state
+                const t1StateBefore = {
+                    jobName: readConfigVar(configPath, `TUNE_JOB_NAME_${t1Upper}`),
+                    adapterPath: readConfigVar(configPath, `TUNE_ADAPTER_PATH_${t1Upper}`),
+                    modelPath: readConfigVar(configPath, `TUNE_MODEL_PATH_${t1Upper}`)
+                };
+
+                // Submit job for T2
+                const jobName2 = generateJobName(projectName, t2, new Date(2025, 0, 10, 9, 0, 0));
+                persistSubmissionState(configPath, {
+                    technique: t2,
+                    trainingType: trainingType2,
+                    datasetPath: datasetPath2,
+                    jobName: jobName2
+                });
+
+                // Also simulate T2 completion with its own paths
+                const t2Upper = t2.toUpperCase();
+                updateConfigVar(configPath, `TUNE_ADAPTER_PATH_${t2Upper}`, 's3://other-bucket/t2/adapter.tar.gz');
+                updateConfigVar(configPath, `TUNE_MODEL_PATH_${t2Upper}`, 's3://other-bucket/t2/model.tar.gz');
+
+                // Verify ALL of T1's per-technique state is unchanged
+                const t1StateAfter = {
+                    jobName: readConfigVar(configPath, `TUNE_JOB_NAME_${t1Upper}`),
+                    adapterPath: readConfigVar(configPath, `TUNE_ADAPTER_PATH_${t1Upper}`),
+                    modelPath: readConfigVar(configPath, `TUNE_MODEL_PATH_${t1Upper}`)
+                };
+
+                assert.deepStrictEqual(t1StateAfter, t1StateBefore,
+                    `All per-technique state for ${t1} must be preserved after T2 (${t2}) operations. ` +
+                    `Before: ${JSON.stringify(t1StateBefore)}, After: ${JSON.stringify(t1StateAfter)}`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});

--- a/test/property/tune-dataset-validation.property.test.js
+++ b/test/property/tune-dataset-validation.property.test.js
@@ -1,0 +1,639 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tune Dataset Validation Property-Based Tests
+ *
+ * Property 6: Dataset argument parsing accepts valid formats
+ *
+ * For any string matching the pattern `s3://[bucket]/[key]` or
+ * `hf://[org]/[name]` (optionally with `/[split]`), the dataset
+ * argument parser SHALL accept it as valid input without error.
+ *
+ * Feature: managed-model-customization, Property 6: Dataset argument parsing accepts valid formats
+ * Validates: Requirements 3.1
+ */
+
+import fc from 'fast-check';
+import { describe, it } from 'mocha';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import { parseDatasetArg, validateDatasetFormat } from '../../src/lib/tune-dataset-validator.js';
+
+const require = createRequire(import.meta.url);
+const catalog = require('../../config/tune-catalog.json');
+
+const PROPERTY_CONFIG = { numRuns: 100, timeout: 30000, verbose: false };
+
+// ── Generators ───────────────────────────────────────────────────────────────
+
+/**
+ * Generate a valid S3 bucket name segment (alphanumeric + hyphens,
+ * must start/end with alphanumeric, 3-63 chars).
+ */
+const s3BucketArb = fc.stringMatching(/^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/);
+
+/**
+ * Generate a valid S3 key (non-empty path, alphanumeric + common path chars).
+ */
+const s3KeyArb = fc.array(
+    fc.stringMatching(/^[a-zA-Z0-9_.-]+$/),
+    { minLength: 1, maxLength: 5 }
+).map(parts => parts.join('/'));
+
+/**
+ * Generate a valid S3 URI: s3://bucket/key
+ */
+const s3UriArb = fc.tuple(s3BucketArb, s3KeyArb)
+    .map(([bucket, key]) => `s3://${bucket}/${key}`);
+
+/**
+ * Generate a valid HF org/name segment (alphanumeric + hyphens,
+ * at least 1 char).
+ */
+const hfSegmentArb = fc.stringMatching(/^[a-zA-Z0-9][a-zA-Z0-9-]{0,38}[a-zA-Z0-9]$/);
+
+/**
+ * Generate a valid HF reference without split: hf://org/name
+ */
+const hfRefNoSplitArb = fc.tuple(hfSegmentArb, hfSegmentArb)
+    .map(([org, name]) => `hf://${org}/${name}`);
+
+/**
+ * Generate a valid HF reference with split: hf://org/name/split
+ */
+const hfRefWithSplitArb = fc.tuple(hfSegmentArb, hfSegmentArb, hfSegmentArb)
+    .map(([org, name, split]) => `hf://${org}/${name}/${split}`);
+
+// ── Property tests ───────────────────────────────────────────────────────────
+
+describe('Feature: managed-model-customization, Property 6: Dataset argument parsing accepts valid formats', () => {
+
+    it('accepts valid S3 URIs (s3://bucket/key)', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            s3UriArb,
+            (uri) => {
+                const result = parseDatasetArg(uri);
+                assert.strictEqual(result.valid, true,
+                    `Expected S3 URI "${uri}" to be valid, got error: ${result.error}`);
+                assert.strictEqual(result.type, 's3',
+                    `Expected type "s3" for URI "${uri}", got "${result.type}"`);
+                assert.ok(result.bucket && result.bucket.length > 0,
+                    `Expected non-empty bucket for URI "${uri}"`);
+                assert.ok(result.key && result.key.length > 0,
+                    `Expected non-empty key for URI "${uri}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('accepts valid HF references without split (hf://org/name)', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            hfRefNoSplitArb,
+            (ref) => {
+                const result = parseDatasetArg(ref);
+                assert.strictEqual(result.valid, true,
+                    `Expected HF ref "${ref}" to be valid, got error: ${result.error}`);
+                assert.strictEqual(result.type, 'hf',
+                    `Expected type "hf" for ref "${ref}", got "${result.type}"`);
+                assert.ok(result.org && result.org.length > 0,
+                    `Expected non-empty org for ref "${ref}"`);
+                assert.ok(result.name && result.name.length > 0,
+                    `Expected non-empty name for ref "${ref}"`);
+                assert.strictEqual(result.split, 'train',
+                    `Expected default split "train" for ref "${ref}" without explicit split, got "${result.split}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('accepts valid HF references with split (hf://org/name/split)', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            hfRefWithSplitArb,
+            (ref) => {
+                const result = parseDatasetArg(ref);
+                assert.strictEqual(result.valid, true,
+                    `Expected HF ref "${ref}" to be valid, got error: ${result.error}`);
+                assert.strictEqual(result.type, 'hf',
+                    `Expected type "hf" for ref "${ref}", got "${result.type}"`);
+                assert.ok(result.org && result.org.length > 0,
+                    `Expected non-empty org for ref "${ref}"`);
+                assert.ok(result.name && result.name.length > 0,
+                    `Expected non-empty name for ref "${ref}"`);
+                assert.ok(result.split && result.split.length > 0,
+                    `Expected non-empty split for ref "${ref}" with explicit split`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('correctly extracts bucket and key from S3 URIs', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            s3BucketArb,
+            s3KeyArb,
+            (bucket, key) => {
+                const uri = `s3://${bucket}/${key}`;
+                const result = parseDatasetArg(uri);
+                assert.strictEqual(result.valid, true,
+                    `Expected S3 URI "${uri}" to be valid, got error: ${result.error}`);
+                assert.strictEqual(result.bucket, bucket,
+                    `Expected bucket "${bucket}", got "${result.bucket}" for URI "${uri}"`);
+                assert.strictEqual(result.key, key,
+                    `Expected key "${key}", got "${result.key}" for URI "${uri}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('correctly extracts org, name, and split from HF references', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            hfSegmentArb,
+            hfSegmentArb,
+            hfSegmentArb,
+            (org, name, split) => {
+                const ref = `hf://${org}/${name}/${split}`;
+                const result = parseDatasetArg(ref);
+                assert.strictEqual(result.valid, true,
+                    `Expected HF ref "${ref}" to be valid, got error: ${result.error}`);
+                assert.strictEqual(result.org, org,
+                    `Expected org "${org}", got "${result.org}" for ref "${ref}"`);
+                assert.strictEqual(result.name, name,
+                    `Expected name "${name}", got "${result.name}" for ref "${ref}"`);
+                assert.strictEqual(result.split, split,
+                    `Expected split "${split}", got "${result.split}" for ref "${ref}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});
+
+
+// ── Property 7 ───────────────────────────────────────────────────────────────
+
+/**
+ * Property 7: Dataset validation is catalog-driven and technique-aware
+ *
+ * For any model entry in the catalog and any technique supported by that model,
+ * the dataset validator SHALL accept a JSONL dataset if and only if every
+ * inspected line contains all keys specified in that model+technique's
+ * `datasetSchema.required` array with values matching the specified types.
+ *
+ * Feature: managed-model-customization, Property 7: Dataset validation is catalog-driven and technique-aware
+ * Validates: Requirements 3.5, 3.6, 3.7, 3.8
+ */
+
+// ── Property 7 Generators ────────────────────────────────────────────────────
+
+/**
+ * Generate a value matching the expected schema type.
+ */
+function valueArbForType(type) {
+    switch (type) {
+    case 'string':
+        return fc.string({ minLength: 1, maxLength: 100 });
+    case 'array':
+        return fc.array(
+            fc.record({ role: fc.constantFrom('user', 'assistant'), content: fc.string({ minLength: 1 }) }),
+            { minLength: 1, maxLength: 5 }
+        );
+    case 'number':
+        return fc.double({ min: -1000, max: 1000, noNaN: true });
+    case 'object':
+        return fc.dictionary(fc.string({ minLength: 1, maxLength: 10 }), fc.string(), { minKeys: 1, maxKeys: 3 });
+    default:
+        return fc.string({ minLength: 1 });
+    }
+}
+
+/**
+ * Generate a value that does NOT match the expected schema type.
+ */
+function wrongValueArbForType(type) {
+    switch (type) {
+    case 'string':
+        // Return a number instead of a string
+        return fc.integer({ min: 0, max: 1000 });
+    case 'array':
+        // Return a string instead of an array
+        return fc.string({ minLength: 1, maxLength: 50 });
+    case 'number':
+        // Return a string instead of a number
+        return fc.string({ minLength: 1, maxLength: 20 });
+    case 'object':
+        // Return an array instead of an object
+        return fc.array(fc.string(), { minLength: 1, maxLength: 3 });
+    default:
+        return fc.constant(null);
+    }
+}
+
+/**
+ * Build all model+technique combinations from the catalog.
+ */
+function getAllModelTechniqueCombinations() {
+    const combinations = [];
+    for (const [modelId, modelEntry] of Object.entries(catalog.models)) {
+        for (const [technique, techConfig] of Object.entries(modelEntry.techniques)) {
+            if (techConfig.datasetSchema) {
+                combinations.push({
+                    modelId,
+                    technique,
+                    schema: techConfig.datasetSchema
+                });
+            }
+        }
+    }
+    return combinations;
+}
+
+/**
+ * Generate a valid JSONL line object matching the given schema.
+ */
+function validLineArbForSchema(schema) {
+    const recordShape = {};
+    for (const key of schema.required) {
+        const type = (schema.types && schema.types[key]) || 'string';
+        recordShape[key] = valueArbForType(type);
+    }
+    return fc.record(recordShape);
+}
+
+/**
+ * Generate an array of valid JSONL line strings for a schema.
+ */
+function validLinesArb(schema) {
+    return fc.array(validLineArbForSchema(schema), { minLength: 1, maxLength: 10 })
+        .map(records => records.map(r => JSON.stringify(r)));
+}
+
+/**
+ * Generate an invalid JSONL line by removing a required key from a valid record.
+ */
+function lineWithMissingKeyArb(schema) {
+    return fc.tuple(
+        validLineArbForSchema(schema),
+        fc.constantFrom(...schema.required)
+    ).map(([record, keyToRemove]) => {
+        const copy = { ...record };
+        delete copy[keyToRemove];
+        return JSON.stringify(copy);
+    });
+}
+
+/**
+ * Generate an invalid JSONL line by using a wrong type for one field.
+ */
+function lineWithWrongTypeArb(schema) {
+    // Only pick keys that have a type defined
+    const typedKeys = Object.entries(schema.types || {}).filter(([key]) => schema.required.includes(key));
+    if (typedKeys.length === 0) {
+        // Fallback: just remove a key
+        return lineWithMissingKeyArb(schema);
+    }
+
+    return fc.tuple(
+        validLineArbForSchema(schema),
+        fc.constantFrom(...typedKeys)
+    ).chain(([record, [keyToCorrupt, expectedType]]) => {
+        return wrongValueArbForType(expectedType).map(wrongValue => {
+            const copy = { ...record };
+            copy[keyToCorrupt] = wrongValue;
+            return JSON.stringify(copy);
+        });
+    });
+}
+
+// ── Property 7 Tests ─────────────────────────────────────────────────────────
+
+describe('Feature: managed-model-customization, Property 7: Dataset validation is catalog-driven and technique-aware', () => {
+
+    const combinations = getAllModelTechniqueCombinations();
+
+    // Deduplicate schemas to avoid redundant tests (many models share the same schema)
+    const uniqueSchemas = new Map();
+    for (const combo of combinations) {
+        const key = JSON.stringify(combo.schema);
+        if (!uniqueSchemas.has(key)) {
+            uniqueSchemas.set(key, combo);
+        }
+    }
+    const representativeCombos = [...uniqueSchemas.values()];
+
+    it('accepts valid JSONL datasets matching the catalog schema for each model+technique', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+
+        for (const { modelId, technique, schema } of representativeCombos) {
+            fc.assert(fc.property(
+                validLinesArb(schema),
+                (lines) => {
+                    const result = validateDatasetFormat(lines, schema);
+                    assert.strictEqual(result.valid, true,
+                        `Expected valid dataset for ${modelId}/${technique} to be accepted. ` +
+                        `Got error: ${result.error}. Lines: ${JSON.stringify(lines)}`);
+                }
+            ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+        }
+    });
+
+    it('rejects JSONL datasets with missing required keys for each model+technique', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+
+        for (const { modelId, technique, schema } of representativeCombos) {
+            fc.assert(fc.property(
+                fc.tuple(
+                    fc.array(validLineArbForSchema(schema).map(r => JSON.stringify(r)), { minLength: 0, maxLength: 3 }),
+                    lineWithMissingKeyArb(schema),
+                    fc.array(validLineArbForSchema(schema).map(r => JSON.stringify(r)), { minLength: 0, maxLength: 3 })
+                ),
+                ([validBefore, invalidLine, validAfter]) => {
+                    const lines = [...validBefore, invalidLine, ...validAfter];
+                    const result = validateDatasetFormat(lines, schema);
+                    assert.strictEqual(result.valid, false,
+                        `Expected dataset with missing key for ${modelId}/${technique} to be rejected. ` +
+                        `Lines: ${JSON.stringify(lines)}`);
+                    assert.ok(result.error && result.error.length > 0,
+                        `Expected non-empty error message for ${modelId}/${technique}`);
+                    assert.ok(result.lineNumber !== null && result.lineNumber > 0,
+                        `Expected lineNumber to be reported for ${modelId}/${technique}`);
+                }
+            ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+        }
+    });
+
+    it('rejects JSONL datasets with wrong value types for each model+technique', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+
+        for (const { modelId, technique, schema } of representativeCombos) {
+            fc.assert(fc.property(
+                fc.tuple(
+                    fc.array(validLineArbForSchema(schema).map(r => JSON.stringify(r)), { minLength: 0, maxLength: 3 }),
+                    lineWithWrongTypeArb(schema),
+                    fc.array(validLineArbForSchema(schema).map(r => JSON.stringify(r)), { minLength: 0, maxLength: 3 })
+                ),
+                ([validBefore, invalidLine, validAfter]) => {
+                    const lines = [...validBefore, invalidLine, ...validAfter];
+                    const result = validateDatasetFormat(lines, schema);
+                    assert.strictEqual(result.valid, false,
+                        `Expected dataset with wrong type for ${modelId}/${technique} to be rejected. ` +
+                        `Lines: ${JSON.stringify(lines)}`);
+                    assert.ok(result.error && result.error.length > 0,
+                        `Expected non-empty error message for ${modelId}/${technique}`);
+                    assert.ok(result.lineNumber !== null && result.lineNumber > 0,
+                        `Expected lineNumber to be reported for ${modelId}/${technique}`);
+                }
+            ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+        }
+    });
+
+    it('validates against the specific schema for each model+technique (catalog-driven)', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+
+        // Verify that different schemas produce different validation results
+        // e.g., a valid SFT line should fail DPO validation and vice versa
+        for (const [modelId, modelEntry] of Object.entries(catalog.models)) {
+            const techniques = Object.entries(modelEntry.techniques);
+            if (techniques.length < 2) continue;
+
+            // Pick two techniques with different schemas
+            const [tech1Name, tech1Config] = techniques[0];
+            const [tech2Name, tech2Config] = techniques[1];
+            const schema1 = tech1Config.datasetSchema;
+            const schema2 = tech2Config.datasetSchema;
+
+            // Only test if schemas are actually different
+            if (JSON.stringify(schema1) === JSON.stringify(schema2)) continue;
+
+            fc.assert(fc.property(
+                validLineArbForSchema(schema1),
+                (validForSchema1) => {
+                    const line = JSON.stringify(validForSchema1);
+
+                    // Valid for schema1
+                    const result1 = validateDatasetFormat([line], schema1);
+                    assert.strictEqual(result1.valid, true,
+                        `Line valid for ${modelId}/${tech1Name} should pass its own schema`);
+
+                    // Check if it would be invalid for schema2
+                    // (only if schema2 has required keys not in schema1)
+                    const extraKeys = schema2.required.filter(k => !schema1.required.includes(k));
+                    if (extraKeys.length > 0) {
+                        const result2 = validateDatasetFormat([line], schema2);
+                        assert.strictEqual(result2.valid, false,
+                            `Line valid for ${modelId}/${tech1Name} should fail ${tech2Name} schema ` +
+                            `(missing keys: ${extraKeys.join(', ')})`);
+                    }
+                }
+            ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+
+            break; // One model is sufficient to demonstrate catalog-driven behavior
+        }
+    });
+});
+
+
+// ── Property 8 ───────────────────────────────────────────────────────────────
+
+/**
+ * Property 8: Malformed dataset reports first bad line
+ *
+ * For any JSONL dataset where at least one of the first 10 lines does not
+ * match the expected schema, the validation error SHALL include the line
+ * number and content of the first malformed line, plus a description of
+ * the expected format.
+ *
+ * Feature: managed-model-customization, Property 8: Malformed dataset reports first bad line
+ * Validates: Requirements 3.11
+ */
+
+// ── Property 8 Generators ────────────────────────────────────────────────────
+
+/**
+ * Generate a malformed line — not valid JSON.
+ */
+const notJsonArb = fc.oneof(
+    fc.string({ minLength: 1, maxLength: 80 }).filter(s => {
+        try { JSON.parse(s); return false; } catch { return true; }
+    }),
+    fc.constant('{ broken json'),
+    fc.constant('not json at all'),
+    fc.constant('{missing: closing brace')
+);
+
+/**
+ * Generate a malformed line — valid JSON but missing a required key.
+ */
+function missingKeyLineArb(schema) {
+    return fc.tuple(
+        validLineArbForSchema(schema),
+        fc.constantFrom(...schema.required)
+    ).map(([record, keyToRemove]) => {
+        const copy = { ...record };
+        delete copy[keyToRemove];
+        return JSON.stringify(copy);
+    });
+}
+
+/**
+ * Generate a malformed line — valid JSON but with wrong type for a field.
+ */
+function wrongTypeLineArb(schema) {
+    const typedKeys = Object.entries(schema.types || {}).filter(([key]) => schema.required.includes(key));
+    if (typedKeys.length === 0) {
+        return missingKeyLineArb(schema);
+    }
+
+    return fc.tuple(
+        validLineArbForSchema(schema),
+        fc.constantFrom(...typedKeys)
+    ).chain(([record, [keyToCorrupt, expectedType]]) => {
+        return wrongValueArbForType(expectedType).map(wrongValue => {
+            const copy = { ...record };
+            copy[keyToCorrupt] = wrongValue;
+            return JSON.stringify(copy);
+        });
+    });
+}
+
+/**
+ * Generate a malformed line using one of three strategies:
+ * not valid JSON, missing required key, or wrong type.
+ */
+function malformedLineArb(schema) {
+    return fc.oneof(
+        notJsonArb,
+        missingKeyLineArb(schema),
+        wrongTypeLineArb(schema)
+    );
+}
+
+/**
+ * Generate N valid lines (0 to 9) followed by one malformed line,
+ * ensuring the malformed line is within the first 10 lines.
+ * Returns { lines, malformedIndex } where malformedIndex is 0-based.
+ */
+function datasetWithMalformedLineArb(schema) {
+    return fc.integer({ min: 0, max: 9 }).chain(n => {
+        const validBeforeArb = fc.array(
+            validLineArbForSchema(schema).map(r => JSON.stringify(r)),
+            { minLength: n, maxLength: n }
+        );
+        return fc.tuple(validBeforeArb, malformedLineArb(schema)).map(([validLines, badLine]) => ({
+            lines: [...validLines, badLine],
+            malformedIndex: n
+        }));
+    });
+}
+
+// ── Property 8 Tests ─────────────────────────────────────────────────────────
+
+describe('Feature: managed-model-customization, Property 8: Malformed dataset reports first bad line', () => {
+
+    const combinations = getAllModelTechniqueCombinations();
+
+    // Deduplicate schemas
+    const uniqueSchemas = new Map();
+    for (const combo of combinations) {
+        const key = JSON.stringify(combo.schema);
+        if (!uniqueSchemas.has(key)) {
+            uniqueSchemas.set(key, combo);
+        }
+    }
+    const representativeCombos = [...uniqueSchemas.values()];
+
+    it('reports the correct line number of the first malformed line', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+
+        for (const { modelId, technique, schema } of representativeCombos) {
+            fc.assert(fc.property(
+                datasetWithMalformedLineArb(schema),
+                ({ lines, malformedIndex }) => {
+                    const result = validateDatasetFormat(lines, schema);
+                    assert.strictEqual(result.valid, false,
+                        `Expected dataset with malformed line at index ${malformedIndex} to be rejected ` +
+                        `for ${modelId}/${technique}`);
+                    assert.strictEqual(result.lineNumber, malformedIndex + 1,
+                        `Expected lineNumber to be ${malformedIndex + 1} (1-based), ` +
+                        `got ${result.lineNumber} for ${modelId}/${technique}`);
+                }
+            ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+        }
+    });
+
+    it('includes the content of the malformed line in the error', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+
+        for (const { modelId, technique, schema } of representativeCombos) {
+            fc.assert(fc.property(
+                datasetWithMalformedLineArb(schema),
+                ({ lines, malformedIndex }) => {
+                    const result = validateDatasetFormat(lines, schema);
+                    assert.strictEqual(result.valid, false,
+                        `Expected invalid result for ${modelId}/${technique}`);
+                    assert.ok(result.malformedLine !== null && result.malformedLine !== undefined,
+                        `Expected malformedLine to be present for ${modelId}/${technique}`);
+                    assert.strictEqual(result.malformedLine, lines[malformedIndex],
+                        `Expected malformedLine to equal the bad line content for ${modelId}/${technique}. ` +
+                        `Got "${result.malformedLine}" but expected "${lines[malformedIndex]}"`);
+                }
+            ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+        }
+    });
+
+    it('includes a non-empty expected format description in the error', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+
+        for (const { modelId, technique, schema } of representativeCombos) {
+            fc.assert(fc.property(
+                datasetWithMalformedLineArb(schema),
+                ({ lines }) => {
+                    const result = validateDatasetFormat(lines, schema);
+                    assert.strictEqual(result.valid, false,
+                        `Expected invalid result for ${modelId}/${technique}`);
+                    assert.ok(result.expectedFormat !== null && result.expectedFormat !== undefined,
+                        `Expected expectedFormat to be present for ${modelId}/${technique}`);
+                    assert.ok(typeof result.expectedFormat === 'string' && result.expectedFormat.length > 0,
+                        `Expected expectedFormat to be a non-empty string for ${modelId}/${technique}, ` +
+                        `got: "${result.expectedFormat}"`);
+                }
+            ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+        }
+    });
+
+    it('reports all three fields together: lineNumber, malformedLine, and expectedFormat', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+
+        for (const { modelId, technique, schema } of representativeCombos) {
+            fc.assert(fc.property(
+                datasetWithMalformedLineArb(schema),
+                ({ lines, malformedIndex }) => {
+                    const result = validateDatasetFormat(lines, schema);
+                    assert.strictEqual(result.valid, false,
+                        `Expected invalid result for ${modelId}/${technique}`);
+
+                    // All three fields must be present simultaneously
+                    assert.ok(result.lineNumber !== null,
+                        `lineNumber must not be null for ${modelId}/${technique}`);
+                    assert.ok(result.malformedLine !== null,
+                        `malformedLine must not be null for ${modelId}/${technique}`);
+                    assert.ok(result.expectedFormat !== null,
+                        `expectedFormat must not be null for ${modelId}/${technique}`);
+
+                    // lineNumber is correct
+                    assert.strictEqual(result.lineNumber, malformedIndex + 1,
+                        `lineNumber should be ${malformedIndex + 1} for ${modelId}/${technique}`);
+
+                    // malformedLine matches the bad line
+                    assert.strictEqual(result.malformedLine, lines[malformedIndex],
+                        `malformedLine should match the bad line for ${modelId}/${technique}`);
+
+                    // expectedFormat describes the schema
+                    for (const key of schema.required) {
+                        assert.ok(result.expectedFormat.includes(key),
+                            `expectedFormat should mention required key "${key}" for ${modelId}/${technique}. ` +
+                            `Got: "${result.expectedFormat}"`);
+                    }
+                }
+            ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+        }
+    });
+});

--- a/test/property/tune-dataset-validation.property.test.js
+++ b/test/property/tune-dataset-validation.property.test.js
@@ -453,7 +453,7 @@ describe('Feature: managed-model-customization, Property 7: Dataset validation i
 const notJsonArb = fc.oneof(
     fc.string({ minLength: 1, maxLength: 80 }).filter(s => {
         try { JSON.parse(s); return false; } catch { return true; }
-    }),
+    }).filter(s => s.trim() !== ''),
     fc.constant('{ broken json'),
     fc.constant('not json at all'),
     fc.constant('{missing: closing brace')

--- a/test/property/tune-generator-inclusion.property.test.js
+++ b/test/property/tune-generator-inclusion.property.test.js
@@ -1,0 +1,281 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tune Generator Inclusion Property-Based Tests
+ *
+ * Property 1: Generator includes tune script for transformers
+ *
+ * For any valid generator configuration where `framework === 'transformers'`
+ * and `deploymentTarget !== 'batch-transform'`, the generated project SHALL
+ * contain the files `do/tune`, `do/.tune_helper.py`, and `do/.tune_catalog.json`.
+ *
+ * Feature: managed-model-customization, Property 1: Generator includes tune script for transformers
+ * Validates: Requirements 1.1
+ */
+
+import fc from 'fast-check';
+import { describe, it } from 'mocha';
+import assert from 'node:assert';
+
+const PROPERTY_CONFIG = { numRuns: 100, timeout: 30000, verbose: false };
+
+// ── Ignore pattern logic (mirrors src/app.js writeProject) ───────────────────
+//
+// The generator excludes tune files via ignore patterns when:
+//   architecture !== 'transformers' || deploymentTarget === 'batch-transform'
+//
+// The tune catalog is copied when:
+//   architecture === 'transformers' && deploymentTarget !== 'batch-transform'
+//
+// Architecture is resolved from framework:
+//   if framework === 'transformers' → architecture = 'transformers'
+//   otherwise → architecture = 'http' (or from deploymentConfig)
+
+const TUNE_IGNORE_PATTERNS = ['**/do/tune', '**/do/.tune_helper.py'];
+
+/**
+ * Simulates the ignore pattern logic from src/app.js for tune files.
+ * Returns the list of tune-related ignore patterns that would be applied.
+ *
+ * @param {object} config - Generator configuration
+ * @param {string} config.framework - The framework (e.g., 'transformers')
+ * @param {string} config.deploymentTarget - The deployment target
+ * @param {string} [config.architecture] - Explicit architecture override
+ * @returns {string[]} Array of tune-related ignore patterns applied
+ */
+function getTuneIgnorePatterns(config) {
+    // Resolve architecture the same way src/app.js does
+    let architecture = config.architecture;
+    if (!architecture) {
+        architecture = config.framework === 'transformers' ? 'transformers' : 'http';
+    }
+
+    const ignorePatterns = [];
+    if (architecture !== 'transformers' || config.deploymentTarget === 'batch-transform') {
+        ignorePatterns.push('**/do/tune');
+        ignorePatterns.push('**/do/.tune_helper.py');
+    }
+    return ignorePatterns;
+}
+
+/**
+ * Simulates whether the tune catalog would be copied.
+ * Returns true if the catalog would be included in the generated project.
+ *
+ * @param {object} config - Generator configuration
+ * @returns {boolean} Whether tune catalog is copied
+ */
+function isTuneCatalogIncluded(config) {
+    let architecture = config.architecture;
+    if (!architecture) {
+        architecture = config.framework === 'transformers' ? 'transformers' : 'http';
+    }
+    return architecture === 'transformers' && config.deploymentTarget !== 'batch-transform';
+}
+
+// ── Generators ───────────────────────────────────────────────────────────────
+
+// Valid deployment targets that are NOT batch-transform
+const NON_BATCH_DEPLOYMENT_TARGETS = [
+    'realtime-inference',
+    'async-inference',
+    'hyperpod-eks'
+];
+
+/**
+ * Generator for valid configs where framework is transformers
+ * and deploymentTarget is NOT batch-transform.
+ */
+const validTransformersConfigArb = fc.record({
+    framework: fc.constant('transformers'),
+    deploymentTarget: fc.constantFrom(...NON_BATCH_DEPLOYMENT_TARGETS)
+});
+
+// ── Property tests ───────────────────────────────────────────────────────────
+
+describe('Feature: managed-model-customization, Property 1: Generator includes tune script for transformers', () => {
+
+    it('tune files are NOT in ignore patterns when framework is transformers and deploymentTarget is not batch-transform', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            validTransformersConfigArb,
+            (config) => {
+                const ignorePatterns = getTuneIgnorePatterns(config);
+
+                // Verify that tune ignore patterns are NOT applied
+                for (const pattern of TUNE_IGNORE_PATTERNS) {
+                    assert.ok(!ignorePatterns.includes(pattern),
+                        `Ignore pattern "${pattern}" should NOT be present for framework="${config.framework}", deploymentTarget="${config.deploymentTarget}"`);
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('tune catalog is included when framework is transformers and deploymentTarget is not batch-transform', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            validTransformersConfigArb,
+            (config) => {
+                const catalogIncluded = isTuneCatalogIncluded(config);
+
+                assert.strictEqual(catalogIncluded, true,
+                    `Tune catalog should be included for framework="${config.framework}", deploymentTarget="${config.deploymentTarget}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('all three tune files (do/tune, do/.tune_helper.py, do/.tune_catalog.json) are available for transformers non-batch configs', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            validTransformersConfigArb,
+            (config) => {
+                const ignorePatterns = getTuneIgnorePatterns(config);
+                const catalogIncluded = isTuneCatalogIncluded(config);
+
+                // do/tune is not ignored
+                assert.ok(!ignorePatterns.includes('**/do/tune'),
+                    'do/tune should not be in ignore patterns');
+
+                // do/.tune_helper.py is not ignored
+                assert.ok(!ignorePatterns.includes('**/do/.tune_helper.py'),
+                    'do/.tune_helper.py should not be in ignore patterns');
+
+                // do/.tune_catalog.json is copied explicitly
+                assert.strictEqual(catalogIncluded, true,
+                    'do/.tune_catalog.json should be copied to generated project');
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('explicit architecture=transformers also includes tune files regardless of framework field', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.record({
+                architecture: fc.constant('transformers'),
+                framework: fc.constantFrom('transformers', 'sklearn', 'xgboost', 'tensorflow'),
+                deploymentTarget: fc.constantFrom(...NON_BATCH_DEPLOYMENT_TARGETS)
+            }),
+            (config) => {
+                const ignorePatterns = getTuneIgnorePatterns(config);
+                const catalogIncluded = isTuneCatalogIncluded(config);
+
+                // When architecture is explicitly 'transformers', tune files are included
+                for (const pattern of TUNE_IGNORE_PATTERNS) {
+                    assert.ok(!ignorePatterns.includes(pattern),
+                        `Ignore pattern "${pattern}" should NOT be present when architecture="transformers"`);
+                }
+                assert.strictEqual(catalogIncluded, true,
+                    'Tune catalog should be included when architecture="transformers"');
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});
+
+// ── Property 2 ──────────────────────────────────────────────────────────────
+//
+// Property 2: Generator excludes tune script for batch-transform
+//
+// For any valid generator configuration where `deploymentTarget === 'batch-transform'`,
+// the generated project SHALL NOT contain the file `do/tune`.
+//
+// Feature: managed-model-customization, Property 2: Generator excludes tune script for batch-transform
+// Validates: Requirements 1.2
+
+// ── Generators for Property 2 ────────────────────────────────────────────────
+
+// All supported frameworks (tune exclusion for batch-transform applies regardless of framework)
+const ALL_FRAMEWORKS = ['transformers', 'sklearn', 'xgboost', 'tensorflow'];
+
+/**
+ * Generator for valid configs where deploymentTarget is batch-transform.
+ * Framework varies to prove the property holds regardless of framework choice.
+ */
+const batchTransformConfigArb = fc.record({
+    framework: fc.constantFrom(...ALL_FRAMEWORKS),
+    deploymentTarget: fc.constant('batch-transform')
+});
+
+/**
+ * Generator for configs with explicit architecture override and batch-transform target.
+ */
+const batchTransformWithArchitectureArb = fc.record({
+    architecture: fc.constantFrom('transformers', 'http'),
+    framework: fc.constantFrom(...ALL_FRAMEWORKS),
+    deploymentTarget: fc.constant('batch-transform')
+});
+
+// ── Property 2 tests ─────────────────────────────────────────────────────────
+
+describe('Feature: managed-model-customization, Property 2: Generator excludes tune script for batch-transform', () => {
+
+    it('tune files ARE in ignore patterns when deploymentTarget is batch-transform (any framework)', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            batchTransformConfigArb,
+            (config) => {
+                const ignorePatterns = getTuneIgnorePatterns(config);
+
+                // Verify that tune ignore patterns ARE applied
+                assert.ok(ignorePatterns.includes('**/do/tune'),
+                    `Ignore pattern "**/do/tune" SHOULD be present for deploymentTarget="batch-transform", framework="${config.framework}"`);
+                assert.ok(ignorePatterns.includes('**/do/.tune_helper.py'),
+                    `Ignore pattern "**/do/.tune_helper.py" SHOULD be present for deploymentTarget="batch-transform", framework="${config.framework}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('tune catalog is NOT included when deploymentTarget is batch-transform (any framework)', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            batchTransformConfigArb,
+            (config) => {
+                const catalogIncluded = isTuneCatalogIncluded(config);
+
+                assert.strictEqual(catalogIncluded, false,
+                    `Tune catalog should NOT be included for deploymentTarget="batch-transform", framework="${config.framework}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('batch-transform exclusion applies even when framework is transformers', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.record({
+                framework: fc.constant('transformers'),
+                deploymentTarget: fc.constant('batch-transform')
+            }),
+            (config) => {
+                const ignorePatterns = getTuneIgnorePatterns(config);
+                const catalogIncluded = isTuneCatalogIncluded(config);
+
+                // Even though framework is transformers, batch-transform overrides inclusion
+                assert.ok(ignorePatterns.includes('**/do/tune'),
+                    'do/tune should be excluded for batch-transform even with transformers framework');
+                assert.ok(ignorePatterns.includes('**/do/.tune_helper.py'),
+                    'do/.tune_helper.py should be excluded for batch-transform even with transformers framework');
+                assert.strictEqual(catalogIncluded, false,
+                    'Tune catalog should NOT be copied for batch-transform even with transformers framework');
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('batch-transform exclusion applies regardless of explicit architecture override', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            batchTransformWithArchitectureArb,
+            (config) => {
+                const ignorePatterns = getTuneIgnorePatterns(config);
+                const catalogIncluded = isTuneCatalogIncluded(config);
+
+                // batch-transform always excludes tune files, even with architecture=transformers
+                assert.ok(ignorePatterns.includes('**/do/tune'),
+                    `do/tune should be excluded for batch-transform with architecture="${config.architecture}"`);
+                assert.ok(ignorePatterns.includes('**/do/.tune_helper.py'),
+                    `do/.tune_helper.py should be excluded for batch-transform with architecture="${config.architecture}"`);
+                assert.strictEqual(catalogIncluded, false,
+                    `Tune catalog should NOT be copied for batch-transform with architecture="${config.architecture}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});

--- a/test/property/tune-output-detection.property.test.js
+++ b/test/property/tune-output-detection.property.test.js
@@ -1,0 +1,447 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tune Output Detection Property-Based Tests
+ *
+ * Property 14: Output type detection from training type
+ *
+ * For any completed job, if `training_type === 'lora'` then `output_type`
+ * SHALL be `adapter`, and if `training_type === 'full-rank'` then
+ * `output_type` SHALL be `full-model`.
+ *
+ * Feature: managed-model-customization, Property 14: Output type detection from training type
+ * Validates: Requirements 8.3
+ */
+
+import fc from 'fast-check';
+import { describe, it } from 'mocha';
+import assert from 'node:assert';
+
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { detectOutputType } from '../../src/lib/tune-output-resolver.js';
+import { persistCompletionState, readConfigVar } from '../../src/lib/tune-config-state.js';
+
+const PROPERTY_CONFIG = { numRuns: 100, timeout: 30000, verbose: false };
+
+// ── Generators ───────────────────────────────────────────────────────────────
+
+const trainingTypeArb = fc.constantFrom('lora', 'full-rank');
+
+// ── Property 14: Output type detection from training type ────────────────────
+
+describe('Feature: managed-model-customization, Property 14: Output type detection from training type', () => {
+
+    it('lora training type always produces adapter output type', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.constant('lora'),
+            (trainingType) => {
+                const outputType = detectOutputType(trainingType);
+
+                assert.strictEqual(outputType, 'adapter',
+                    `detectOutputType("lora") must return "adapter", got "${outputType}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('full-rank training type always produces full-model output type', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.constant('full-rank'),
+            (trainingType) => {
+                const outputType = detectOutputType(trainingType);
+
+                assert.strictEqual(outputType, 'full-model',
+                    `detectOutputType("full-rank") must return "full-model", got "${outputType}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('for any valid training type, output type is deterministic and correct', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            trainingTypeArb,
+            (trainingType) => {
+                const outputType = detectOutputType(trainingType);
+
+                if (trainingType === 'lora') {
+                    assert.strictEqual(outputType, 'adapter',
+                        `detectOutputType("${trainingType}") must return "adapter", got "${outputType}"`);
+                } else if (trainingType === 'full-rank') {
+                    assert.strictEqual(outputType, 'full-model',
+                        `detectOutputType("${trainingType}") must return "full-model", got "${outputType}"`);
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('output type is always one of the two valid values for valid training types', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            trainingTypeArb,
+            (trainingType) => {
+                const outputType = detectOutputType(trainingType);
+                const validOutputTypes = ['adapter', 'full-model'];
+
+                assert.ok(validOutputTypes.includes(outputType),
+                    `detectOutputType("${trainingType}") must return one of ${JSON.stringify(validOutputTypes)}, got "${outputType}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('mapping is bijective: distinct training types produce distinct output types', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            fc.constant(['lora', 'full-rank']),
+            (trainingTypes) => {
+                const outputTypes = trainingTypes.map(tt => detectOutputType(tt));
+
+                // Verify the two training types map to different output types
+                assert.notStrictEqual(outputTypes[0], outputTypes[1],
+                    'Different training types must produce different output types. ' +
+                    `"lora" → "${outputTypes[0]}", "full-rank" → "${outputTypes[1]}"`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});
+
+
+// ── Generators for Property 15 ──────────────────────────────────────────────
+
+const techniqueArb = fc.constantFrom('sft', 'dpo', 'rlaif', 'rlvr');
+const trainingTypeArbP15 = fc.constantFrom('lora', 'full-rank');
+
+const s3BucketArb = fc.stringMatching(/^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/);
+const s3KeyArb = fc.array(
+    fc.stringMatching(/^[a-zA-Z0-9_-]{1,20}$/),
+    { minLength: 1, maxLength: 4 }
+).map(parts => parts.join('/'));
+
+const artifactPathArb = fc.tuple(s3BucketArb, s3KeyArb).map(
+    ([bucket, key]) => `s3://${bucket}/${key}/output/model.tar.gz`
+);
+
+// ── Property 15: Output state persistence after completion ───────────────────
+
+/**
+ * Feature: managed-model-customization, Property 15: Output state persistence after completion
+ *
+ * For any completed job with technique T and training type TT:
+ * - If TT is 'lora', then TUNE_ADAPTER_PATH_<T> SHALL contain the artifact S3 path
+ * - If TT is 'full-rank', then TUNE_MODEL_PATH_<T> SHALL contain the artifact S3 path
+ * - TUNE_OUTPUT_PATH_LATEST SHALL equal the artifact path
+ * - TUNE_OUTPUT_TYPE_LATEST SHALL equal the output type
+ *
+ * Validates: Requirements 8.4, 8.5, 8.6, 8.7
+ */
+describe('Feature: managed-model-customization, Property 15: Output state persistence after completion', () => {
+
+    it('lora completion persists TUNE_ADAPTER_PATH_<T> with artifact path', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArb,
+            artifactPathArb,
+            (technique, artifactPath) => {
+                const tmpDir = mkdtempSync(join(tmpdir(), 'tune-p15-'));
+                const configPath = join(tmpDir, 'config');
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                try {
+                    const outputType = detectOutputType('lora');
+                    persistCompletionState(configPath, {
+                        technique,
+                        trainingType: 'lora',
+                        artifactPath,
+                        outputType
+                    });
+
+                    const techniqueUpper = technique.toUpperCase();
+                    const storedPath = readConfigVar(configPath, `TUNE_ADAPTER_PATH_${techniqueUpper}`);
+
+                    assert.strictEqual(storedPath, artifactPath,
+                        `TUNE_ADAPTER_PATH_${techniqueUpper} must equal artifact path. ` +
+                        `Expected "${artifactPath}", got "${storedPath}"`);
+                } finally {
+                    rmSync(tmpDir, { recursive: true, force: true });
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('full-rank completion persists TUNE_MODEL_PATH_<T> with artifact path', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArb,
+            artifactPathArb,
+            (technique, artifactPath) => {
+                const tmpDir = mkdtempSync(join(tmpdir(), 'tune-p15-'));
+                const configPath = join(tmpDir, 'config');
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                try {
+                    const outputType = detectOutputType('full-rank');
+                    persistCompletionState(configPath, {
+                        technique,
+                        trainingType: 'full-rank',
+                        artifactPath,
+                        outputType
+                    });
+
+                    const techniqueUpper = technique.toUpperCase();
+                    const storedPath = readConfigVar(configPath, `TUNE_MODEL_PATH_${techniqueUpper}`);
+
+                    assert.strictEqual(storedPath, artifactPath,
+                        `TUNE_MODEL_PATH_${techniqueUpper} must equal artifact path. ` +
+                        `Expected "${artifactPath}", got "${storedPath}"`);
+                } finally {
+                    rmSync(tmpDir, { recursive: true, force: true });
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('TUNE_OUTPUT_PATH_LATEST always equals the artifact path regardless of training type', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArb,
+            trainingTypeArbP15,
+            artifactPathArb,
+            (technique, trainingType, artifactPath) => {
+                const tmpDir = mkdtempSync(join(tmpdir(), 'tune-p15-'));
+                const configPath = join(tmpDir, 'config');
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                try {
+                    const outputType = detectOutputType(trainingType);
+                    persistCompletionState(configPath, {
+                        technique,
+                        trainingType,
+                        artifactPath,
+                        outputType
+                    });
+
+                    const latestPath = readConfigVar(configPath, 'TUNE_OUTPUT_PATH_LATEST');
+
+                    assert.strictEqual(latestPath, artifactPath,
+                        'TUNE_OUTPUT_PATH_LATEST must equal artifact path. ' +
+                        `Expected "${artifactPath}", got "${latestPath}"`);
+                } finally {
+                    rmSync(tmpDir, { recursive: true, force: true });
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('TUNE_OUTPUT_TYPE_LATEST equals the detected output type', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArb,
+            trainingTypeArbP15,
+            artifactPathArb,
+            (technique, trainingType, artifactPath) => {
+                const tmpDir = mkdtempSync(join(tmpdir(), 'tune-p15-'));
+                const configPath = join(tmpDir, 'config');
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                try {
+                    const outputType = detectOutputType(trainingType);
+                    persistCompletionState(configPath, {
+                        technique,
+                        trainingType,
+                        artifactPath,
+                        outputType
+                    });
+
+                    const storedType = readConfigVar(configPath, 'TUNE_OUTPUT_TYPE_LATEST');
+                    const expectedType = trainingType === 'lora' ? 'adapter' : 'full-model';
+
+                    assert.strictEqual(storedType, expectedType,
+                        `TUNE_OUTPUT_TYPE_LATEST must equal "${expectedType}" for training type "${trainingType}". ` +
+                        `Got "${storedType}"`);
+                } finally {
+                    rmSync(tmpDir, { recursive: true, force: true });
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('lora does NOT write TUNE_MODEL_PATH and full-rank does NOT write TUNE_ADAPTER_PATH', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArb,
+            trainingTypeArbP15,
+            artifactPathArb,
+            (technique, trainingType, artifactPath) => {
+                const tmpDir = mkdtempSync(join(tmpdir(), 'tune-p15-'));
+                const configPath = join(tmpDir, 'config');
+                writeFileSync(configPath, '#!/bin/bash\n# do/config\n', 'utf8');
+
+                try {
+                    const outputType = detectOutputType(trainingType);
+                    persistCompletionState(configPath, {
+                        technique,
+                        trainingType,
+                        artifactPath,
+                        outputType
+                    });
+
+                    const techniqueUpper = technique.toUpperCase();
+
+                    if (trainingType === 'lora') {
+                        const modelPath = readConfigVar(configPath, `TUNE_MODEL_PATH_${techniqueUpper}`);
+                        assert.strictEqual(modelPath, null,
+                            `TUNE_MODEL_PATH_${techniqueUpper} must NOT be set for lora training type`);
+                    } else {
+                        const adapterPath = readConfigVar(configPath, `TUNE_ADAPTER_PATH_${techniqueUpper}`);
+                        assert.strictEqual(adapterPath, null,
+                            `TUNE_ADAPTER_PATH_${techniqueUpper} must NOT be set for full-rank training type`);
+                    }
+                } finally {
+                    rmSync(tmpDir, { recursive: true, force: true });
+                }
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});
+
+
+// ── Generators for Property 16 ──────────────────────────────────────────────
+
+import { generateNextStepCommands } from '../../src/lib/tune-output-resolver.js';
+
+const outputTypeArb = fc.constantFrom('adapter', 'full-model');
+const techniqueArbP16 = fc.constantFrom('sft', 'dpo', 'rlaif', 'rlvr');
+
+const s3BucketArbP16 = fc.stringMatching(/^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/);
+const s3KeyArbP16 = fc.array(
+    fc.stringMatching(/^[a-zA-Z0-9_-]{1,20}$/),
+    { minLength: 1, maxLength: 4 }
+).map(parts => parts.join('/'));
+
+const artifactPathArbP16 = fc.tuple(s3BucketArbP16, s3KeyArbP16).map(
+    ([bucket, key]) => `s3://${bucket}/${key}/output/model.tar.gz`
+);
+
+// ── Property 16: Context-aware next-step commands ────────────────────────────
+
+/**
+ * Feature: managed-model-customization, Property 16: Context-aware next-step commands
+ *
+ * For any completed job, if `output_type === 'adapter'` then the displayed
+ * next-step commands SHALL include `do/adapter add` with `--from-tune`;
+ * if `output_type === 'full-model'` then the displayed next-step commands
+ * SHALL include `do/add-ic` with `--from-tune`.
+ *
+ * Validates: Requirements 8.11
+ */
+describe('Feature: managed-model-customization, Property 16: Context-aware next-step commands', () => {
+
+    it('adapter output type always includes do/adapter add with --from-tune', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArbP16,
+            artifactPathArbP16,
+            (technique, artifactPath) => {
+                const commands = generateNextStepCommands('adapter', technique, artifactPath);
+
+                const hasAdapterAdd = commands.some(cmd =>
+                    cmd.includes('do/adapter add') && cmd.includes('--from-tune')
+                );
+
+                assert.ok(hasAdapterAdd,
+                    'For adapter output type, at least one command must include "do/adapter add" AND "--from-tune". ' +
+                    `Got commands: ${JSON.stringify(commands)}`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('full-model output type always includes do/add-ic with --from-tune', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArbP16,
+            artifactPathArbP16,
+            (technique, artifactPath) => {
+                const commands = generateNextStepCommands('full-model', technique, artifactPath);
+
+                const hasAddIc = commands.some(cmd =>
+                    cmd.includes('do/add-ic') && cmd.includes('--from-tune')
+                );
+
+                assert.ok(hasAddIc,
+                    'For full-model output type, at least one command must include "do/add-ic" AND "--from-tune". ' +
+                    `Got commands: ${JSON.stringify(commands)}`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('adapter commands include the artifact path in at least one variant', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArbP16,
+            artifactPathArbP16,
+            (technique, artifactPath) => {
+                const commands = generateNextStepCommands('adapter', technique, artifactPath);
+
+                const hasArtifactPath = commands.some(cmd => cmd.includes(artifactPath));
+
+                assert.ok(hasArtifactPath,
+                    `For adapter output, at least one command must include the artifact path "${artifactPath}". ` +
+                    `Got commands: ${JSON.stringify(commands)}`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('full-model commands include the artifact path in at least one variant', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArbP16,
+            artifactPathArbP16,
+            (technique, artifactPath) => {
+                const commands = generateNextStepCommands('full-model', technique, artifactPath);
+
+                const hasArtifactPath = commands.some(cmd => cmd.includes(artifactPath));
+
+                assert.ok(hasArtifactPath,
+                    `For full-model output, at least one command must include the artifact path "${artifactPath}". ` +
+                    `Got commands: ${JSON.stringify(commands)}`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('adapter commands include the technique name', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            techniqueArbP16,
+            artifactPathArbP16,
+            (technique, artifactPath) => {
+                const commands = generateNextStepCommands('adapter', technique, artifactPath);
+
+                const hasTechnique = commands.some(cmd => cmd.includes(technique));
+
+                assert.ok(hasTechnique,
+                    `For adapter output, at least one command must include the technique name "${technique}". ` +
+                    `Got commands: ${JSON.stringify(commands)}`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+
+    it('for any output type, generateNextStepCommands returns a non-empty array', function () {
+        this.timeout(PROPERTY_CONFIG.timeout);
+        fc.assert(fc.property(
+            outputTypeArb,
+            techniqueArbP16,
+            artifactPathArbP16,
+            (outputType, technique, artifactPath) => {
+                const commands = generateNextStepCommands(outputType, technique, artifactPath);
+
+                assert.ok(Array.isArray(commands) && commands.length > 0,
+                    `generateNextStepCommands must return a non-empty array for output type "${outputType}". ` +
+                    `Got: ${JSON.stringify(commands)}`);
+            }
+        ), { numRuns: PROPERTY_CONFIG.numRuns, verbose: PROPERTY_CONFIG.verbose });
+    });
+});

--- a/test/unit/bootstrap-non-interactive.test.js
+++ b/test/unit/bootstrap-non-interactive.test.js
@@ -113,6 +113,12 @@ function setupHandler(_opts = {}) {
     // Mock _verifyCliV2 to skip real CLI version check in tests
     handler._verifyCliV2 = () => true;
 
+    // Mock _execAws to prevent real AWS CLI calls (e.g., cloudformation list-stacks)
+    handler._execAws = () => [];
+
+    // Mock _displayProgress to prevent output noise
+    handler._displayProgress = () => {};
+
     const restore = () => { console.log = origLog; };
 
     return { handler, calls, logs, restore, promptCalls, configPath };

--- a/test/unit/bootstrap-non-interactive.test.js
+++ b/test/unit/bootstrap-non-interactive.test.js
@@ -129,7 +129,8 @@ describe('Bootstrap Non-Interactive Mode', () => {
     });
 
     describe('when --non-interactive is set with all required flags', () => {
-        it('should not prompt for any input', async () => {
+        it('should not prompt for any input', async function () {
+            this.timeout(10000);
             const { handler, calls, restore, promptCalls } = setupHandler();
             restoreFn = restore;
 

--- a/test/unit/bootstrap-tune-resources.test.js
+++ b/test/unit/bootstrap-tune-resources.test.js
@@ -1,0 +1,313 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Bootstrap Stack — Tune Resources Validation
+ *
+ * Validates that the bootstrap CloudFormation template contains the required
+ * resources and IAM permissions for the managed model customization (tune) feature:
+ * - TuneS3Bucket resource with correct properties
+ * - SageMakerModelCustomization IAM statement with all required actions
+ * - SageMakerMLflow IAM statement with sagemaker-mlflow:*
+ * - LambdaInvokeForReward IAM statement with lambda:InvokeFunction
+ * - PassRoleToSageMaker IAM statement with iam:PassRole
+ * - TuneS3BucketName output
+ *
+ * Validates: Requirements 10.1, 10.2, 10.3, 10.4, 10.6, 10.7, 10.8
+ */
+
+import { describe, it, before } from 'mocha';
+import assert from 'assert';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('Bootstrap Stack — Tune Resources', () => {
+    let template;
+    let resources;
+    let outputs;
+    let conditions;
+    let policyStatements;
+
+    before(() => {
+        const templatePath = resolve(__dirname, '../../config/bootstrap-stack.json');
+        template = JSON.parse(readFileSync(templatePath, 'utf8'));
+        resources = template.Resources;
+        outputs = template.Outputs;
+        conditions = template.Conditions;
+
+        // Extract IAM policy statements from SageMakerExecutionRole
+        const role = resources.SageMakerExecutionRole;
+        const policy = role.Properties.Policies[0];
+        policyStatements = policy.PolicyDocument.Statement;
+    });
+
+    describe('TuneS3Bucket resource', () => {
+        it('should exist in the template', () => {
+            assert.ok(
+                resources.TuneS3Bucket,
+                'TuneS3Bucket resource should exist'
+            );
+        });
+
+        it('should be of type AWS::S3::Bucket', () => {
+            assert.strictEqual(
+                resources.TuneS3Bucket.Type,
+                'AWS::S3::Bucket',
+                'TuneS3Bucket should be an S3 bucket'
+            );
+        });
+
+        it('should be gated on ShouldCreateS3Buckets condition', () => {
+            assert.strictEqual(
+                resources.TuneS3Bucket.Condition,
+                'ShouldCreateS3Buckets',
+                'TuneS3Bucket should have Condition: ShouldCreateS3Buckets'
+            );
+        });
+
+        it('should have correct bucket name pattern (mlcc-tune-${AccountId}-${Region})', () => {
+            const bucketName = resources.TuneS3Bucket.Properties.BucketName;
+            assert.ok(bucketName['Fn::Sub'], 'BucketName should use Fn::Sub');
+            assert.strictEqual(
+                bucketName['Fn::Sub'],
+                'mlcc-tune-${AWS::AccountId}-${AWS::Region}',
+                'BucketName should follow mlcc-tune-${AccountId}-${Region} pattern'
+            );
+        });
+
+        it('should have versioning enabled', () => {
+            const versioning = resources.TuneS3Bucket.Properties.VersioningConfiguration;
+            assert.ok(versioning, 'VersioningConfiguration should exist');
+            assert.strictEqual(
+                versioning.Status,
+                'Enabled',
+                'Versioning should be enabled'
+            );
+        });
+
+        it('should have AES256 server-side encryption', () => {
+            const encryption = resources.TuneS3Bucket.Properties.BucketEncryption;
+            assert.ok(encryption, 'BucketEncryption should exist');
+
+            const sseConfig = encryption.ServerSideEncryptionConfiguration;
+            assert.ok(Array.isArray(sseConfig), 'ServerSideEncryptionConfiguration should be an array');
+            assert.ok(sseConfig.length > 0, 'Should have at least one encryption rule');
+
+            const algorithm = sseConfig[0].ServerSideEncryptionByDefault.SSEAlgorithm;
+            assert.strictEqual(algorithm, 'AES256', 'Should use AES256 encryption');
+        });
+
+        it('should have DeletionPolicy set to Retain', () => {
+            assert.strictEqual(
+                resources.TuneS3Bucket.DeletionPolicy,
+                'Retain',
+                'DeletionPolicy should be Retain'
+            );
+        });
+    });
+
+    describe('ShouldCreateS3Buckets condition', () => {
+        it('should exist in the template', () => {
+            assert.ok(
+                conditions.ShouldCreateS3Buckets,
+                'ShouldCreateS3Buckets condition should exist'
+            );
+        });
+
+        it('should check CreateS3Buckets parameter equals "true"', () => {
+            const condition = conditions.ShouldCreateS3Buckets;
+            assert.ok(condition['Fn::Equals'], 'Should use Fn::Equals');
+
+            const equalsArgs = condition['Fn::Equals'];
+            assert.strictEqual(equalsArgs.length, 2, 'Fn::Equals should have two arguments');
+
+            // One arg should reference CreateS3Buckets, the other should be "true"
+            const refArg = equalsArgs.find(a => a.Ref === 'CreateS3Buckets');
+            assert.ok(refArg, 'Should reference CreateS3Buckets parameter');
+            assert.ok(
+                equalsArgs.includes('true'),
+                'Should compare against "true"'
+            );
+        });
+    });
+
+    describe('SageMakerModelCustomization IAM statement', () => {
+        let statement;
+
+        before(() => {
+            statement = policyStatements.find(s => s.Sid === 'SageMakerModelCustomization');
+        });
+
+        it('should exist', () => {
+            assert.ok(statement, 'SageMakerModelCustomization statement should exist');
+        });
+
+        it('should have Effect: Allow', () => {
+            assert.strictEqual(statement.Effect, 'Allow');
+        });
+
+        it('should include all required SageMaker actions', () => {
+            const requiredActions = [
+                'sagemaker:CreateTrainingJob',
+                'sagemaker:DescribeTrainingJob',
+                'sagemaker:ListTrainingJobs',
+                'sagemaker:StopTrainingJob',
+                'sagemaker:CreateModelPackage',
+                'sagemaker:CreateModelPackageGroup',
+                'sagemaker:DescribeModelPackage',
+                'sagemaker:DescribeModelPackageGroup',
+                'sagemaker:ListModelPackages',
+                'sagemaker:CallMlflowAppApi'
+            ];
+
+            for (const action of requiredActions) {
+                assert.ok(
+                    statement.Action.includes(action),
+                    `Should include action: ${action}`
+                );
+            }
+        });
+
+        it('should have Resource: "*"', () => {
+            assert.strictEqual(statement.Resource, '*');
+        });
+    });
+
+    describe('SageMakerMLflow IAM statement', () => {
+        let statement;
+
+        before(() => {
+            statement = policyStatements.find(s => s.Sid === 'SageMakerMLflow');
+        });
+
+        it('should exist', () => {
+            assert.ok(statement, 'SageMakerMLflow statement should exist');
+        });
+
+        it('should have Effect: Allow', () => {
+            assert.strictEqual(statement.Effect, 'Allow');
+        });
+
+        it('should grant sagemaker-mlflow:* action', () => {
+            assert.strictEqual(
+                statement.Action,
+                'sagemaker-mlflow:*',
+                'Should grant sagemaker-mlflow:* action'
+            );
+        });
+
+        it('should have Resource: "*"', () => {
+            assert.strictEqual(statement.Resource, '*');
+        });
+    });
+
+    describe('LambdaInvokeForReward IAM statement', () => {
+        let statement;
+
+        before(() => {
+            statement = policyStatements.find(s => s.Sid === 'LambdaInvokeForReward');
+        });
+
+        it('should exist', () => {
+            assert.ok(statement, 'LambdaInvokeForReward statement should exist');
+        });
+
+        it('should have Effect: Allow', () => {
+            assert.strictEqual(statement.Effect, 'Allow');
+        });
+
+        it('should grant lambda:InvokeFunction action', () => {
+            assert.strictEqual(
+                statement.Action,
+                'lambda:InvokeFunction',
+                'Should grant lambda:InvokeFunction action'
+            );
+        });
+
+        it('should scope resource to Lambda functions in the account', () => {
+            const resource = statement.Resource;
+            assert.ok(resource['Fn::Sub'], 'Resource should use Fn::Sub');
+            assert.ok(
+                resource['Fn::Sub'].includes('arn:aws:lambda:'),
+                'Resource ARN should reference Lambda service'
+            );
+            assert.ok(
+                resource['Fn::Sub'].includes(':function:*'),
+                'Resource ARN should scope to functions'
+            );
+        });
+    });
+
+    describe('PassRoleToSageMaker IAM statement', () => {
+        let statement;
+
+        before(() => {
+            statement = policyStatements.find(s => s.Sid === 'PassRoleToSageMaker');
+        });
+
+        it('should exist', () => {
+            assert.ok(statement, 'PassRoleToSageMaker statement should exist');
+        });
+
+        it('should have Effect: Allow', () => {
+            assert.strictEqual(statement.Effect, 'Allow');
+        });
+
+        it('should grant iam:PassRole action', () => {
+            assert.strictEqual(
+                statement.Action,
+                'iam:PassRole',
+                'Should grant iam:PassRole action'
+            );
+        });
+
+        it('should have a condition restricting to sagemaker.amazonaws.com', () => {
+            assert.ok(statement.Condition, 'Should have a Condition');
+            assert.ok(
+                statement.Condition.StringEquals,
+                'Should use StringEquals condition'
+            );
+            assert.strictEqual(
+                statement.Condition.StringEquals['iam:PassedToService'],
+                'sagemaker.amazonaws.com',
+                'Should restrict PassRole to sagemaker.amazonaws.com'
+            );
+        });
+    });
+
+    describe('TuneS3BucketName output', () => {
+        it('should exist', () => {
+            assert.ok(
+                outputs.TuneS3BucketName,
+                'TuneS3BucketName output should exist'
+            );
+        });
+
+        it('should be gated on ShouldCreateS3Buckets condition', () => {
+            assert.strictEqual(
+                outputs.TuneS3BucketName.Condition,
+                'ShouldCreateS3Buckets',
+                'TuneS3BucketName output should have Condition: ShouldCreateS3Buckets'
+            );
+        });
+
+        it('should reference the TuneS3Bucket resource', () => {
+            const value = outputs.TuneS3BucketName.Value;
+            assert.ok(
+                value.Ref === 'TuneS3Bucket',
+                'TuneS3BucketName output should reference TuneS3Bucket'
+            );
+        });
+
+        it('should have a description', () => {
+            assert.ok(
+                outputs.TuneS3BucketName.Description,
+                'TuneS3BucketName output should have a description'
+            );
+        });
+    });
+});

--- a/test/unit/tune-dataset-validator.test.js
+++ b/test/unit/tune-dataset-validator.test.js
@@ -1,0 +1,320 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for tune dataset validator.
+ *
+ * Tests:
+ * - parseDatasetArg correctly parses S3 URIs
+ * - parseDatasetArg correctly parses HF references
+ * - parseDatasetArg rejects invalid formats
+ * - validateDatasetFormat accepts valid JSONL
+ * - validateDatasetFormat rejects invalid JSONL
+ * - validateDatasetFormat inspects only first 10 lines
+ *
+ * Validates: Requirements 3.1, 3.5, 3.6, 3.7, 3.8, 3.10, 3.11, 3.12
+ */
+
+import { describe, it } from 'mocha';
+import assert from 'assert';
+import { parseDatasetArg, validateDatasetFormat } from '../../src/lib/tune-dataset-validator.js';
+
+// ── parseDatasetArg Tests ────────────────────────────────────────────────────
+
+describe('parseDatasetArg', () => {
+    describe('S3 URIs', () => {
+        it('parses a simple S3 URI', () => {
+            const result = parseDatasetArg('s3://my-bucket/train.jsonl');
+            assert.deepStrictEqual(result, {
+                valid: true,
+                type: 's3',
+                bucket: 'my-bucket',
+                key: 'train.jsonl'
+            });
+        });
+
+        it('parses an S3 URI with nested path', () => {
+            const result = parseDatasetArg('s3://my-bucket/path/to/dataset.jsonl');
+            assert.deepStrictEqual(result, {
+                valid: true,
+                type: 's3',
+                bucket: 'my-bucket',
+                key: 'path/to/dataset.jsonl'
+            });
+        });
+
+        it('rejects S3 URI without key', () => {
+            const result = parseDatasetArg('s3://my-bucket/');
+            assert.strictEqual(result.valid, false);
+            assert.ok(result.error.includes('Key path is empty'));
+        });
+
+        it('rejects S3 URI without bucket', () => {
+            const result = parseDatasetArg('s3:///key');
+            assert.strictEqual(result.valid, false);
+        });
+
+        it('rejects S3 URI with only scheme', () => {
+            const result = parseDatasetArg('s3://bucket');
+            assert.strictEqual(result.valid, false);
+            assert.ok(result.error.includes('s3://bucket/key'));
+        });
+    });
+
+    describe('Hugging Face references', () => {
+        it('parses HF reference with org and name', () => {
+            const result = parseDatasetArg('hf://my-org/my-dataset');
+            assert.deepStrictEqual(result, {
+                valid: true,
+                type: 'hf',
+                org: 'my-org',
+                name: 'my-dataset',
+                split: 'train'
+            });
+        });
+
+        it('parses HF reference with explicit split', () => {
+            const result = parseDatasetArg('hf://my-org/my-dataset/validation');
+            assert.deepStrictEqual(result, {
+                valid: true,
+                type: 'hf',
+                org: 'my-org',
+                name: 'my-dataset',
+                split: 'validation'
+            });
+        });
+
+        it('defaults to train split when not specified', () => {
+            const result = parseDatasetArg('hf://org/name');
+            assert.strictEqual(result.split, 'train');
+        });
+
+        it('rejects HF reference without name', () => {
+            const result = parseDatasetArg('hf://org-only');
+            assert.strictEqual(result.valid, false);
+            assert.ok(result.error.includes('hf://org/name'));
+        });
+
+        it('rejects HF reference with empty org', () => {
+            const result = parseDatasetArg('hf:///name');
+            assert.strictEqual(result.valid, false);
+        });
+    });
+
+    describe('invalid inputs', () => {
+        it('rejects empty string', () => {
+            const result = parseDatasetArg('');
+            assert.strictEqual(result.valid, false);
+        });
+
+        it('rejects null', () => {
+            const result = parseDatasetArg(null);
+            assert.strictEqual(result.valid, false);
+        });
+
+        it('rejects undefined', () => {
+            const result = parseDatasetArg(undefined);
+            assert.strictEqual(result.valid, false);
+        });
+
+        it('rejects unknown scheme', () => {
+            const result = parseDatasetArg('gs://bucket/key');
+            assert.strictEqual(result.valid, false);
+            assert.ok(result.error.includes('Expected s3://'));
+        });
+
+        it('rejects plain path', () => {
+            const result = parseDatasetArg('/local/path/data.jsonl');
+            assert.strictEqual(result.valid, false);
+        });
+    });
+});
+
+// ── validateDatasetFormat Tests ──────────────────────────────────────────────
+
+describe('validateDatasetFormat', () => {
+    const sftSchema = {
+        required: ['prompt', 'completion'],
+        types: { prompt: 'string', completion: 'string' }
+    };
+
+    const dpoSchema = {
+        required: ['prompt', 'chosen', 'rejected'],
+        types: { prompt: 'string', chosen: 'string', rejected: 'string' }
+    };
+
+    const rlvrSchema = {
+        required: ['prompt', 'reward_model'],
+        types: { prompt: 'array', reward_model: 'string' }
+    };
+
+    describe('valid datasets', () => {
+        it('accepts valid SFT JSONL', () => {
+            const lines = [
+                '{"prompt": "What is AI?", "completion": "AI is artificial intelligence."}',
+                '{"prompt": "Hello", "completion": "Hi there!"}'
+            ];
+            const result = validateDatasetFormat(lines, sftSchema);
+            assert.strictEqual(result.valid, true);
+            assert.strictEqual(result.error, null);
+            assert.strictEqual(result.lineNumber, null);
+            assert.strictEqual(result.malformedLine, null);
+        });
+
+        it('accepts valid DPO JSONL', () => {
+            const lines = [
+                '{"prompt": "Explain X", "chosen": "Good answer", "rejected": "Bad answer"}'
+            ];
+            const result = validateDatasetFormat(lines, dpoSchema);
+            assert.strictEqual(result.valid, true);
+        });
+
+        it('accepts valid RLVR JSONL with array prompt', () => {
+            const lines = [
+                '{"prompt": [{"role": "user", "content": "Solve 2+2"}], "reward_model": "arn:aws:lambda:us-east-1:123:function:reward"}'
+            ];
+            const result = validateDatasetFormat(lines, rlvrSchema);
+            assert.strictEqual(result.valid, true);
+        });
+
+        it('accepts lines with extra keys beyond required', () => {
+            const lines = [
+                '{"prompt": "Q", "completion": "A", "metadata": {"source": "test"}}'
+            ];
+            const result = validateDatasetFormat(lines, sftSchema);
+            assert.strictEqual(result.valid, true);
+        });
+
+        it('skips empty lines', () => {
+            const lines = [
+                '{"prompt": "Q", "completion": "A"}',
+                '',
+                '{"prompt": "Q2", "completion": "A2"}'
+            ];
+            const result = validateDatasetFormat(lines, sftSchema);
+            assert.strictEqual(result.valid, true);
+        });
+    });
+
+    describe('invalid datasets — missing keys', () => {
+        it('reports missing required key', () => {
+            const lines = [
+                '{"prompt": "What is AI?"}'
+            ];
+            const result = validateDatasetFormat(lines, sftSchema);
+            assert.strictEqual(result.valid, false);
+            assert.strictEqual(result.lineNumber, 1);
+            assert.ok(result.error.includes('missing required key "completion"'));
+            assert.strictEqual(result.malformedLine, lines[0]);
+            assert.ok(result.expectedFormat.includes('prompt'));
+            assert.ok(result.expectedFormat.includes('completion'));
+        });
+
+        it('reports first malformed line when error is on line 3', () => {
+            const lines = [
+                '{"prompt": "Q1", "completion": "A1"}',
+                '{"prompt": "Q2", "completion": "A2"}',
+                '{"prompt": "Q3"}'
+            ];
+            const result = validateDatasetFormat(lines, sftSchema);
+            assert.strictEqual(result.valid, false);
+            assert.strictEqual(result.lineNumber, 3);
+            assert.ok(result.error.includes('Line 3'));
+        });
+    });
+
+    describe('invalid datasets — wrong types', () => {
+        it('reports wrong type for string field', () => {
+            const lines = [
+                '{"prompt": 123, "completion": "A"}'
+            ];
+            const result = validateDatasetFormat(lines, sftSchema);
+            assert.strictEqual(result.valid, false);
+            assert.ok(result.error.includes('wrong type'));
+            assert.ok(result.error.includes('"string"'));
+            assert.ok(result.error.includes('"number"'));
+        });
+
+        it('reports wrong type for array field', () => {
+            const lines = [
+                '{"prompt": "not an array", "reward_model": "arn"}'
+            ];
+            const result = validateDatasetFormat(lines, rlvrSchema);
+            assert.strictEqual(result.valid, false);
+            assert.ok(result.error.includes('wrong type'));
+            assert.ok(result.error.includes('"array"'));
+        });
+    });
+
+    describe('invalid datasets — malformed JSON', () => {
+        it('reports invalid JSON', () => {
+            const lines = [
+                'not json at all'
+            ];
+            const result = validateDatasetFormat(lines, sftSchema);
+            assert.strictEqual(result.valid, false);
+            assert.strictEqual(result.lineNumber, 1);
+            assert.ok(result.error.includes('not valid JSON'));
+            assert.strictEqual(result.malformedLine, 'not json at all');
+        });
+
+        it('reports non-object JSON (array)', () => {
+            const lines = [
+                '[1, 2, 3]'
+            ];
+            const result = validateDatasetFormat(lines, sftSchema);
+            assert.strictEqual(result.valid, false);
+            assert.ok(result.error.includes('must be a JSON object'));
+        });
+
+        it('reports non-object JSON (null)', () => {
+            const lines = ['null'];
+            const result = validateDatasetFormat(lines, sftSchema);
+            assert.strictEqual(result.valid, false);
+            assert.ok(result.error.includes('must be a JSON object'));
+        });
+    });
+
+    describe('10-line inspection limit', () => {
+        it('only inspects first 10 lines', () => {
+            const validLines = Array.from({ length: 10 }, (_, i) =>
+                `{"prompt": "Q${i}", "completion": "A${i}"}`
+            );
+            // Line 11 is invalid but should not be inspected
+            const invalidLine = '{"prompt": "missing completion"}';
+            const lines = [...validLines, invalidLine];
+
+            const result = validateDatasetFormat(lines, sftSchema);
+            assert.strictEqual(result.valid, true);
+        });
+
+        it('catches error on line 10', () => {
+            const validLines = Array.from({ length: 9 }, (_, i) =>
+                `{"prompt": "Q${i}", "completion": "A${i}"}`
+            );
+            const invalidLine = '{"prompt": "missing completion"}';
+            const lines = [...validLines, invalidLine];
+
+            const result = validateDatasetFormat(lines, sftSchema);
+            assert.strictEqual(result.valid, false);
+            assert.strictEqual(result.lineNumber, 10);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('returns error for null lines', () => {
+            const result = validateDatasetFormat(null, sftSchema);
+            assert.strictEqual(result.valid, false);
+        });
+
+        it('returns error for missing schema', () => {
+            const result = validateDatasetFormat(['{}'], null);
+            assert.strictEqual(result.valid, false);
+        });
+
+        it('accepts empty lines array', () => {
+            const result = validateDatasetFormat([], sftSchema);
+            assert.strictEqual(result.valid, true);
+        });
+    });
+});

--- a/test/unit/tune-helper-dispatch.test.js
+++ b/test/unit/tune-helper-dispatch.test.js
@@ -1,0 +1,563 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for Python helper (.tune_helper.py) subcommand dispatch.
+ *
+ * Tests:
+ * - Each subcommand (submit, status, resolve, stage-hf, validate) is correctly routed
+ * - JSON output format for each subcommand
+ * - Error handling for missing SDK
+ * - Unknown commands produce errors
+ * - Missing required args produce errors
+ *
+ * Validates: Requirements 5.1, 5.2
+ */
+
+import { describe, it } from 'mocha';
+import assert from 'assert';
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+import os from 'os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const HELPER_PATH = path.resolve(__dirname, '../../templates/do/.tune_helper.py');
+
+/**
+ * Run the Python helper with given args and return the result.
+ */
+function runHelper(args, options = {}) {
+    const result = spawnSync('python3', [HELPER_PATH, ...args], {
+        encoding: 'utf-8',
+        timeout: 10000,
+        env: { ...process.env, ...options.env },
+        input: options.input || undefined
+    });
+    return {
+        stdout: result.stdout || '',
+        stderr: result.stderr || '',
+        exitCode: result.status
+    };
+}
+
+/**
+ * Parse JSON from stdout, returning null if parsing fails.
+ */
+function parseOutput(stdout) {
+    try {
+        return JSON.parse(stdout.trim());
+    } catch {
+        return null;
+    }
+}
+
+// ── Subcommand Recognition ───────────────────────────────────────────────────
+
+describe('tune_helper.py subcommand dispatch', () => {
+    before(function () {
+        // Skip all tests if python3 is not available
+        const result = spawnSync('python3', ['--version'], { encoding: 'utf-8' });
+        if (result.status !== 0) {
+            this.skip();
+        }
+        // Verify the helper script exists
+        if (!fs.existsSync(HELPER_PATH)) {
+            this.skip();
+        }
+    });
+
+    describe('subcommand recognition', () => {
+        it('recognizes the submit subcommand', () => {
+            // submit requires args, so missing args should produce an error exit
+            // but the subcommand itself should be recognized (not "unknown command")
+            const result = runHelper(['submit']);
+            // argparse exits with code 2 for missing required args
+            assert.strictEqual(result.exitCode, 2);
+            assert.ok(result.stderr.includes('--model-id'),
+                'should mention required --model-id arg');
+        });
+
+        it('recognizes the status subcommand', () => {
+            const result = runHelper(['status']);
+            assert.strictEqual(result.exitCode, 2);
+            assert.ok(result.stderr.includes('--job-name'),
+                'should mention required --job-name arg');
+        });
+
+        it('recognizes the resolve subcommand', () => {
+            const result = runHelper(['resolve']);
+            assert.strictEqual(result.exitCode, 2);
+            assert.ok(result.stderr.includes('--job-name'),
+                'should mention required --job-name arg');
+        });
+
+        it('recognizes the stage-hf subcommand', () => {
+            const result = runHelper(['stage-hf']);
+            assert.strictEqual(result.exitCode, 2);
+            assert.ok(result.stderr.includes('--hf-org'),
+                'should mention required --hf-org arg');
+        });
+
+        it('recognizes the validate subcommand', () => {
+            const result = runHelper(['validate']);
+            assert.strictEqual(result.exitCode, 2);
+            assert.ok(result.stderr.includes('--schema'),
+                'should mention required --schema arg');
+        });
+    });
+
+    // ── Unknown Commands ─────────────────────────────────────────────────────
+
+    describe('unknown commands', () => {
+        it('exits with error when no subcommand is given', () => {
+            const result = runHelper([]);
+            assert.notStrictEqual(result.exitCode, 0);
+        });
+
+        it('exits with error for unknown subcommand', () => {
+            const result = runHelper(['unknown-cmd']);
+            assert.notStrictEqual(result.exitCode, 0);
+        });
+
+        it('exits with error for misspelled subcommand', () => {
+            const result = runHelper(['submitt']);
+            assert.notStrictEqual(result.exitCode, 0);
+        });
+    });
+
+    // ── Missing Required Args ────────────────────────────────────────────────
+
+    describe('missing required arguments', () => {
+        it('submit requires --model-id, --technique, --training-type, --dataset-s3-uri, --output-bucket, --role-arn, --job-name, --project-name', () => {
+            const result = runHelper(['submit', '--model-id', 'test-model']);
+            assert.strictEqual(result.exitCode, 2);
+            assert.ok(result.stderr.includes('--technique'),
+                'should mention missing --technique');
+        });
+
+        it('status requires --job-name and --region', () => {
+            const result = runHelper(['status', '--job-name', 'test-job']);
+            assert.strictEqual(result.exitCode, 2);
+            assert.ok(result.stderr.includes('--region'),
+                'should mention missing --region');
+        });
+
+        it('resolve requires --job-name, --region, and --training-type', () => {
+            const result = runHelper(['resolve', '--job-name', 'test-job', '--region', 'us-east-1']);
+            assert.strictEqual(result.exitCode, 2);
+            assert.ok(result.stderr.includes('--training-type'),
+                'should mention missing --training-type');
+        });
+
+        it('stage-hf requires --hf-org, --hf-name, --output-bucket, --project-name, --region', () => {
+            const result = runHelper(['stage-hf', '--hf-org', 'test-org']);
+            assert.strictEqual(result.exitCode, 2);
+            assert.ok(result.stderr.includes('--hf-name'),
+                'should mention missing --hf-name');
+        });
+
+        it('validate requires --schema', () => {
+            const result = runHelper(['validate']);
+            assert.strictEqual(result.exitCode, 2);
+            assert.ok(result.stderr.includes('--schema'),
+                'should mention missing --schema');
+        });
+    });
+
+    // ── Validate Subcommand (end-to-end, no SDK needed) ──────────────────────
+
+    describe('validate subcommand — end-to-end', () => {
+        const sftSchema = JSON.stringify({
+            required: ['prompt', 'completion'],
+            types: { prompt: 'string', completion: 'string' }
+        });
+
+        const dpoSchema = JSON.stringify({
+            required: ['prompt', 'chosen', 'rejected'],
+            types: { prompt: 'string', chosen: 'string', rejected: 'string' }
+        });
+
+        it('validates a correct SFT dataset from stdin', () => {
+            const input = [
+                '{"prompt": "What is AI?", "completion": "Artificial intelligence."}',
+                '{"prompt": "Hello", "completion": "Hi there!"}'
+            ].join('\n');
+
+            const result = runHelper(
+                ['validate', '--schema', sftSchema],
+                { input }
+            );
+            assert.strictEqual(result.exitCode, 0);
+            const output = parseOutput(result.stdout);
+            assert.notStrictEqual(output, null, 'should produce valid JSON output');
+            assert.strictEqual(output.valid, true);
+            assert.strictEqual(output.error, null);
+            assert.strictEqual(output.line_number, null);
+            assert.strictEqual(output.malformed_line, null);
+        });
+
+        it('validates a correct DPO dataset from stdin', () => {
+            const input = '{"prompt": "Explain X", "chosen": "Good", "rejected": "Bad"}\n';
+            const result = runHelper(
+                ['validate', '--schema', dpoSchema],
+                { input }
+            );
+            assert.strictEqual(result.exitCode, 0);
+            const output = parseOutput(result.stdout);
+            assert.strictEqual(output.valid, true);
+        });
+
+        it('reports missing required key', () => {
+            const input = '{"prompt": "What is AI?"}\n';
+            const result = runHelper(
+                ['validate', '--schema', sftSchema],
+                { input }
+            );
+            assert.strictEqual(result.exitCode, 0);
+            const output = parseOutput(result.stdout);
+            assert.strictEqual(output.valid, false);
+            assert.ok(output.error.includes('missing required key "completion"'));
+            assert.strictEqual(output.line_number, 1);
+            assert.ok(output.malformed_line.includes('"prompt"'));
+        });
+
+        it('reports wrong type for a field', () => {
+            const input = '{"prompt": 123, "completion": "A"}\n';
+            const result = runHelper(
+                ['validate', '--schema', sftSchema],
+                { input }
+            );
+            assert.strictEqual(result.exitCode, 0);
+            const output = parseOutput(result.stdout);
+            assert.strictEqual(output.valid, false);
+            assert.ok(output.error.includes('wrong type'));
+            assert.ok(output.error.includes('"string"'));
+            assert.ok(output.error.includes('"number"'));
+        });
+
+        it('reports invalid JSON on a line', () => {
+            const input = 'not valid json\n';
+            const result = runHelper(
+                ['validate', '--schema', sftSchema],
+                { input }
+            );
+            assert.strictEqual(result.exitCode, 0);
+            const output = parseOutput(result.stdout);
+            assert.strictEqual(output.valid, false);
+            assert.ok(output.error.includes('not valid JSON'));
+            assert.strictEqual(output.line_number, 1);
+            assert.strictEqual(output.malformed_line, 'not valid json');
+        });
+
+        it('reports non-object JSON (array)', () => {
+            const input = '[1, 2, 3]\n';
+            const result = runHelper(
+                ['validate', '--schema', sftSchema],
+                { input }
+            );
+            assert.strictEqual(result.exitCode, 0);
+            const output = parseOutput(result.stdout);
+            assert.strictEqual(output.valid, false);
+            assert.ok(output.error.includes('must be a JSON object'));
+        });
+
+        it('reports error on correct line number', () => {
+            const input = [
+                '{"prompt": "Q1", "completion": "A1"}',
+                '{"prompt": "Q2", "completion": "A2"}',
+                '{"prompt": "Q3"}'
+            ].join('\n');
+
+            const result = runHelper(
+                ['validate', '--schema', sftSchema],
+                { input }
+            );
+            assert.strictEqual(result.exitCode, 0);
+            const output = parseOutput(result.stdout);
+            assert.strictEqual(output.valid, false);
+            assert.strictEqual(output.line_number, 3);
+            assert.ok(output.error.includes('Line 3'));
+        });
+
+        it('only inspects first 10 lines', () => {
+            const validLines = Array.from({ length: 10 }, (_, i) =>
+                `{"prompt": "Q${i}", "completion": "A${i}"}`
+            );
+            // Line 11 is invalid but should not be inspected
+            const input = [...validLines, '{"prompt": "missing"}'].join('\n');
+
+            const result = runHelper(
+                ['validate', '--schema', sftSchema],
+                { input }
+            );
+            assert.strictEqual(result.exitCode, 0);
+            const output = parseOutput(result.stdout);
+            assert.strictEqual(output.valid, true);
+        });
+
+        it('validates from a file using --file flag', () => {
+            const tmpFile = path.join(os.tmpdir(), 'tune-test-dataset.jsonl');
+            fs.writeFileSync(tmpFile, [
+                '{"prompt": "Q1", "completion": "A1"}',
+                '{"prompt": "Q2", "completion": "A2"}'
+            ].join('\n'));
+
+            try {
+                const result = runHelper([
+                    'validate', '--schema', sftSchema, '--file', tmpFile
+                ]);
+                assert.strictEqual(result.exitCode, 0);
+                const output = parseOutput(result.stdout);
+                assert.strictEqual(output.valid, true);
+            } finally {
+                fs.unlinkSync(tmpFile);
+            }
+        });
+
+        it('reports error for non-existent file', () => {
+            const result = runHelper([
+                'validate', '--schema', sftSchema, '--file', '/tmp/nonexistent-dataset-xyz.jsonl'
+            ]);
+            assert.strictEqual(result.exitCode, 1);
+            const output = parseOutput(result.stdout);
+            assert.ok(output.error.includes('not found'));
+        });
+
+        it('reports error for invalid schema JSON', () => {
+            const result = runHelper(
+                ['validate', '--schema', 'not-json'],
+                { input: '{"prompt": "Q", "completion": "A"}\n' }
+            );
+            assert.strictEqual(result.exitCode, 1);
+            const output = parseOutput(result.stdout);
+            assert.ok(output.error.includes('Invalid schema JSON'));
+        });
+
+        it('includes expected_format in error output', () => {
+            const input = '{"prompt": "Q"}\n';
+            const result = runHelper(
+                ['validate', '--schema', sftSchema],
+                { input }
+            );
+            assert.strictEqual(result.exitCode, 0);
+            const output = parseOutput(result.stdout);
+            assert.strictEqual(output.valid, false);
+            assert.ok(output.expected_format !== undefined,
+                'should include expected_format field');
+            assert.ok(output.expected_format.includes('prompt'));
+            assert.ok(output.expected_format.includes('completion'));
+        });
+
+        it('skips empty lines during validation', () => {
+            const input = [
+                '{"prompt": "Q1", "completion": "A1"}',
+                '',
+                '{"prompt": "Q2", "completion": "A2"}'
+            ].join('\n');
+
+            const result = runHelper(
+                ['validate', '--schema', sftSchema],
+                { input }
+            );
+            assert.strictEqual(result.exitCode, 0);
+            const output = parseOutput(result.stdout);
+            assert.strictEqual(output.valid, true);
+        });
+    });
+
+    // ── JSON Output Format ───────────────────────────────────────────────────
+
+    describe('JSON output format', () => {
+        it('validate success output has correct structure', () => {
+            const schema = JSON.stringify({
+                required: ['prompt', 'completion'],
+                types: { prompt: 'string', completion: 'string' }
+            });
+            const input = '{"prompt": "Q", "completion": "A"}\n';
+
+            const result = runHelper(
+                ['validate', '--schema', schema],
+                { input }
+            );
+            const output = parseOutput(result.stdout);
+            assert.notStrictEqual(output, null);
+            assert.ok('valid' in output, 'should have valid field');
+            assert.ok('error' in output, 'should have error field');
+            assert.ok('line_number' in output, 'should have line_number field');
+            assert.ok('malformed_line' in output, 'should have malformed_line field');
+        });
+
+        it('validate error output has correct structure', () => {
+            const schema = JSON.stringify({
+                required: ['prompt', 'completion'],
+                types: { prompt: 'string', completion: 'string' }
+            });
+            const input = '{"prompt": "Q"}\n';
+
+            const result = runHelper(
+                ['validate', '--schema', schema],
+                { input }
+            );
+            const output = parseOutput(result.stdout);
+            assert.notStrictEqual(output, null);
+            assert.strictEqual(output.valid, false);
+            assert.strictEqual(typeof output.error, 'string');
+            assert.strictEqual(typeof output.line_number, 'number');
+            assert.strictEqual(typeof output.malformed_line, 'string');
+            assert.ok('expected_format' in output, 'should have expected_format field');
+        });
+
+        it('error exit produces JSON with error field', () => {
+            const result = runHelper([
+                'validate', '--schema', '{invalid', '--file', '-'
+            ], { input: '' });
+            assert.strictEqual(result.exitCode, 1);
+            const output = parseOutput(result.stdout);
+            assert.notStrictEqual(output, null, 'error output should be valid JSON');
+            assert.ok('error' in output, 'should have error field');
+            assert.strictEqual(typeof output.error, 'string');
+        });
+    });
+
+    // ── SDK Dependency Check ─────────────────────────────────────────────────
+
+    describe('SDK dependency handling', () => {
+        it('submit dispatches to cmd_submit and exits non-zero without valid SDK modules', function () {
+            this.timeout(15000);
+            // The submit subcommand is correctly routed (argparse accepts it)
+            // but fails because the required SDK trainer modules are not available.
+            // This verifies the dispatch works and the command exits with error.
+            const result = runHelper([
+                'submit',
+                '--model-id', 'test-model',
+                '--technique', 'sft',
+                '--training-type', 'lora',
+                '--dataset-s3-uri', 's3://bucket/data.jsonl',
+                '--output-bucket', 'my-bucket',
+                '--role-arn', 'arn:aws:iam::123456789012:role/test',
+                '--job-name', 'test-job',
+                '--project-name', 'test-project'
+            ]);
+            // Should exit non-zero (either SDK missing or module import error)
+            assert.notStrictEqual(result.exitCode, 0,
+                'should exit with error when SDK modules are unavailable');
+            // Should NOT exit with 2 (argparse error) — the subcommand was recognized
+            assert.notStrictEqual(result.exitCode, 2,
+                'should not be an argparse error — subcommand was dispatched');
+        });
+
+        it('status dispatches to cmd_status and exits non-zero without AWS credentials', () => {
+            const result = runHelper([
+                'status',
+                '--job-name', 'test-job-name',
+                '--region', 'us-east-1'
+            ], {
+                env: {
+                    PATH: process.env.PATH,
+                    HOME: process.env.HOME,
+                    AWS_ACCESS_KEY_ID: '',
+                    AWS_SECRET_ACCESS_KEY: '',
+                    AWS_DEFAULT_REGION: 'us-east-1'
+                }
+            });
+            // Should exit non-zero (boto3 will fail without credentials)
+            assert.notStrictEqual(result.exitCode, 0,
+                'should exit with error without valid AWS credentials');
+            assert.notStrictEqual(result.exitCode, 2,
+                'should not be an argparse error — subcommand was dispatched');
+        });
+    });
+
+    // ── Submit Argument Validation ───────────────────────────────────────────
+
+    describe('submit argument validation', () => {
+        it('rejects invalid technique choice', () => {
+            const result = runHelper([
+                'submit',
+                '--model-id', 'test-model',
+                '--technique', 'invalid-technique',
+                '--training-type', 'lora',
+                '--dataset-s3-uri', 's3://bucket/data.jsonl',
+                '--output-bucket', 'my-bucket',
+                '--role-arn', 'arn:aws:iam::123456789012:role/test',
+                '--job-name', 'test-job',
+                '--project-name', 'test-project'
+            ]);
+            assert.strictEqual(result.exitCode, 2);
+            assert.ok(result.stderr.includes('invalid choice'),
+                'should report invalid choice for technique');
+        });
+
+        it('rejects invalid training-type choice', () => {
+            const result = runHelper([
+                'submit',
+                '--model-id', 'test-model',
+                '--technique', 'sft',
+                '--training-type', 'invalid-type',
+                '--dataset-s3-uri', 's3://bucket/data.jsonl',
+                '--output-bucket', 'my-bucket',
+                '--role-arn', 'arn:aws:iam::123456789012:role/test',
+                '--job-name', 'test-job',
+                '--project-name', 'test-project'
+            ]);
+            assert.strictEqual(result.exitCode, 2);
+            assert.ok(result.stderr.includes('invalid choice'),
+                'should report invalid choice for training-type');
+        });
+
+        it('accepts valid technique choices: sft, dpo, rlaif, rlvr', function () {
+            this.timeout(60000);
+            for (const technique of ['sft', 'dpo', 'rlaif', 'rlvr']) {
+                const result = runHelper([
+                    'submit',
+                    '--model-id', 'test-model',
+                    '--technique', technique,
+                    '--training-type', 'lora',
+                    '--dataset-s3-uri', 's3://bucket/data.jsonl',
+                    '--output-bucket', 'my-bucket',
+                    '--role-arn', 'arn:aws:iam::123456789012:role/test',
+                    '--job-name', 'test-job',
+                    '--project-name', 'test-project'
+                ], {
+                    env: {
+                        PYTHONPATH: '/nonexistent',
+                        PATH: process.env.PATH,
+                        HOME: process.env.HOME
+                    }
+                });
+                // Should not exit with code 2 (argparse error)
+                // It may exit with 1 (SDK not found) which is fine
+                assert.notStrictEqual(result.exitCode, 2,
+                    `technique "${technique}" should be accepted by argparse`);
+            }
+        });
+
+        it('accepts valid training-type choices: lora, full-rank', function () {
+            this.timeout(30000);
+            for (const trainingType of ['lora', 'full-rank']) {
+                const result = runHelper([
+                    'submit',
+                    '--model-id', 'test-model',
+                    '--technique', 'sft',
+                    '--training-type', trainingType,
+                    '--dataset-s3-uri', 's3://bucket/data.jsonl',
+                    '--output-bucket', 'my-bucket',
+                    '--role-arn', 'arn:aws:iam::123456789012:role/test',
+                    '--job-name', 'test-job',
+                    '--project-name', 'test-project'
+                ], {
+                    env: {
+                        PYTHONPATH: '/nonexistent',
+                        PATH: process.env.PATH,
+                        HOME: process.env.HOME
+                    }
+                });
+                assert.notStrictEqual(result.exitCode, 2,
+                    `training-type "${trainingType}" should be accepted by argparse`);
+            }
+        });
+    });
+});

--- a/test/unit/tune-helper-dispatch.test.js
+++ b/test/unit/tune-helper-dispatch.test.js
@@ -449,7 +449,8 @@ describe('tune_helper.py subcommand dispatch', () => {
                 'should not be an argparse error — subcommand was dispatched');
         });
 
-        it('status dispatches to cmd_status and exits non-zero without AWS credentials', () => {
+        it('status dispatches to cmd_status and exits non-zero without AWS credentials', function () {
+            this.timeout(15000);
             const result = runHelper([
                 'status',
                 '--job-name', 'test-job-name',


### PR DESCRIPTION
# Managed Model Customization (`do/tune`) [BETA]

## Summary

Adds SageMaker Managed Model Customization support — a serverless fine-tuning capability that eliminates instance selection and container management. Users provide a dataset and technique; SageMaker handles infrastructure, optimization, and produces a deployable model.

## What's New

### `do/tune` Command

A new `do/` script that wraps SageMaker AI Managed Model Customization:

```bash
# Basic SFT with S3 dataset
./do/tune --technique sft --dataset s3://my-bucket/train.jsonl

# DPO with HuggingFace dataset
./do/tune --technique dpo --dataset hf://my-org/preference-data

# Full-rank fine-tuning (produces merged model, not adapter)
./do/tune --technique sft --dataset s3://my-bucket/train.jsonl --training-type full-rank
```

**Supported techniques**: SFT, DPO, RLAIF, RLVR  
**Supported models**: Qwen 2.5/3, DeepSeek R1 Distill, Llama 3.1/3.2/3.3, GPT-OSS  
**Output types**: LoRA adapter weights or full merged model

### Deployment Integration

Tune output feeds directly into existing deployment commands:

```bash
# LoRA adapter output → attach to running endpoint
./do/adapter add tuned-sft --from-tune

# Full-rank output → deploy as new inference component
./do/add-ic tuned-v1 --from-tune
```

### Infrastructure

- Bootstrap stack updated with tune IAM permissions (`CreateTrainingJob`, `CreateModelPackage`, etc.)
- Dedicated S3 bucket: `mlcc-tune-${AccountId}-${Region}`
- Tune catalog (`config/tune-catalog.json`) tracks supported models, techniques, and dataset formats

## Changes

| Area | Files | Description |
|------|-------|-------------|
| Core | `src/app.js`, `bin/cli.js` | Generator inclusion logic for `do/tune` |
| Tune logic | `src/lib/tune-*.js` (4 files) | Catalog validator, dataset validator, config state, output resolver |
| Templates | `templates/do/tune`, `templates/do/.tune_helper.py` | Generated scripts |
| Templates | `templates/do/adapter`, `templates/do/add-ic` | `--from-tune` flag support |
| Config | `templates/do/config` | `TUNE_SUPPORTED`, `TUNE_S3_BUCKET` exports |
| Infra | `config/bootstrap-stack.json` | IAM permissions for tune jobs |
| Catalog | `config/tune-catalog.json` | Supported models registry |
| Docs | `docs/fine-tuning.md`, `docs/getting-started.md` | User documentation |
| Tests | `test/property/tune-*.test.js` (5 files) | Property-based tests |
| Tests | `test/unit/tune-*.test.js` (3 files) | Unit tests |
| Tests | `test/integration/tune-*.test.js` (1 file) | Integration test |

## Testing

- **3545 tests passing**, 0 failures, 16 pending
- 5 new property test suites covering catalog schema, dataset validation, config state, output detection, and generator inclusion
- 3 new unit test suites for bootstrap resources, dataset validator, and helper dispatch
- 1 new integration test for the tune → adapter deployment flow
- Lint clean (`npm run lint:fix` passes with no errors)

## Spec Reference

- `.kiro/specs/managed-model-customization/` — full requirements, design, and tasks

## Notes

- `do/tune` is only generated for `transformers` framework projects (not traditional ML)
- Excluded for `batch-transform` deployment target (no persistent endpoint for adapters)
- Runtime model validation checks against the tune catalog — unsupported models get a clear error with supported alternatives
- Job idempotency: re-running `do/tune` resumes/reports on existing jobs rather than creating duplicates
