### PR TITLE
CW logging workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/ml-container-creator",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/ml-container-creator",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/ml-container-creator",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/ml-container-creator",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/ml-container-creator",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Generator for SageMaker AI BYOC paradigm for predictive inference use-cases.",
   "type": "module",
   "main": "src/app.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/ml-container-creator",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Generator for SageMaker AI BYOC paradigm for predictive inference use-cases.",
   "type": "module",
   "main": "src/app.js",

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -290,6 +290,7 @@ RUN chmod +x /usr/bin/serve_trtllm
 
 # Copy startup script
 COPY code/cuda_compat.sh /usr/bin/cuda_compat.sh
+COPY code/cw_log_forwarder.py /usr/bin/cw_log_forwarder.py
 COPY code/start_server.sh /usr/bin/start_server.sh
 RUN chmod +x /usr/bin/start_server.sh /usr/bin/cuda_compat.sh
 
@@ -307,6 +308,7 @@ COPY code/serving.properties /opt/ml/model/serving.properties
 # The container will automatically start DJL Serving with the configuration
 <% } else { %>
 COPY code/cuda_compat.sh /usr/bin/cuda_compat.sh
+COPY code/cw_log_forwarder.py /usr/bin/cw_log_forwarder.py
 COPY code/serve /usr/bin/serve
 RUN chmod 777 /usr/bin/serve /usr/bin/cuda_compat.sh
 

--- a/templates/code/cw_log_forwarder.py
+++ b/templates/code/cw_log_forwarder.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""CloudWatch log forwarder — workaround for IC platform log routing gap.
+Pipes stdin to a CW log stream while passing through to stderr.
+Usage: exec > >(python3 /usr/bin/cw_log_forwarder.py) 2>&1
+"""
+import sys, os, time, threading
+import boto3
+from botocore.config import Config
+
+LOG_GROUP = os.environ.get("CW_LOG_GROUP",
+    f"/aws/sagemaker/InferenceComponents/{os.environ.get('INFERENCE_COMPONENT_NAME', os.environ.get('HOSTNAME', 'unknown'))}")
+LOG_STREAM = f"AllTraffic/{os.environ.get('HOSTNAME', 'container')}"
+REGION = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-west-2"))
+
+def main():
+    client = boto3.client("logs", region_name=REGION, config=Config(retries={"max_attempts": 2}))
+    try:
+        client.create_log_group(logGroupName=LOG_GROUP)
+    except Exception:
+        pass
+    try:
+        client.create_log_stream(logGroupName=LOG_GROUP, logStreamName=LOG_STREAM)
+    except Exception as e:
+        # Can't create stream — just passthrough
+        for line in sys.stdin:
+            sys.stderr.write(line)
+        return
+
+    buf, lock, seq = [], threading.Lock(), [None]
+
+    def flush():
+        with lock:
+            if not buf:
+                return
+            batch = buf[:50]
+            del buf[:50]
+        events = [{"timestamp": int(t * 1000), "message": m} for t, m in batch]
+        kw = {"logGroupName": LOG_GROUP, "logStreamName": LOG_STREAM, "logEvents": events}
+        if seq[0]:
+            kw["sequenceToken"] = seq[0]
+        try:
+            r = client.put_log_events(**kw)
+            seq[0] = r.get("nextSequenceToken")
+        except Exception:
+            pass
+
+    def loop():
+        while True:
+            time.sleep(2)
+            flush()
+
+    threading.Thread(target=loop, daemon=True).start()
+    try:
+        for line in sys.stdin:
+            sys.stderr.write(line)
+            with lock:
+                buf.append((time.time(), line.rstrip("\n")))
+    except (KeyboardInterrupt, BrokenPipeError):
+        pass
+    finally:
+        flush()
+
+if __name__ == "__main__":
+    main()

--- a/templates/code/serve
+++ b/templates/code/serve
@@ -270,8 +270,14 @@ for var in "${env_vars[@]}"; do
     
     # Remove prefix, convert to lowercase, and replace underscores with dashes
     arg_name=$(echo "${key#"${PREFIX}"}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+
+    # Boolean handling: true = flag only, false = skip entirely
+    if [ "$value" = "false" ]; then
+        continue
+    fi
+
     SERVER_ARGS+=("${ARG_PREFIX}${arg_name}")
-    if [ -n "$value" ]; then
+    if [ -n "$value" ] && [ "$value" != "true" ]; then
         SERVER_ARGS+=("$value")
     fi
 done

--- a/templates/code/serve
+++ b/templates/code/serve
@@ -2,6 +2,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# CloudWatch log forwarder — workaround for IC platform log routing gap
+exec > >(python3 /usr/bin/cw_log_forwarder.py) 2>&1
+
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') [serve] Container started — PID $$"
+
 # CUDA compatibility setup (required for newer SageMaker inference AMIs)
 source /usr/bin/cuda_compat.sh 2>/dev/null || true
 

--- a/templates/deploy_notebook_generator.py
+++ b/templates/deploy_notebook_generator.py
@@ -1,0 +1,897 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate deploy_notebook.ipynb from environment variables."""
+import json
+import os
+import sys
+
+
+def env(name, default=""):
+    """Read an environment variable with a default."""
+    return os.environ.get(name, default)
+
+
+def make_markdown_cell(source_lines):
+    """Create a markdown cell dict."""
+    return {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": source_lines
+    }
+
+
+def make_code_cell(source_lines):
+    """Create a code cell dict."""
+    return {
+        "cell_type": "code",
+        "metadata": {},
+        "source": source_lines,
+        "outputs": [],
+        "execution_count": None
+    }
+
+
+cells = []
+
+# ── Section 1: Setup ─────────────────────────────────────────────────────────
+
+# Title markdown cell
+cells.append(make_markdown_cell([
+    f"# Deploy {env('PROJECT_NAME')} on SageMaker\n",
+    "\n",
+    f"**Model Server**: {env('MODEL_SERVER')}  \n",
+    f"**Instance**: {env('INSTANCE_TYPE')}  \n",
+    f"**Region**: {env('AWS_REGION')}\n"
+]))
+
+# Pip install cell
+cells.append(make_code_cell([
+    "%pip install -qU sagemaker boto3"
+]))
+
+# Imports cell
+cells.append(make_code_cell([
+    "import json\n",
+    "import time\n",
+    "import boto3\n",
+    "import sagemaker\n",
+    "from sagemaker import get_execution_role\n",
+    "from sagemaker.session import Session\n",
+    "\n",
+    "sagemaker_session = Session()\n",
+    "role = get_execution_role()\n",
+    "account_id = boto3.client('sts').get_caller_identity()['Account']\n",
+    "region = sagemaker_session.boto_region_name\n",
+    "\n",
+    "sm_client = boto3.client('sagemaker', region_name=region)\n",
+    "smr_client = boto3.client('sagemaker-runtime', region_name=region)"
+]))
+
+# ── Section 2: Configuration ─────────────────────────────────────────────────
+
+# Project variables baked as Python literals
+cells.append(make_code_cell([
+    f'PROJECT_NAME = "{env("PROJECT_NAME")}"\n',
+    f'AWS_REGION = "{env("AWS_REGION")}"\n',
+<% if (deploymentTarget !== 'hyperpod-eks' && !(typeof existingEndpointName !== 'undefined' && existingEndpointName)) { %>
+    f'INSTANCE_TYPE = "{env("INSTANCE_TYPE")}"\n',
+<% } %>
+    f'ENDPOINT_NAME = f"{{PROJECT_NAME}}-ep-{{int(time.time())}}"\n',
+<% if (typeof inferenceAmiVersion !== 'undefined' && inferenceAmiVersion) { %>
+    f'INFERENCE_AMI_VERSION = "{env("INFERENCE_AMI_VERSION")}"\n',
+<% } else { %>
+    f'INFERENCE_AMI_VERSION = "{env("INFERENCE_AMI_VERSION", "")}"\n',
+<% } %>
+    f'HEALTH_CHECK_TIMEOUT = 850\n',
+    f'IC_GPU_COUNT = {env("IC_GPU_COUNT", "1")}\n',
+    f'IC_MIN_MEMORY_MB = {env("IC_MEMORY_SIZE", "1024")}'
+]))
+
+# Environment variables dict cell
+cells.append(make_code_cell([
+    "env = {\n",
+<% if (orderedEnvVars && orderedEnvVars.length > 0) { %>
+<% orderedEnvVars.forEach(function(item, index) { %>
+    f'    "<%= item.key %>": "{env("<%= item.key %>", "<%= item.value %>")}",\n',
+<% }); %>
+<% } %>
+    "}"
+]))
+
+# ── Section 2b: Secrets Handling ─────────────────────────────────────────────
+
+<% if (typeof hfTokenArn !== 'undefined' && hfTokenArn) { %>
+# HF_TOKEN_ARN is configured — resolve via Secrets Manager
+cells.append(make_code_cell([
+    "import boto3 as _boto3_secrets\n",
+    "\n",
+    f'HF_TOKEN_ARN = "{env("HF_TOKEN_ARN")}"\n',
+    "\n",
+    "secrets_client = _boto3_secrets.client('secretsmanager', region_name=AWS_REGION)\n",
+    "hf_token = secrets_client.get_secret_value(SecretId=HF_TOKEN_ARN)['SecretString']\n",
+    'env["HF_TOKEN"] = hf_token'
+]))
+<% } else if (hfToken) { %>
+# HF_TOKEN is configured — read from environment variable at notebook runtime
+cells.append(make_markdown_cell([
+    "### \u26a0\ufe0f HuggingFace Token Required\n",
+    "\n",
+    "Set the `HF_TOKEN` environment variable before running the next cell.  \n",
+    "In SageMaker Studio, use the **Environment** tab or run:  \n",
+    '`export HF_TOKEN="hf_your_token_here"`'
+]))
+
+cells.append(make_code_cell([
+    "import os\n",
+    "\n",
+    'env["HF_TOKEN"] = os.environ["HF_TOKEN"]'
+]))
+<% } %>
+<% if (typeof ngcTokenArn !== 'undefined' && ngcTokenArn) { %>
+# NGC_API_KEY_ARN is configured — resolve via Secrets Manager
+cells.append(make_code_cell([
+    "import boto3 as _boto3_secrets\n",
+    "\n",
+    f'NGC_API_KEY_ARN = "{env("NGC_API_KEY_ARN")}"\n',
+    "\n",
+    "secrets_client = _boto3_secrets.client('secretsmanager', region_name=AWS_REGION)\n",
+    "ngc_key = secrets_client.get_secret_value(SecretId=NGC_API_KEY_ARN)['SecretString']\n",
+    'env["NGC_API_KEY"] = ngc_key'
+]))
+<% } else if (ngcApiKey) { %>
+# NGC_API_KEY is configured — read from environment variable at notebook runtime
+cells.append(make_markdown_cell([
+    "### \u26a0\ufe0f NVIDIA NGC API Key Required\n",
+    "\n",
+    "Set the `NGC_API_KEY` environment variable before running the next cell.  \n",
+    "In SageMaker Studio, use the **Environment** tab or run:  \n",
+    '`export NGC_API_KEY="your_ngc_key_here"`'
+]))
+
+cells.append(make_code_cell([
+    "import os\n",
+    "\n",
+    'env["NGC_API_KEY"] = os.environ["NGC_API_KEY"]'
+]))
+<% } %>
+
+# ── Section 3: Build & Push ──────────────────────────────────────────────────
+
+<% if (modelServer !== 'lmi' && modelServer !== 'djl') { %>
+cells.append(make_markdown_cell([
+    "## Build & Push Container\n",
+    "\n",
+    "Build the container via CodeBuild and push to ECR.\n"
+]))
+
+cells.append(make_code_cell([
+    'CODEBUILD_PROJECT_NAME = f"{PROJECT_NAME}-build"\n',
+    'cb_client = boto3.client("codebuild", region_name=AWS_REGION)\n',
+    '\n',
+    'build = cb_client.start_build(\n',
+    '    projectName=CODEBUILD_PROJECT_NAME,\n',
+    '    sourceVersion="main",\n',
+    ')\n',
+    'build_id = build["build"]["id"]\n',
+    'print(f"Build started: {build_id}")\n',
+    '\n',
+    'while True:\n',
+    '    resp = cb_client.batch_get_builds(ids=[build_id])\n',
+    '    status = resp["builds"][0]["buildStatus"]\n',
+    '    phase = resp["builds"][0].get("currentPhase", "UNKNOWN")\n',
+    '    if status == "SUCCEEDED":\n',
+    '        print(f"\\u2705 Build succeeded")\n',
+    '        break\n',
+    '    elif status in ("FAILED", "FAULT", "TIMED_OUT", "STOPPED"):\n',
+    '        print(f"\\u274c Build {status}")\n',
+    '        break\n',
+    '    print(f"   {phase}... ({status})")\n',
+    '    time.sleep(30)\n',
+]))
+
+cells.append(make_code_cell([
+    f'image_uri = f"{{account_id}}.dkr.ecr.{{region}}.amazonaws.com/{env("PROJECT_NAME")}:{env("PROJECT_NAME")}-latest"\n',
+    'print(f"Image URI: {image_uri}")'
+]))
+<% } else { %>
+cells.append(make_markdown_cell([
+    "## Container Image\n",
+    "\n",
+    "Using AWS Deep Learning Container (DLC) image.\n"
+]))
+
+cells.append(make_code_cell([
+    f'image_uri = sagemaker.image_uris.retrieve(\n',
+    f'    framework="<%= modelServer %>",\n',
+    f'    region=region,\n',
+    f'    version="latest",\n',
+    f'    instance_type=INSTANCE_TYPE,\n',
+    f')\n',
+    'print(f"DLC Image URI: {image_uri}")'
+]))
+<% } %>
+
+# ── Section 4: Model ─────────────────────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## Create SageMaker Model\n",
+    "\n",
+    "Define the model container and environment variables.\n"
+]))
+
+cells.append(make_code_cell([
+    'model_name = f"{PROJECT_NAME}-model-{int(time.time())}"\n',
+    '\n',
+    'sm_client.create_model(\n',
+    '    ModelName=model_name,\n',
+    '    ExecutionRoleArn=role,\n',
+    '    PrimaryContainer={\n',
+    '        "Image": image_uri,\n',
+    '        "Environment": env,\n',
+    '    },\n',
+    ')\n',
+    '\n',
+    'print(f"✅ Model created: {model_name}")'
+]))
+
+<% if (deploymentTarget === 'realtime-inference') { %>
+# ── Section 5: Endpoint ──────────────────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## Create Endpoint\n",
+    "\n",
+    "Create an endpoint configuration and deploy the endpoint.\n"
+]))
+
+# Create endpoint config
+cells.append(make_code_cell([
+    'endpoint_config_name = f"{PROJECT_NAME}-epc-{int(time.time())}"\n',
+    '\n',
+    'production_variant = {\n',
+    '    "VariantName": "AllTraffic",\n',
+    '    "InstanceType": INSTANCE_TYPE,\n',
+    '    "InitialInstanceCount": 1,\n',
+    '    "ContainerStartupHealthCheckTimeoutInSeconds": HEALTH_CHECK_TIMEOUT,\n',
+    '}\n',
+    '\n',
+    '# Include InferenceAmiVersion if configured\n',
+    'if INFERENCE_AMI_VERSION:\n',
+    '    production_variant["InferenceAmiVersion"] = INFERENCE_AMI_VERSION\n',
+    '\n',
+    'sm_client.create_endpoint_config(\n',
+    '    EndpointConfigName=endpoint_config_name,\n',
+    '    ExecutionRoleArn=role,\n',
+    '    ProductionVariants=[production_variant],\n',
+    ')\n',
+    '\n',
+    'print(f"✅ Endpoint config created: {endpoint_config_name}")'
+]))
+
+# Create endpoint
+cells.append(make_code_cell([
+    'sm_client.create_endpoint(\n',
+    '    EndpointName=ENDPOINT_NAME,\n',
+    '    EndpointConfigName=endpoint_config_name,\n',
+    ')\n',
+    '\n',
+    'print(f"Creating endpoint: {ENDPOINT_NAME}...")\n',
+    '\n',
+    '# Wait for InService\n',
+    'while True:\n',
+    '    resp = sm_client.describe_endpoint(EndpointName=ENDPOINT_NAME)\n',
+    '    status = resp["EndpointStatus"]\n',
+    '    if status == "InService":\n',
+    '        print(f"✅ Endpoint InService: {ENDPOINT_NAME}")\n',
+    '        break\n',
+    '    elif status == "Failed":\n',
+    '        print(f"❌ Endpoint failed: {resp.get(\'FailureReason\', \'Unknown\')}")\n',
+    '        break\n',
+    '    print(f"   Status: {status}...")\n',
+    '    time.sleep(30)'
+]))
+
+# ── Section 6: Inference Component ───────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## Create Inference Component\n",
+    "\n",
+    "Attach the model to the endpoint with compute resource allocation.  \n",
+    "This is separate from the endpoint to support multi-LoRA adapter extensibility.\n"
+]))
+
+cells.append(make_code_cell([
+    'ic_name = f"{PROJECT_NAME}-ic-{int(time.time())}"\n',
+    '\n',
+    'sm_client.create_inference_component(\n',
+    '    InferenceComponentName=ic_name,\n',
+    '    EndpointName=ENDPOINT_NAME,\n',
+    '    VariantName="AllTraffic",\n',
+    '    Specification={\n',
+    '        "ModelName": model_name,\n',
+    '        "Container": {\n',
+    '            "Image": image_uri,\n',
+    '            "Environment": env,\n',
+    '        },\n',
+    '        "ComputeResourceRequirements": {\n',
+    '            "NumberOfAcceleratorDevicesRequired": IC_GPU_COUNT,\n',
+    '            "MinMemoryRequiredInMb": IC_MIN_MEMORY_MB,\n',
+    '        },\n',
+    '    },\n',
+    '    RuntimeConfig={\n',
+    '        "CopyCount": 1,\n',
+    '    },\n',
+    ')\n',
+    '\n',
+    'print(f"Creating inference component: {ic_name}...")\n',
+    '\n',
+    '# Wait for IC InService\n',
+    'while True:\n',
+    '    resp = sm_client.describe_inference_component(InferenceComponentName=ic_name)\n',
+    '    status = resp["InferenceComponentStatus"]\n',
+    '    if status == "InService":\n',
+    '        print(f"✅ Inference Component InService: {ic_name}")\n',
+    '        break\n',
+    '    elif status == "Failed":\n',
+    '        print(f"❌ IC failed: {resp.get(\'FailureReason\', \'Unknown\')}")\n',
+    '        break\n',
+    '    print(f"   Status: {status}...")\n',
+    '    time.sleep(30)'
+]))
+
+# ── Section 7: Test ──────────────────────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## Test Inference\n",
+    "\n",
+    "Send a test request to the deployed model.\n"
+]))
+
+<% if (framework === 'transformers') { %>
+cells.append(make_code_cell([
+    'payload = {\n',
+    '    "messages": [{"role": "user", "content": "What is machine learning?"}],\n',
+    '    "max_tokens": 100,\n',
+    '    "temperature": 0.7,\n',
+    '}\n',
+    '\n',
+    'response = smr_client.invoke_endpoint(\n',
+    '    EndpointName=ENDPOINT_NAME,\n',
+    '    InferenceComponentName=ic_name,\n',
+    '    ContentType="application/json",\n',
+    '    Body=json.dumps(payload),\n',
+    ')\n',
+    '\n',
+    'result = json.loads(response["Body"].read().decode())\n',
+    'print(result["choices"][0]["message"]["content"])'
+]))
+<% } else { %>
+cells.append(make_code_cell([
+    'payload = {\n',
+    '    "inputs": "What is machine learning?",\n',
+    '    "parameters": {"max_new_tokens": 100},\n',
+    '}\n',
+    '\n',
+    'response = smr_client.invoke_endpoint(\n',
+    '    EndpointName=ENDPOINT_NAME,\n',
+    '    InferenceComponentName=ic_name,\n',
+    '    ContentType="application/json",\n',
+    '    Body=json.dumps(payload),\n',
+    ')\n',
+    '\n',
+    'result = json.loads(response["Body"].read().decode())\n',
+    'print(json.dumps(result, indent=2))'
+]))
+<% } %>
+<% if (enableLora) { %>
+# ── Section 8: LoRA Adapter ──────────────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## 🔗 LoRA Adapter\n",
+    "\n",
+    "LoRA (Low-Rank Adaptation) adapters let you serve multiple fine-tuned \"personalities\"\n",
+    "from a single base model. Adapter ICs share the base IC's GPU resources — no additional\n",
+    "compute allocation is needed. You can add/remove adapters without redeploying the endpoint.\n"
+]))
+
+cells.append(make_code_cell([
+    '# ✏️ Edit these values to configure your adapter\n',
+    'ADAPTER_NAME = "my-adapter"\n',
+    f'ADAPTER_WEIGHTS_URI = "{env("TUNE_ADAPTER_PATH_SFT", env("TUNE_ADAPTER_PATH_DPO", env("TUNE_OUTPUT_PATH_LATEST", "s3://your-bucket/adapters/my-adapter/adapter.tar.gz")))}"\n',
+]))
+
+cells.append(make_code_cell([
+    'adapter_ic_name = f"{PROJECT_NAME}-adapter-{ADAPTER_NAME}"\n',
+    '\n',
+    'sm_client.create_inference_component(\n',
+    '    InferenceComponentName=adapter_ic_name,\n',
+    '    EndpointName=ENDPOINT_NAME,\n',
+    '    Specification={\n',
+    '        "BaseInferenceComponentName": ic_name,\n',
+    '        "Container": {\n',
+    '            "ArtifactUrl": ADAPTER_WEIGHTS_URI,\n',
+    '        },\n',
+    '    },\n',
+    ')\n',
+    '\n',
+    'print(f"Creating adapter IC: {adapter_ic_name}...")\n',
+    '\n',
+    '# Wait for adapter IC InService\n',
+    'while True:\n',
+    '    resp = sm_client.describe_inference_component(InferenceComponentName=adapter_ic_name)\n',
+    '    status = resp["InferenceComponentStatus"]\n',
+    '    if status == "InService":\n',
+    '        print(f"✅ Adapter IC InService: {adapter_ic_name}")\n',
+    '        break\n',
+    '    elif status == "Failed":\n',
+    '        print(f"❌ Adapter IC failed: {resp.get(\'FailureReason\', \'Unknown\')}")\n',
+    '        break\n',
+    '    print(f"   Status: {status}...")\n',
+    '    time.sleep(30)'
+]))
+
+<% if (framework === 'transformers') { %>
+cells.append(make_code_cell([
+    'payload = {\n',
+    '    "messages": [{"role": "user", "content": "What is machine learning?"}],\n',
+    '    "max_tokens": 100,\n',
+    '    "temperature": 0.7,\n',
+    '}\n',
+    '\n',
+    'response = smr_client.invoke_endpoint(\n',
+    '    EndpointName=ENDPOINT_NAME,\n',
+    '    InferenceComponentName=adapter_ic_name,\n',
+    '    ContentType="application/json",\n',
+    '    Body=json.dumps(payload),\n',
+    ')\n',
+    '\n',
+    'result = json.loads(response["Body"].read().decode())\n',
+    'print(f"Adapter \'{ADAPTER_NAME}\' response:")\n',
+    'print(result["choices"][0]["message"]["content"])'
+]))
+<% } else { %>
+cells.append(make_code_cell([
+    'payload = {\n',
+    '    "inputs": "What is machine learning?",\n',
+    '    "parameters": {"max_new_tokens": 100},\n',
+    '}\n',
+    '\n',
+    'response = smr_client.invoke_endpoint(\n',
+    '    EndpointName=ENDPOINT_NAME,\n',
+    '    InferenceComponentName=adapter_ic_name,\n',
+    '    ContentType="application/json",\n',
+    '    Body=json.dumps(payload),\n',
+    ')\n',
+    '\n',
+    'result = json.loads(response["Body"].read().decode())\n',
+    'print(f"Adapter \'{ADAPTER_NAME}\' response:")\n',
+    'print(json.dumps(result, indent=2))'
+]))
+<% } %>
+
+cells.append(make_markdown_cell([
+    "### Adding More Adapters\n",
+    "\n",
+    "To add another adapter, duplicate this section with a different `ADAPTER_NAME` and\n",
+    "`ADAPTER_WEIGHTS_URI`. Each adapter shares the base IC's GPU resources.\n",
+    "\n",
+    "The CLI equivalent is: `./do/adapter add <name> --weights <s3-uri>`\n"
+]))
+<% } %>
+<% if (tuneSupported) { %>
+# ── Section 9: Fine-Tune ─────────────────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## 🎯 Managed Fine-Tuning\n",
+    "\n",
+    "SageMaker Managed Model Customization provides serverless fine-tuning — no instance\n",
+    "selection or container management needed. You provide a dataset and technique; SageMaker\n",
+    "handles infrastructure and optimization. The output is either LoRA adapter weights or a\n",
+    "full merged model, depending on the training type.\n"
+]))
+
+cells.append(make_code_cell([
+    '# ✏️ Edit these values to configure your fine-tuning job\n',
+    'TECHNIQUE = "sft"  # Options: sft, dpo, rlaif, rlvr\n',
+    'TRAINING_TYPE = "lora"  # Options: lora, full-rank\n',
+    'DATASET_S3_URI = "s3://your-bucket/datasets/train.jsonl"  # ← Replace with your dataset\n',
+    f'TUNE_OUTPUT_BUCKET = "{env("TUNE_S3_BUCKET")}"'
+]))
+
+cells.append(make_code_cell([
+    'from sagemaker.modules.train import ModelTrainer\n',
+    '\n',
+    f'MODEL_NAME = "{env("MODEL_NAME")}"\n',
+    '\n',
+    'job_name = f"{PROJECT_NAME}-tune-{TECHNIQUE}-{int(time.time())}"\n',
+    '\n',
+    'trainer = ModelTrainer(\n',
+    '    model_id=MODEL_NAME,\n',
+    '    training_dataset={"s3Uri": DATASET_S3_URI},\n',
+    '    technique=TECHNIQUE,\n',
+    '    training_type=TRAINING_TYPE,\n',
+    '    output_path=f"s3://{TUNE_OUTPUT_BUCKET}/{PROJECT_NAME}/output/",\n',
+    '    role=role,\n',
+    ')\n',
+    'trainer.train()\n',
+    '\n',
+    'print(f"✅ Training job submitted: {job_name}")'
+]))
+
+cells.append(make_code_cell([
+    'import time as _time\n',
+    'start_time = _time.time()\n',
+    '\n',
+    'while True:\n',
+    '    status = trainer.describe()["TrainingJobStatus"]\n',
+    '    elapsed = int(_time.time() - start_time)\n',
+    '    elapsed_str = f"{elapsed // 60}m {elapsed % 60}s"\n',
+    '\n',
+    '    if status == "Completed":\n',
+    '        print(f"✅ Training completed in {elapsed_str}")\n',
+    '        break\n',
+    '    elif status == "Failed":\n',
+    '        reason = trainer.describe().get("FailureReason", "Unknown")\n',
+    '        print(f"❌ Training failed after {elapsed_str}: {reason}")\n',
+    '        break\n',
+    '    print(f"   Status: {status} (elapsed: {elapsed_str})...")\n',
+    '    _time.sleep(60)'
+]))
+
+cells.append(make_code_cell([
+    'job_desc = trainer.describe()\n',
+    'output_path = job_desc["ModelArtifacts"]["S3ModelArtifacts"]\n',
+    'print(f"Output artifacts: {output_path}")'
+]))
+
+cells.append(make_markdown_cell([
+    "### Next Steps\n",
+    "\n",
+    "**If LoRA output** (TRAINING_TYPE=\"lora\"):  \n",
+    "- Run the adapter section above with `ADAPTER_WEIGHTS_URI` set to the output path  \n",
+    "- Or use the CLI: `./do/adapter add tuned-sft --from-tune`\n",
+    "\n",
+    "**If full-rank output** (TRAINING_TYPE=\"full-rank\"):  \n",
+    "- Deploy as a new inference component: `./do/add-ic tuned-v1 --from-tune`\n"
+]))
+<% } %>
+
+# ── Section 10: Cleanup ───────────────────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## ⚠️ Cleanup\n",
+    "\n",
+    "**Warning**: This will delete all deployed resources. Only run when you're done testing.\n"
+]))
+
+cells.append(make_code_cell([
+    '# Delete in reverse dependency order\n',
+    '\n',
+    '# 1. Delete adapter IC (if created in Section 8)\n',
+    'try:\n',
+    '    sm_client.delete_inference_component(InferenceComponentName=adapter_ic_name)\n',
+    '    print(f"Deleting adapter IC: {adapter_ic_name}...")\n',
+    '    time.sleep(15)\n',
+    'except NameError:\n',
+    '    pass  # adapter_ic_name not defined — Section 8 was not run\n',
+    'except Exception as e:\n',
+    '    print(f"Note: {e}")\n',
+    '\n',
+    '# 2. Delete base IC\n',
+    'sm_client.delete_inference_component(InferenceComponentName=ic_name)\n',
+    'print(f"Deleting base IC: {ic_name}...")\n',
+    'time.sleep(30)\n',
+    '\n',
+    '# 3. Delete endpoint\n',
+    'sm_client.delete_endpoint(EndpointName=ENDPOINT_NAME)\n',
+    'print(f"Deleting endpoint: {ENDPOINT_NAME}...")\n',
+    '\n',
+    '# 4. Delete endpoint config\n',
+    'sm_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name)\n',
+    'print(f"Deleting endpoint config: {endpoint_config_name}...")\n',
+    '\n',
+    '# 5. Delete model\n',
+    'sm_client.delete_model(ModelName=model_name)\n',
+    'print(f"Deleting model: {model_name}...")\n',
+    '\n',
+    'print("\\n✅ All resources cleaned up")'
+]))
+<% } else if (deploymentTarget === 'async-inference') { %>
+# ── Section 5: Endpoint (Async) ──────────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## Create Async Endpoint\n",
+    "\n",
+    "Create an endpoint configuration with async inference settings and deploy the endpoint.  \n",
+    "Async inference is ideal for large payloads or long-running predictions — results are\n",
+    "written to S3 when ready.\n"
+]))
+
+# Create endpoint config with AsyncInferenceConfig
+cells.append(make_code_cell([
+    'endpoint_config_name = f"{PROJECT_NAME}-epc-{int(time.time())}"\n',
+    '\n',
+    'sm_client.create_endpoint_config(\n',
+    '    EndpointConfigName=endpoint_config_name,\n',
+    '    ExecutionRoleArn=role,\n',
+    '    ProductionVariants=[\n',
+    '        {\n',
+    '            "VariantName": "AllTraffic",\n',
+    '            "InstanceType": INSTANCE_TYPE,\n',
+    '            "InitialInstanceCount": 1,\n',
+    '            "ContainerStartupHealthCheckTimeoutInSeconds": HEALTH_CHECK_TIMEOUT,\n',
+    '        }\n',
+    '    ],\n',
+    '    AsyncInferenceConfig={\n',
+    '        "OutputConfig": {\n',
+    '            "S3OutputPath": f"s3://{PROJECT_NAME}-async-output/{PROJECT_NAME}/",\n',
+    '        },\n',
+    '        "ClientConfig": {\n',
+    '            "MaxConcurrentInvocationsPerInstance": 4,\n',
+    '        },\n',
+    '    },\n',
+    ')\n',
+    '\n',
+    'print(f"✅ Async endpoint config created: {endpoint_config_name}")'
+]))
+
+# Create endpoint
+cells.append(make_code_cell([
+    'sm_client.create_endpoint(\n',
+    '    EndpointName=ENDPOINT_NAME,\n',
+    '    EndpointConfigName=endpoint_config_name,\n',
+    ')\n',
+    '\n',
+    'print(f"Creating endpoint: {ENDPOINT_NAME}...")\n',
+    '\n',
+    '# Wait for InService\n',
+    'while True:\n',
+    '    resp = sm_client.describe_endpoint(EndpointName=ENDPOINT_NAME)\n',
+    '    status = resp["EndpointStatus"]\n',
+    '    if status == "InService":\n',
+    '        print(f"✅ Endpoint InService: {ENDPOINT_NAME}")\n',
+    '        break\n',
+    '    elif status == "Failed":\n',
+    '        print(f"❌ Endpoint failed: {resp.get(\'FailureReason\', \'Unknown\')}")\n',
+    '        break\n',
+    '    print(f"   Status: {status}...")\n',
+    '    time.sleep(30)'
+]))
+
+# ── Section 6: Inference Component — SKIPPED for async ───────────────────────
+# Async inference does not support inference components.
+
+# ── Section 7: Test (Async) ──────────────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## Test Async Inference\n",
+    "\n",
+    "Upload input to S3, invoke the async endpoint, then poll S3 for the result.\n"
+]))
+
+cells.append(make_code_cell([
+    'import boto3\n',
+    '\n',
+    's3_client = boto3.client("s3", region_name=AWS_REGION)\n',
+    'async_input_bucket = f"{PROJECT_NAME}-async-output"\n',
+    'async_input_key = f"{PROJECT_NAME}/input/test-request.json"\n',
+    '\n',
+<% if (framework === 'transformers') { %>
+    'payload = {\n',
+    '    "messages": [{"role": "user", "content": "What is machine learning?"}],\n',
+    '    "max_tokens": 100,\n',
+    '    "temperature": 0.7,\n',
+    '}\n',
+<% } else { %>
+    'payload = {\n',
+    '    "inputs": "What is machine learning?",\n',
+    '    "parameters": {"max_new_tokens": 100},\n',
+    '}\n',
+<% } %>
+    '\n',
+    '# Upload input payload to S3\n',
+    's3_client.put_object(\n',
+    '    Bucket=async_input_bucket,\n',
+    '    Key=async_input_key,\n',
+    '    Body=json.dumps(payload),\n',
+    '    ContentType="application/json",\n',
+    ')\n',
+    'input_s3_uri = f"s3://{async_input_bucket}/{async_input_key}"\n',
+    'print(f"Input uploaded to: {input_s3_uri}")'
+]))
+
+cells.append(make_code_cell([
+    '# Invoke async endpoint\n',
+    'response = smr_client.invoke_endpoint_async(\n',
+    '    EndpointName=ENDPOINT_NAME,\n',
+    '    ContentType="application/json",\n',
+    '    InputLocation=input_s3_uri,\n',
+    ')\n',
+    'output_location = response["OutputLocation"]\n',
+    'print(f"Output will be at: {output_location}")\n',
+    '\n',
+    '# Poll S3 for the result\n',
+    'import urllib.parse\n',
+    'parsed = urllib.parse.urlparse(output_location)\n',
+    'output_bucket = parsed.netloc\n',
+    'output_key = parsed.path.lstrip("/")\n',
+    '\n',
+    'print("Waiting for result...")\n',
+    'while True:\n',
+    '    try:\n',
+    '        result_obj = s3_client.get_object(Bucket=output_bucket, Key=output_key)\n',
+    '        result = json.loads(result_obj["Body"].read().decode())\n',
+    '        print("\\n✅ Async inference result:")\n',
+    '        print(json.dumps(result, indent=2))\n',
+    '        break\n',
+    '    except s3_client.exceptions.NoSuchKey:\n',
+    '        print("   Waiting for output...")\n',
+    '        time.sleep(10)'
+]))
+
+# ── Sections 8-9: SKIPPED for async ─────────────────────────────────────────
+# LoRA adapters and fine-tuning require a realtime endpoint with inference components.
+
+# ── Section 10: Cleanup (Async) ──────────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## ⚠️ Cleanup\n",
+    "\n",
+    "**Warning**: This will delete all deployed resources. Only run when you're done testing.  \n",
+    "Note: The S3 output bucket and any SNS topics are NOT deleted (user-managed).\n"
+]))
+
+cells.append(make_code_cell([
+    '# Delete in reverse dependency order (no IC for async)\n',
+    '\n',
+    '# 1. Delete endpoint\n',
+    'sm_client.delete_endpoint(EndpointName=ENDPOINT_NAME)\n',
+    'print(f"Deleting endpoint: {ENDPOINT_NAME}...")\n',
+    '\n',
+    '# 2. Delete endpoint config\n',
+    'sm_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name)\n',
+    'print(f"Deleting endpoint config: {endpoint_config_name}...")\n',
+    '\n',
+    '# 3. Delete model\n',
+    'sm_client.delete_model(ModelName=model_name)\n',
+    'print(f"Deleting model: {model_name}...")\n',
+    '\n',
+    'print("\\n✅ All resources cleaned up")\n',
+    'print("Note: S3 output bucket and SNS topics are not deleted (user-managed).")'
+]))
+<% } else if (deploymentTarget === 'batch-transform') { %>
+# ── Section 5: Batch Transform Job ───────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## Create Batch Transform Job\n",
+    "\n",
+    "Run batch inference on your input data stored in S3.  \n",
+    "The transform job reads input from S3, runs inference, and writes output back to S3.\n"
+]))
+
+cells.append(make_code_cell([
+    'INPUT_S3_URI = "s3://your-bucket/input/"  # ← Replace with your input data S3 path\n',
+    'OUTPUT_S3_URI = "s3://your-bucket/output/"  # ← Replace with your desired output S3 path\n',
+    '\n',
+    'transform_job_name = f"{PROJECT_NAME}-transform-{int(time.time())}"\n',
+    '\n',
+    'sm_client.create_transform_job(\n',
+    '    TransformJobName=transform_job_name,\n',
+    '    ModelName=model_name,\n',
+    '    TransformInput={\n',
+    '        "DataSource": {\n',
+    '            "S3DataSource": {\n',
+    '                "S3DataType": "S3Prefix",\n',
+    '                "S3Uri": INPUT_S3_URI,\n',
+    '            }\n',
+    '        },\n',
+    '        "ContentType": "application/json",\n',
+    '    },\n',
+    '    TransformOutput={\n',
+    '        "S3OutputPath": OUTPUT_S3_URI,\n',
+    '    },\n',
+    '    TransformResources={\n',
+    '        "InstanceType": INSTANCE_TYPE,\n',
+    '        "InstanceCount": 1,\n',
+    '    },\n',
+    ')\n',
+    '\n',
+    'print(f"Transform job started: {transform_job_name}")\n',
+    '\n',
+    '# Wait for transform job to complete\n',
+    'while True:\n',
+    '    resp = sm_client.describe_transform_job(TransformJobName=transform_job_name)\n',
+    '    status = resp["TransformJobStatus"]\n',
+    '    if status == "Completed":\n',
+    '        print(f"✅ Transform job completed: {transform_job_name}")\n',
+    '        break\n',
+    '    elif status == "Failed":\n',
+    '        print(f"❌ Transform job failed: {resp.get(\'FailureReason\', \'Unknown\')}")\n',
+    '        break\n',
+    '    elif status == "Stopped":\n',
+    '        print(f"⚠️ Transform job stopped")\n',
+    '        break\n',
+    '    print(f"   Status: {status}...")\n',
+    '    time.sleep(30)'
+]))
+
+# ── Section 7: Test (Download Output) ────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## Review Transform Output\n",
+    "\n",
+    "Download and display a sample result from the batch transform output.\n"
+]))
+
+cells.append(make_code_cell([
+    'import boto3\n',
+    'from urllib.parse import urlparse\n',
+    '\n',
+    's3 = boto3.client("s3", region_name=AWS_REGION)\n',
+    '\n',
+    '# Parse the output S3 URI\n',
+    'parsed = urlparse(OUTPUT_S3_URI)\n',
+    'bucket = parsed.netloc\n',
+    'prefix = parsed.path.lstrip("/")\n',
+    '\n',
+    '# List output files\n',
+    'response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)\n',
+    'output_files = [obj["Key"] for obj in response.get("Contents", [])]\n',
+    'print(f"Output files ({len(output_files)}):")\n',
+    'for f in output_files[:10]:\n',
+    '    print(f"  s3://{bucket}/{f}")\n',
+    '\n',
+    '# Download and display first result\n',
+    'if output_files:\n',
+    '    first_file = output_files[0]\n',
+    '    obj = s3.get_object(Bucket=bucket, Key=first_file)\n',
+    '    content = obj["Body"].read().decode("utf-8")\n',
+    '    print(f"\\nSample output from: {first_file}")\n',
+    '    print("-" * 60)\n',
+    '    print(content[:2000])\n',
+    'else:\n',
+    '    print("No output files found.")'
+]))
+
+# ── Section 10: Cleanup ───────────────────────────────────────────────────────
+
+cells.append(make_markdown_cell([
+    "## ⚠️ Cleanup\n",
+    "\n",
+    "**Warning**: This will delete the model resource. Only run when you're done.  \n",
+    "Note: The transform job is ephemeral and does not need deletion.\n"
+]))
+
+cells.append(make_code_cell([
+    'sm_client.delete_model(ModelName=model_name)\n',
+    'print(f"Deleting model: {model_name}...")\n',
+    '\n',
+    'print("\\n✅ All resources cleaned up")'
+]))
+<% } %>
+
+# ── Write notebook ───────────────────────────────────────────────────────────
+
+notebook = {
+    "nbformat": 4,
+    "nbformat_minor": 5,
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "name": "python",
+            "version": "3.10.0"
+        }
+    },
+    "cells": cells
+}
+
+output_path = "deploy_notebook.ipynb"
+with open(output_path, "w") as f:
+    json.dump(notebook, f, indent=1)
+
+print(f"\u2705 Notebook exported: ./{output_path}")

--- a/templates/do/export
+++ b/templates/do/export
@@ -2,16 +2,33 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Export current configuration as a CLI command or JSON object
-# Usage: ./do/export [--json]
+# Export current configuration as a CLI command, JSON object, or Jupyter notebook
+# Usage: ./do/export [--json | --notebook]
 
 # Source configuration (suppress the summary output)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/config" > /dev/null 2>&1
 
+# ── Notebook output mode ──────────────────────────────────────────────────────
+
+if [ "${1:-}" = "--notebook" ]; then
+    # Ensure not combined with --json
+    if [ "${2:-}" = "--json" ]; then
+        echo "Error: --notebook and --json are mutually exclusive" >&2
+        exit 1
+    fi
+    python3 "${SCRIPT_DIR}/../deploy_notebook_generator.py"
+    exit 0
+fi
+
 # ── JSON output mode ─────────────────────────────────────────────────────────
 
 if [ "${1:-}" = "--json" ]; then
+    # Ensure not combined with --notebook
+    if [ "${2:-}" = "--notebook" ]; then
+        echo "Error: --notebook and --json are mutually exclusive" >&2
+        exit 1
+    fi
     # Build a JSON object with all configuration parameters.
     # Uses ConfigManager camelCase keys so the output can be fed directly
     # back into the generator via --config=<file>.

--- a/templates/do/lib/endpoint-config.sh
+++ b/templates/do/lib/endpoint-config.sh
@@ -152,7 +152,9 @@ create_endpoint_config() {
         variant_json="${variant_json}}]"
     else
         # Standard path: single instance type
-        variant_json="[{\"VariantName\":\"AllTraffic\",\"InstanceType\":\"${INSTANCE_TYPE}\",\"InitialInstanceCount\":1"
+        # RoutingConfig is required for IC-based endpoints — without it the IC scheduler
+        # cannot place containers and the IC stays in Creating with no logs.
+        variant_json="[{\"VariantName\":\"AllTraffic\",\"InstanceType\":\"${INSTANCE_TYPE}\",\"InitialInstanceCount\":1,\"RoutingConfig\":{\"RoutingStrategy\":\"LEAST_OUTSTANDING_REQUESTS\"}"
 
         # Optional: AMI version
         if [ -n "${INFERENCE_AMI_VERSION:-}" ]; then

--- a/templates/do/lib/inference-component.sh
+++ b/templates/do/lib/inference-component.sh
@@ -46,10 +46,14 @@ create_inference_component() {
 
     # Build container spec JSON
     local container_spec="{\"Image\":\"${ECR_REPOSITORY}:${IC_IMAGE_TAG:-${PROJECT_NAME}-latest}\""
+    # Always inject IC name for CW log forwarder
+    local ic_env="\"INFERENCE_COMPONENT_NAME\":\"${ic_name}\""
     if [ -n "${CONTAINER_ENV_JSON}${IC_CONTAINER_ENV_EXTRA:-}" ]; then
         local env_json="${CONTAINER_ENV_JSON}"
         [ -n "${IC_CONTAINER_ENV_EXTRA:-}" ] && env_json="${env_json:+${env_json},}${IC_CONTAINER_ENV_EXTRA}"
-        container_spec="${container_spec},\"Environment\":{${env_json}}"
+        container_spec="${container_spec},\"Environment\":{${ic_env},${env_json}}"
+    else
+        container_spec="${container_spec},\"Environment\":{${ic_env}}"
     fi
     container_spec="${container_spec}}"
 

--- a/test/input-parsing-and-generation/endpoint-config-instance-pools.test.js
+++ b/test/input-parsing-and-generation/endpoint-config-instance-pools.test.js
@@ -205,7 +205,7 @@ create_endpoint_config 2>/dev/null
         assert.strictEqual(variant.InstanceType, 'ml.g5.xlarge');
         assert.strictEqual(variant.InitialInstanceCount, 1);
         assert.ok(!('InstancePools' in variant), 'Must NOT have InstancePools when using single type');
-        assert.ok(!('RoutingConfig' in variant), 'Must NOT have RoutingConfig when using single type');
+        assert.deepStrictEqual(variant.RoutingConfig, { RoutingStrategy: 'LEAST_OUTSTANDING_REQUESTS' }, 'IC-based endpoints require RoutingConfig for scheduler placement');
         assert.ok(!('VariantInstanceProvisionTimeoutInSeconds' in variant), 'Must NOT have timeout when using single type');
     });
 

--- a/test/input-parsing-and-generation/instance-pools-integration.test.js
+++ b/test/input-parsing-and-generation/instance-pools-integration.test.js
@@ -107,7 +107,7 @@ create_endpoint_config 2>/dev/null
             const variant = extractJson(result.stdout);
             assert.strictEqual(variant[0].InstanceType, 'ml.g5.xlarge');
             assert.ok(!('InstancePools' in variant[0]), 'Single selection must NOT produce InstancePools');
-            assert.ok(!('RoutingConfig' in variant[0]), 'Single selection must NOT have RoutingConfig');
+            assert.deepStrictEqual(variant[0].RoutingConfig, { RoutingStrategy: 'LEAST_OUTSTANDING_REQUESTS' }, 'IC-based endpoints require RoutingConfig for scheduler placement');
         });
     });
 

--- a/test/property/notebook-export.property.test.js
+++ b/test/property/notebook-export.property.test.js
@@ -1,0 +1,485 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Notebook Export Property-Based Tests
+ *
+ * Feature: notebook-export, Property 1: Valid JSON output for all config combos
+ * Feature: notebook-export, Property 4: All code cells have valid Python syntax
+ * Feature: notebook-export, Property 5: Section presence/absence matches branching matrix
+ * Feature: notebook-export, Property 7: Adapter IC creation never contains ComputeResourceRequirements
+ * Feature: notebook-export, Property 8: Tune section uses ModelTrainer with model_id matching MODEL_NAME
+ *
+ * Validates: Requirements 1.2, 1.3, 6.1, 7.1, 9.1, 9.5, 10.1, 10.4, 12.4, 12.5
+ */
+
+import fc from 'fast-check';
+import { describe, it } from 'mocha';
+import assert from 'assert';
+import ejs from 'ejs';
+import { readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ── Template loading ─────────────────────────────────────────────────────────
+
+const TEMPLATE_PATH = path.join(__dirname, '../../templates/deploy_notebook_generator.py');
+const TEMPLATE_CONTENT = readFileSync(TEMPLATE_PATH, 'utf8');
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const DEPLOYMENT_TARGETS = ['realtime-inference', 'async-inference', 'batch-transform'];
+const MODEL_SERVERS = ['vllm', 'sglang', 'tensorrt-llm', 'lmi', 'djl', 'flask'];
+
+/** Map model server to framework */
+function frameworkForServer(server) {
+    if (['flask'].includes(server)) return 'predictors';
+    return 'transformers';
+}
+
+const FAST_PROPERTY_CONFIG = {
+    numRuns: 50,
+    timeout: 120000,
+    verbose: false
+};
+
+// ── Temp directory for script execution ──────────────────────────────────────
+
+const TMP_DIR = path.join(__dirname, '../../.kiro/tmp');
+mkdirSync(TMP_DIR, { recursive: true });
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Render the EJS template with given config and return the Python script content.
+ */
+function renderTemplate(config) {
+    const vars = {
+        deploymentTarget: config.deploymentTarget,
+        modelServer: config.modelServer,
+        framework: config.framework,
+        enableLora: config.enableLora || false,
+        tuneSupported: config.tuneSupported || false,
+        orderedEnvVars: config.orderedEnvVars || [
+            { key: 'HF_MODEL_ID', value: 'meta-llama/Llama-3-8B' }
+        ],
+        hfTokenArn: config.hfTokenArn || '',
+        hfToken: config.hfToken || '',
+        ngcTokenArn: config.ngcTokenArn || '',
+        ngcApiKey: config.ngcApiKey || '',
+        inferenceAmiVersion: config.inferenceAmiVersion || '',
+        existingEndpointName: config.existingEndpointName || '',
+    };
+    return ejs.render(TEMPLATE_CONTENT, vars);
+}
+
+/**
+ * Execute the rendered Python script and return the notebook JSON.
+ * Sets required environment variables for the script.
+ */
+function executeScript(scriptContent, config) {
+    const scriptPath = path.join(TMP_DIR, `notebook-test-${Date.now()}-${Math.random().toString(36).slice(2)}.py`);
+    const outputPath = path.join(TMP_DIR, `notebook-test-${Date.now()}-${Math.random().toString(36).slice(2)}.ipynb`);
+
+    // Patch the script to write to our specific output path
+    const patchedScript = scriptContent.replace(
+        'output_path = "deploy_notebook.ipynb"',
+        `output_path = "${outputPath.replace(/\\/g, '/')}"`
+    );
+
+    writeFileSync(scriptPath, patchedScript, { mode: 0o755 });
+
+    const envVars = {
+        ...process.env,
+        PROJECT_NAME: 'test-project',
+        AWS_REGION: 'us-west-2',
+        INSTANCE_TYPE: 'ml.g5.2xlarge',
+        MODEL_SERVER: config.modelServer,
+        FRAMEWORK: config.framework,
+        DEPLOYMENT_TARGET: config.deploymentTarget,
+        IC_GPU_COUNT: '1',
+        IC_MEMORY_SIZE: '4096',
+        CODEBUILD_PROJECT_NAME: 'test-project-build',
+        ENABLE_LORA: config.enableLora ? 'true' : 'false',
+        TUNE_SUPPORTED: config.tuneSupported ? 'true' : 'false',
+        TUNE_S3_BUCKET: 'test-tune-bucket',
+        MODEL_NAME: 'meta-llama/Llama-3-8B-Instruct',
+        HF_TOKEN_ARN: config.hfTokenArn || '',
+        HF_TOKEN: config.hfToken || '',
+        NGC_API_KEY_ARN: config.ngcTokenArn || '',
+        NGC_API_KEY: config.ngcApiKey || '',
+        INFERENCE_AMI_VERSION: config.inferenceAmiVersion || '',
+    };
+
+    try {
+        execSync(`python3 "${scriptPath}"`, {
+            encoding: 'utf8',
+            timeout: 10000,
+            env: envVars,
+            cwd: TMP_DIR,
+        });
+
+        const notebookContent = readFileSync(outputPath, 'utf8');
+        return JSON.parse(notebookContent);
+    } finally {
+        try { unlinkSync(scriptPath); } catch (e) { /* ignore */ }
+        try { unlinkSync(outputPath); } catch (e) { /* ignore */ }
+    }
+}
+
+/**
+ * Render and execute the template for a given config, returning the notebook JSON.
+ */
+function generateNotebook(config) {
+    const script = renderTemplate(config);
+    return executeScript(script, config);
+}
+
+/**
+ * Extract all code cell sources as strings from a notebook.
+ */
+function getCodeCells(notebook) {
+    return notebook.cells
+        .filter(c => c.cell_type === 'code')
+        .map(c => c.source.join(''));
+}
+
+/**
+ * Extract all markdown cell sources as strings from a notebook.
+ */
+function getMarkdownCells(notebook) {
+    return notebook.cells
+        .filter(c => c.cell_type === 'markdown')
+        .map(c => c.source.join(''));
+}
+
+/**
+ * Get all cell sources concatenated (for searching).
+ */
+function getAllCellText(notebook) {
+    return notebook.cells.map(c => c.source.join('')).join('\n');
+}
+
+// ── Arbitrary generators ─────────────────────────────────────────────────────
+
+/** Generate a valid config combination */
+const arbConfig = fc.record({
+    deploymentTarget: fc.constantFrom(...DEPLOYMENT_TARGETS),
+    modelServer: fc.constantFrom(...MODEL_SERVERS),
+    enableLora: fc.boolean(),
+    tuneSupported: fc.boolean(),
+}).map(config => ({
+    ...config,
+    framework: frameworkForServer(config.modelServer),
+}));
+
+// ── Property 1: Valid JSON output ────────────────────────────────────────────
+
+describe('Feature: notebook-export, Property 1: Valid JSON output for all config combos', function () {
+    this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+    it('every (deploymentTarget × modelServer × enableLora × tuneSupported) combo produces valid JSON', function () {
+        /**
+         * Validates: Requirements 1.2, 12.4, 12.5
+         */
+        fc.assert(fc.property(
+            arbConfig,
+            (config) => {
+                const notebook = generateNotebook(config);
+
+                // Must have nbformat v4 structure
+                assert.strictEqual(notebook.nbformat, 4, 'nbformat must be 4');
+                assert.strictEqual(notebook.nbformat_minor, 5, 'nbformat_minor must be 5');
+                assert.ok(notebook.metadata, 'metadata must exist');
+                assert.ok(notebook.metadata.kernelspec, 'kernelspec must exist');
+                assert.ok(Array.isArray(notebook.cells), 'cells must be an array');
+
+                // Every cell must have valid cell_type
+                for (const cell of notebook.cells) {
+                    assert.ok(
+                        cell.cell_type === 'code' || cell.cell_type === 'markdown',
+                        `cell_type must be "code" or "markdown", got "${cell.cell_type}"`
+                    );
+                    assert.ok(Array.isArray(cell.source), 'source must be an array');
+                    assert.deepStrictEqual(cell.metadata, {}, 'metadata must be empty object');
+
+                    if (cell.cell_type === 'code') {
+                        assert.deepStrictEqual(cell.outputs, [], 'outputs must be empty array');
+                        assert.strictEqual(cell.execution_count, null, 'execution_count must be null');
+                    }
+                }
+
+                return true;
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+    });
+});
+
+// ── Property 4: All code cells have valid Python syntax ──────────────────────
+
+describe('Feature: notebook-export, Property 4: All code cells have valid Python syntax', function () {
+    this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+    it('every code cell passes ast.parse()', function () {
+        /**
+         * Validates: Requirements 1.3, 12.5
+         */
+        fc.assert(fc.property(
+            arbConfig,
+            (config) => {
+                const notebook = generateNotebook(config);
+                const codeCells = getCodeCells(notebook);
+
+                for (const code of codeCells) {
+                    // Skip pip magic commands (not valid Python syntax for ast.parse)
+                    if (code.trim().startsWith('%pip') || code.trim().startsWith('!')) {
+                        continue;
+                    }
+
+                    // Use python3 -c to validate syntax via ast.parse
+                    const checkScript = path.join(TMP_DIR, `syntax-check-${Date.now()}-${Math.random().toString(36).slice(2)}.py`);
+                    const codeB64 = Buffer.from(code).toString('base64');
+                    writeFileSync(checkScript, `import ast, base64\ncode = base64.b64decode("${codeB64}").decode("utf-8")\nast.parse(code)\n`);
+
+                    try {
+                        execSync(`python3 "${checkScript}"`, {
+                            encoding: 'utf8',
+                            timeout: 5000,
+                        });
+                    } catch (e) {
+                        assert.fail(
+                            `Code cell failed ast.parse() for config ${JSON.stringify({
+                                deploymentTarget: config.deploymentTarget,
+                                modelServer: config.modelServer,
+                            })}:\n${code.substring(0, 200)}...\nError: ${e.stderr || e.message}`
+                        );
+                    } finally {
+                        try { unlinkSync(checkScript); } catch (e) { /* ignore */ }
+                    }
+                }
+
+                return true;
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+    });
+});
+
+// ── Property 5: Section presence/absence matches branching matrix ────────────
+
+describe('Feature: notebook-export, Property 5: Section presence/absence matches branching matrix', function () {
+    this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+    it('IC section only present for realtime-inference', function () {
+        /**
+         * Validates: Requirements 6.1, 7.1
+         */
+        fc.assert(fc.property(
+            arbConfig,
+            (config) => {
+                const notebook = generateNotebook(config);
+                const allText = getAllCellText(notebook);
+
+                const hasICSection = allText.includes('Create Inference Component') ||
+                    allText.includes('create_inference_component');
+
+                if (config.deploymentTarget === 'realtime-inference') {
+                    assert.ok(hasICSection,
+                        'realtime-inference must have IC section');
+                } else {
+                    // For async/batch, the base IC section should not be present
+                    // (no "Create Inference Component" heading)
+                    const hasICHeading = getMarkdownCells(notebook).some(
+                        md => md.includes('## Create Inference Component')
+                    );
+                    assert.ok(!hasICHeading,
+                        `${config.deploymentTarget} must NOT have IC section heading`);
+                }
+
+                return true;
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+    });
+
+    it('adapter section only present for realtime + enableLora', function () {
+        /**
+         * Validates: Requirements 9.1
+         */
+        fc.assert(fc.property(
+            arbConfig,
+            (config) => {
+                const notebook = generateNotebook(config);
+                const allText = getAllCellText(notebook);
+
+                const hasAdapterSection = allText.includes('LoRA Adapter') &&
+                    allText.includes('BaseInferenceComponentName');
+
+                if (config.deploymentTarget === 'realtime-inference' && config.enableLora) {
+                    assert.ok(hasAdapterSection,
+                        'realtime + enableLora must have adapter section');
+                } else {
+                    assert.ok(!hasAdapterSection,
+                        `${config.deploymentTarget} + enableLora=${config.enableLora} must NOT have adapter section`);
+                }
+
+                return true;
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+    });
+
+    it('tune section only present for realtime + tuneSupported', function () {
+        /**
+         * Validates: Requirements 10.1
+         */
+        fc.assert(fc.property(
+            arbConfig,
+            (config) => {
+                const notebook = generateNotebook(config);
+                const allText = getAllCellText(notebook);
+
+                const hasTuneSection = allText.includes('Managed Fine-Tuning') &&
+                    allText.includes('ModelTrainer');
+
+                if (config.deploymentTarget === 'realtime-inference' && config.tuneSupported) {
+                    assert.ok(hasTuneSection,
+                        'realtime + tuneSupported must have tune section');
+                } else {
+                    assert.ok(!hasTuneSection,
+                        `${config.deploymentTarget} + tuneSupported=${config.tuneSupported} must NOT have tune section`);
+                }
+
+                return true;
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+    });
+
+    it('async config only present for async-inference', function () {
+        /**
+         * Validates: Requirements 6.1
+         */
+        fc.assert(fc.property(
+            arbConfig,
+            (config) => {
+                const notebook = generateNotebook(config);
+                const allText = getAllCellText(notebook);
+
+                const hasAsyncConfig = allText.includes('AsyncInferenceConfig');
+
+                if (config.deploymentTarget === 'async-inference') {
+                    assert.ok(hasAsyncConfig,
+                        'async-inference must have AsyncInferenceConfig');
+                } else {
+                    assert.ok(!hasAsyncConfig,
+                        `${config.deploymentTarget} must NOT have AsyncInferenceConfig`);
+                }
+
+                return true;
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+    });
+
+    it('transform job only present for batch-transform', function () {
+        /**
+         * Validates: Requirements 6.1
+         */
+        fc.assert(fc.property(
+            arbConfig,
+            (config) => {
+                const notebook = generateNotebook(config);
+                const allText = getAllCellText(notebook);
+
+                const hasTransformJob = allText.includes('create_transform_job');
+
+                if (config.deploymentTarget === 'batch-transform') {
+                    assert.ok(hasTransformJob,
+                        'batch-transform must have create_transform_job');
+                } else {
+                    assert.ok(!hasTransformJob,
+                        `${config.deploymentTarget} must NOT have create_transform_job`);
+                }
+
+                return true;
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+    });
+});
+
+// ── Property 7: Adapter IC never contains ComputeResourceRequirements ────────
+
+describe('Feature: notebook-export, Property 7: Adapter IC creation never contains ComputeResourceRequirements', function () {
+    this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+    it('adapter IC uses BaseInferenceComponentName without ComputeResourceRequirements', function () {
+        /**
+         * Validates: Requirements 9.5
+         */
+        fc.assert(fc.property(
+            arbConfig.filter(c => c.deploymentTarget === 'realtime-inference' && c.enableLora),
+            (config) => {
+                const notebook = generateNotebook(config);
+                const codeCells = getCodeCells(notebook);
+
+                // Find the adapter IC creation cell (contains BaseInferenceComponentName)
+                const adapterCells = codeCells.filter(code =>
+                    code.includes('BaseInferenceComponentName')
+                );
+
+                assert.ok(adapterCells.length > 0,
+                    'Must have at least one cell with BaseInferenceComponentName');
+
+                for (const adapterCode of adapterCells) {
+                    assert.ok(!adapterCode.includes('ComputeResourceRequirements'),
+                        'Adapter IC creation must NOT contain ComputeResourceRequirements');
+                }
+
+                return true;
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+    });
+});
+
+// ── Property 8: Tune section uses ModelTrainer with model_id matching MODEL_NAME ─
+
+describe('Feature: notebook-export, Property 8: Tune section uses ModelTrainer with model_id matching MODEL_NAME', function () {
+    this.timeout(FAST_PROPERTY_CONFIG.timeout);
+
+    it('tune section references ModelTrainer with model_id=MODEL_NAME from env', function () {
+        /**
+         * Validates: Requirements 10.4
+         */
+        fc.assert(fc.property(
+            arbConfig.filter(c => c.deploymentTarget === 'realtime-inference' && c.tuneSupported),
+            (config) => {
+                const notebook = generateNotebook(config);
+                const codeCells = getCodeCells(notebook);
+
+                // Find the cell that imports and uses ModelTrainer
+                const trainerCells = codeCells.filter(code =>
+                    code.includes('ModelTrainer')
+                );
+
+                assert.ok(trainerCells.length > 0,
+                    'Must have at least one cell with ModelTrainer');
+
+                // The trainer cell must use model_id=MODEL_NAME
+                const trainerCell = trainerCells.find(code =>
+                    code.includes('model_id=MODEL_NAME')
+                );
+                assert.ok(trainerCell,
+                    'ModelTrainer must use model_id=MODEL_NAME');
+
+                // MODEL_NAME must be set from the env var
+                const modelNameCell = codeCells.find(code =>
+                    code.includes('MODEL_NAME') && code.includes('meta-llama/Llama-3-8B-Instruct')
+                );
+                assert.ok(modelNameCell,
+                    'MODEL_NAME variable must be set from MODEL_NAME env var');
+
+                return true;
+            }
+        ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
+    });
+});

--- a/test/property/notebook-export.property.test.js
+++ b/test/property/notebook-export.property.test.js
@@ -72,7 +72,7 @@ function renderTemplate(config) {
         ngcTokenArn: config.ngcTokenArn || '',
         ngcApiKey: config.ngcApiKey || '',
         inferenceAmiVersion: config.inferenceAmiVersion || '',
-        existingEndpointName: config.existingEndpointName || '',
+        existingEndpointName: config.existingEndpointName || ''
     };
     return ejs.render(TEMPLATE_CONTENT, vars);
 }
@@ -112,7 +112,7 @@ function executeScript(scriptContent, config) {
         HF_TOKEN: config.hfToken || '',
         NGC_API_KEY_ARN: config.ngcTokenArn || '',
         NGC_API_KEY: config.ngcApiKey || '',
-        INFERENCE_AMI_VERSION: config.inferenceAmiVersion || '',
+        INFERENCE_AMI_VERSION: config.inferenceAmiVersion || ''
     };
 
     try {
@@ -120,7 +120,7 @@ function executeScript(scriptContent, config) {
             encoding: 'utf8',
             timeout: 10000,
             env: envVars,
-            cwd: TMP_DIR,
+            cwd: TMP_DIR
         });
 
         const notebookContent = readFileSync(outputPath, 'utf8');
@@ -171,10 +171,10 @@ const arbConfig = fc.record({
     deploymentTarget: fc.constantFrom(...DEPLOYMENT_TARGETS),
     modelServer: fc.constantFrom(...MODEL_SERVERS),
     enableLora: fc.boolean(),
-    tuneSupported: fc.boolean(),
+    tuneSupported: fc.boolean()
 }).map(config => ({
     ...config,
-    framework: frameworkForServer(config.modelServer),
+    framework: frameworkForServer(config.modelServer)
 }));
 
 // ── Property 1: Valid JSON output ────────────────────────────────────────────
@@ -182,7 +182,7 @@ const arbConfig = fc.record({
 describe('Feature: notebook-export, Property 1: Valid JSON output for all config combos', function () {
     this.timeout(FAST_PROPERTY_CONFIG.timeout);
 
-    it('every (deploymentTarget × modelServer × enableLora × tuneSupported) combo produces valid JSON', function () {
+    it('every (deploymentTarget × modelServer × enableLora × tuneSupported) combo produces valid JSON', () => {
         /**
          * Validates: Requirements 1.2, 12.4, 12.5
          */
@@ -224,7 +224,7 @@ describe('Feature: notebook-export, Property 1: Valid JSON output for all config
 describe('Feature: notebook-export, Property 4: All code cells have valid Python syntax', function () {
     this.timeout(FAST_PROPERTY_CONFIG.timeout);
 
-    it('every code cell passes ast.parse()', function () {
+    it('every code cell passes ast.parse()', () => {
         /**
          * Validates: Requirements 1.3, 12.5
          */
@@ -248,13 +248,13 @@ describe('Feature: notebook-export, Property 4: All code cells have valid Python
                     try {
                         execSync(`python3 "${checkScript}"`, {
                             encoding: 'utf8',
-                            timeout: 5000,
+                            timeout: 5000
                         });
                     } catch (e) {
                         assert.fail(
                             `Code cell failed ast.parse() for config ${JSON.stringify({
                                 deploymentTarget: config.deploymentTarget,
-                                modelServer: config.modelServer,
+                                modelServer: config.modelServer
                             })}:\n${code.substring(0, 200)}...\nError: ${e.stderr || e.message}`
                         );
                     } finally {
@@ -273,7 +273,7 @@ describe('Feature: notebook-export, Property 4: All code cells have valid Python
 describe('Feature: notebook-export, Property 5: Section presence/absence matches branching matrix', function () {
     this.timeout(FAST_PROPERTY_CONFIG.timeout);
 
-    it('IC section only present for realtime-inference', function () {
+    it('IC section only present for realtime-inference', () => {
         /**
          * Validates: Requirements 6.1, 7.1
          */
@@ -304,7 +304,7 @@ describe('Feature: notebook-export, Property 5: Section presence/absence matches
         ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
     });
 
-    it('adapter section only present for realtime + enableLora', function () {
+    it('adapter section only present for realtime + enableLora', () => {
         /**
          * Validates: Requirements 9.1
          */
@@ -330,7 +330,7 @@ describe('Feature: notebook-export, Property 5: Section presence/absence matches
         ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
     });
 
-    it('tune section only present for realtime + tuneSupported', function () {
+    it('tune section only present for realtime + tuneSupported', () => {
         /**
          * Validates: Requirements 10.1
          */
@@ -356,7 +356,7 @@ describe('Feature: notebook-export, Property 5: Section presence/absence matches
         ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
     });
 
-    it('async config only present for async-inference', function () {
+    it('async config only present for async-inference', () => {
         /**
          * Validates: Requirements 6.1
          */
@@ -381,7 +381,7 @@ describe('Feature: notebook-export, Property 5: Section presence/absence matches
         ), { numRuns: FAST_PROPERTY_CONFIG.numRuns, verbose: FAST_PROPERTY_CONFIG.verbose });
     });
 
-    it('transform job only present for batch-transform', function () {
+    it('transform job only present for batch-transform', () => {
         /**
          * Validates: Requirements 6.1
          */
@@ -412,7 +412,7 @@ describe('Feature: notebook-export, Property 5: Section presence/absence matches
 describe('Feature: notebook-export, Property 7: Adapter IC creation never contains ComputeResourceRequirements', function () {
     this.timeout(FAST_PROPERTY_CONFIG.timeout);
 
-    it('adapter IC uses BaseInferenceComponentName without ComputeResourceRequirements', function () {
+    it('adapter IC uses BaseInferenceComponentName without ComputeResourceRequirements', () => {
         /**
          * Validates: Requirements 9.5
          */
@@ -446,7 +446,7 @@ describe('Feature: notebook-export, Property 7: Adapter IC creation never contai
 describe('Feature: notebook-export, Property 8: Tune section uses ModelTrainer with model_id matching MODEL_NAME', function () {
     this.timeout(FAST_PROPERTY_CONFIG.timeout);
 
-    it('tune section references ModelTrainer with model_id=MODEL_NAME from env', function () {
+    it('tune section references ModelTrainer with model_id=MODEL_NAME from env', () => {
         /**
          * Validates: Requirements 10.4
          */

--- a/test/unit/notebook-export.test.js
+++ b/test/unit/notebook-export.test.js
@@ -19,7 +19,7 @@
  * Validates: Requirements 1.2, 1.3, 4.1, 6.1, 9.1, 9.4, 9.5, 10.1, 13.1, 13.7
  */
 
-import { describe, it, beforeEach, afterEach } from 'mocha';
+import { describe, it, afterEach } from 'mocha';
 import assert from 'node:assert';
 import ejs from 'ejs';
 import { readFileSync, writeFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';

--- a/test/unit/notebook-export.test.js
+++ b/test/unit/notebook-export.test.js
@@ -1,0 +1,546 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the notebook export feature (deploy_notebook_generator.py template).
+ *
+ * Tests cover:
+ * - Valid nbformat v4 JSON output for all deployment target × model server combos
+ * - No secrets in rendered output when ARNs are used
+ * - Env vars from config appear in configuration cell as Python literals
+ * - LMI/DJL path skips CodeBuild section
+ * - INFERENCE_AMI_VERSION included in endpoint config when set
+ * - Adapter section present/absent based on ENABLE_LORA + realtime
+ * - Tune section present/absent based on TUNE_SUPPORTED + realtime
+ * - Adapter section uses BaseInferenceComponentName (no ComputeResourceRequirements)
+ * - Tune section pre-fills ADAPTER_WEIGHTS_URI from TUNE_ADAPTER_PATH
+ *
+ * Feature: notebook-export
+ * Validates: Requirements 1.2, 1.3, 4.1, 6.1, 9.1, 9.4, 9.5, 10.1, 13.1, 13.7
+ */
+
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import assert from 'node:assert';
+import ejs from 'ejs';
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import os from 'node:os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMPLATE_PATH = resolve(__dirname, '../../templates/deploy_notebook_generator.py');
+const TEMPLATE = readFileSync(TEMPLATE_PATH, 'utf-8');
+
+// ── Helper: render the EJS template to a Python script ───────────────────────
+
+function renderTemplate(overrides = {}) {
+    const vars = {
+        projectName: 'test-project',
+        deploymentConfig: 'transformers-vllm',
+        framework: 'transformers',
+        modelServer: 'vllm',
+        awsRegion: 'us-east-1',
+        deploymentTarget: 'realtime-inference',
+        instanceType: 'ml.g5.xlarge',
+        modelName: 'meta-llama/Llama-2-7b-hf',
+        hfToken: '',
+        hfTokenArn: '',
+        ngcApiKey: '',
+        ngcTokenArn: '',
+        orderedEnvVars: [],
+        inferenceAmiVersion: '',
+        enableLora: false,
+        tuneSupported: false,
+        existingEndpointName: null,
+        ...overrides
+    };
+    return ejs.render(TEMPLATE, vars);
+}
+
+// ── Helper: execute the rendered Python script and return parsed notebook ─────
+
+function executeNotebookGenerator(pythonScript, envOverrides = {}) {
+    const tmpDir = mkdtempSync(join(os.tmpdir(), 'notebook-test-'));
+    const scriptPath = join(tmpDir, 'deploy_notebook_generator.py');
+    writeFileSync(scriptPath, pythonScript);
+
+    const env = {
+        PROJECT_NAME: 'test-project',
+        AWS_REGION: 'us-east-1',
+        INSTANCE_TYPE: 'ml.g5.xlarge',
+        MODEL_SERVER: 'vllm',
+        DEPLOYMENT_TARGET: 'realtime-inference',
+        FRAMEWORK: 'transformers',
+        IC_GPU_COUNT: '4',
+        IC_MEMORY_SIZE: '65536',
+        ...envOverrides
+    };
+
+    try {
+        execFileSync('python3', [scriptPath], {
+            cwd: tmpDir,
+            env,
+            timeout: 15000,
+            stdio: 'pipe'
+        });
+
+        const notebookPath = join(tmpDir, 'deploy_notebook.ipynb');
+        assert.ok(existsSync(notebookPath), 'deploy_notebook.ipynb should be created');
+        const notebookContent = readFileSync(notebookPath, 'utf-8');
+        const notebook = JSON.parse(notebookContent);
+        return { notebook, tmpDir, notebookContent };
+    } catch (error) {
+        const stdout = error.stdout ? error.stdout.toString() : '';
+        const stderr = error.stderr ? error.stderr.toString() : '';
+        rmSync(tmpDir, { recursive: true, force: true });
+        throw new Error(
+            `Python script execution failed:\n  stdout: ${stdout.substring(0, 500)}\n  stderr: ${stderr.substring(0, 500)}`
+        );
+    }
+}
+
+// ── Helper: validate nbformat v4 structure ───────────────────────────────────
+
+function assertValidNbformat(notebook) {
+    assert.strictEqual(notebook.nbformat, 4, 'nbformat must be 4');
+    assert.strictEqual(notebook.nbformat_minor, 5, 'nbformat_minor must be 5');
+    assert.ok(notebook.metadata, 'metadata must exist');
+    assert.ok(notebook.metadata.kernelspec, 'kernelspec must exist');
+    assert.strictEqual(notebook.metadata.kernelspec.language, 'python');
+    assert.ok(Array.isArray(notebook.cells), 'cells must be an array');
+    assert.ok(notebook.cells.length > 0, 'cells must not be empty');
+
+    for (const cell of notebook.cells) {
+        assert.ok(
+            cell.cell_type === 'code' || cell.cell_type === 'markdown',
+            `cell_type must be "code" or "markdown", got "${cell.cell_type}"`
+        );
+        assert.ok(Array.isArray(cell.source), 'cell source must be an array');
+        assert.deepStrictEqual(cell.metadata, {}, 'cell metadata must be empty object');
+
+        if (cell.cell_type === 'code') {
+            assert.deepStrictEqual(cell.outputs, [], 'code cell outputs must be empty array');
+            assert.strictEqual(cell.execution_count, null, 'execution_count must be null');
+        }
+    }
+}
+
+// ── Helper: get all cell sources concatenated ────────────────────────────────
+
+function getAllCellSource(notebook) {
+    return notebook.cells.map(c => c.source.join('')).join('\n');
+}
+
+function getCodeCellSources(notebook) {
+    return notebook.cells
+        .filter(c => c.cell_type === 'code')
+        .map(c => c.source.join(''));
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Feature: notebook-export — Unit Tests', function () {
+    this.timeout(30000);
+
+    let tmpDirs = [];
+
+    afterEach(() => {
+        for (const dir of tmpDirs) {
+            if (existsSync(dir)) {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        }
+        tmpDirs = [];
+    });
+
+    describe('realtime + vllm config → valid nbformat JSON', () => {
+        it('renders and executes to produce valid nbformat v4 notebook', () => {
+            const script = renderTemplate({
+                framework: 'transformers',
+                modelServer: 'vllm',
+                deploymentTarget: 'realtime-inference',
+                orderedEnvVars: [{ key: 'VLLM_MODEL', value: 'meta-llama/Llama-2-7b-hf' }]
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script, {
+                VLLM_MODEL: 'meta-llama/Llama-2-7b-hf'
+            });
+            tmpDirs.push(tmpDir);
+
+            assertValidNbformat(notebook);
+            const allSource = getAllCellSource(notebook);
+            assert.ok(allSource.includes('create_endpoint'), 'should contain endpoint creation');
+            assert.ok(allSource.includes('create_inference_component'), 'should contain IC creation');
+        });
+    });
+
+    describe('realtime + tensorrt-llm config → valid nbformat JSON', () => {
+        it('renders and executes to produce valid nbformat v4 notebook', () => {
+            const script = renderTemplate({
+                framework: 'transformers',
+                modelServer: 'tensorrt-llm',
+                deploymentTarget: 'realtime-inference',
+                orderedEnvVars: [{ key: 'TRTLLM_MODEL', value: 'meta-llama/Llama-2-7b-hf' }]
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script, {
+                TRTLLM_MODEL: 'meta-llama/Llama-2-7b-hf'
+            });
+            tmpDirs.push(tmpDir);
+
+            assertValidNbformat(notebook);
+        });
+    });
+
+    describe('async + sglang config → valid nbformat JSON', () => {
+        it('renders and executes to produce valid nbformat v4 notebook', () => {
+            const script = renderTemplate({
+                framework: 'transformers',
+                modelServer: 'sglang',
+                deploymentTarget: 'async-inference',
+                orderedEnvVars: [{ key: 'SGLANG_MODEL_PATH', value: 'meta-llama/Llama-2-7b-hf' }]
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script, {
+                SGLANG_MODEL_PATH: 'meta-llama/Llama-2-7b-hf'
+            });
+            tmpDirs.push(tmpDir);
+
+            assertValidNbformat(notebook);
+            const allSource = getAllCellSource(notebook);
+            assert.ok(allSource.includes('AsyncInferenceConfig'), 'should contain async config');
+            assert.ok(allSource.includes('invoke_endpoint_async'), 'should contain async invocation');
+            assert.ok(!allSource.includes('create_inference_component'), 'should NOT contain IC for async');
+        });
+    });
+
+    describe('batch + flask config → valid nbformat JSON', () => {
+        it('renders and executes to produce valid nbformat v4 notebook', () => {
+            const script = renderTemplate({
+                framework: 'sklearn',
+                modelServer: 'flask',
+                deploymentTarget: 'batch-transform',
+                orderedEnvVars: [{ key: 'MODEL_PATH', value: '/opt/ml/model' }]
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script, {
+                MODEL_PATH: '/opt/ml/model'
+            });
+            tmpDirs.push(tmpDir);
+
+            assertValidNbformat(notebook);
+            const allSource = getAllCellSource(notebook);
+            assert.ok(allSource.includes('create_transform_job'), 'should contain transform job');
+            assert.ok(!allSource.includes('create_endpoint('), 'should NOT contain endpoint for batch');
+            assert.ok(!allSource.includes('create_inference_component'), 'should NOT contain IC for batch');
+        });
+    });
+
+    describe('no secrets in rendered output when HF_TOKEN_ARN is used', () => {
+        it('does not hardcode any secret value in the notebook', () => {
+            const script = renderTemplate({
+                hfTokenArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:hf-token-AbCdEf',
+                hfToken: ''
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script, {
+                HF_TOKEN_ARN: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:hf-token-AbCdEf'
+            });
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            // Should reference Secrets Manager resolution, not a hardcoded token
+            assert.ok(allSource.includes('get_secret_value'), 'should use Secrets Manager resolution');
+            assert.ok(allSource.includes('HF_TOKEN_ARN'), 'should reference the ARN variable');
+            // Should not contain a hardcoded HF token value (tokens start with hf_xxxx pattern)
+            // The env["HF_TOKEN"] assignment should come from secrets resolution, not a literal
+            const codeCells = getCodeCellSources(notebook);
+            const secretsCell = codeCells.find(src => src.includes('HF_TOKEN_ARN'));
+            assert.ok(secretsCell, 'should have a cell referencing HF_TOKEN_ARN');
+            assert.ok(
+                secretsCell.includes('get_secret_value'),
+                'HF_TOKEN should be resolved via Secrets Manager, not hardcoded'
+            );
+            // Ensure no cell directly assigns a literal token value to HF_TOKEN
+            const hasHardcodedToken = codeCells.some(src =>
+                /env\["HF_TOKEN"\]\s*=\s*"hf_/.test(src)
+            );
+            assert.ok(!hasHardcodedToken, 'should not contain a hardcoded HF_TOKEN literal value');
+        });
+    });
+
+    describe('no secrets in rendered output when NGC_API_KEY_ARN is used', () => {
+        it('does not hardcode any secret value in the notebook', () => {
+            const script = renderTemplate({
+                ngcTokenArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:ngc-key-XyZ123',
+                ngcApiKey: ''
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script, {
+                NGC_API_KEY_ARN: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:ngc-key-XyZ123'
+            });
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(allSource.includes('get_secret_value'), 'should use Secrets Manager resolution');
+            assert.ok(allSource.includes('NGC_API_KEY_ARN'), 'should reference the ARN variable');
+            assert.ok(!allSource.includes('nvapi-'), 'should not contain any nvapi- key value');
+        });
+    });
+
+    describe('env vars from config appear in configuration cell as Python literals', () => {
+        it('bakes ordered env vars into the env dict cell', () => {
+            const script = renderTemplate({
+                orderedEnvVars: [
+                    { key: 'VLLM_MODEL', value: 'meta-llama/Llama-2-7b-hf' },
+                    { key: 'VLLM_MAX_MODEL_LEN', value: '4096' },
+                    { key: 'VLLM_TENSOR_PARALLEL_SIZE', value: '4' }
+                ]
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script, {
+                VLLM_MODEL: 'meta-llama/Llama-2-7b-hf',
+                VLLM_MAX_MODEL_LEN: '4096',
+                VLLM_TENSOR_PARALLEL_SIZE: '4'
+            });
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(allSource.includes('"VLLM_MODEL"'), 'should contain VLLM_MODEL key');
+            assert.ok(allSource.includes('"VLLM_MAX_MODEL_LEN"'), 'should contain VLLM_MAX_MODEL_LEN key');
+            assert.ok(allSource.includes('"VLLM_TENSOR_PARALLEL_SIZE"'), 'should contain VLLM_TENSOR_PARALLEL_SIZE key');
+            assert.ok(allSource.includes('meta-llama/Llama-2-7b-hf'), 'should contain model value');
+            assert.ok(allSource.includes('4096'), 'should contain max model len value');
+        });
+    });
+
+    describe('LMI/DJL path skips CodeBuild section', () => {
+        it('uses DLC image URI instead of CodeBuild for lmi server', () => {
+            const script = renderTemplate({
+                modelServer: 'lmi',
+                framework: 'transformers',
+                deploymentTarget: 'realtime-inference'
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script);
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(!allSource.includes('codebuild'), 'should NOT contain codebuild for LMI');
+            assert.ok(!allSource.includes('start_build'), 'should NOT contain start_build for LMI');
+            assert.ok(allSource.includes('image_uris.retrieve'), 'should use DLC image_uris.retrieve');
+            assert.ok(allSource.includes('DLC Image URI'), 'should reference DLC');
+        });
+
+        it('uses DLC image URI instead of CodeBuild for djl server', () => {
+            const script = renderTemplate({
+                modelServer: 'djl',
+                framework: 'transformers',
+                deploymentTarget: 'realtime-inference'
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script);
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(!allSource.includes('codebuild'), 'should NOT contain codebuild for DJL');
+            assert.ok(!allSource.includes('start_build'), 'should NOT contain start_build for DJL');
+            assert.ok(allSource.includes('image_uris.retrieve'), 'should use DLC image_uris.retrieve');
+        });
+    });
+
+    describe('INFERENCE_AMI_VERSION included in endpoint config when set', () => {
+        it('includes InferenceAmiVersion conditional in endpoint config', () => {
+            const script = renderTemplate({
+                deploymentTarget: 'realtime-inference',
+                inferenceAmiVersion: 'al2-ami-sagemaker-inference-gpu-2.3.1'
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script, {
+                INFERENCE_AMI_VERSION: 'al2-ami-sagemaker-inference-gpu-2.3.1'
+            });
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(allSource.includes('INFERENCE_AMI_VERSION'), 'should reference INFERENCE_AMI_VERSION');
+            assert.ok(allSource.includes('InferenceAmiVersion'), 'should include InferenceAmiVersion in endpoint config');
+            assert.ok(allSource.includes('al2-ami-sagemaker-inference-gpu-2.3.1'), 'should contain the AMI version value');
+        });
+    });
+
+    describe('adapter section present when ENABLE_LORA=true + realtime, absent otherwise', () => {
+        it('includes adapter section when enableLora=true and realtime', () => {
+            const script = renderTemplate({
+                enableLora: true,
+                deploymentTarget: 'realtime-inference',
+                framework: 'transformers'
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script);
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(allSource.includes('LoRA Adapter'), 'should contain LoRA Adapter section');
+            assert.ok(allSource.includes('ADAPTER_NAME'), 'should contain ADAPTER_NAME variable');
+            assert.ok(allSource.includes('ADAPTER_WEIGHTS_URI'), 'should contain ADAPTER_WEIGHTS_URI variable');
+        });
+
+        it('excludes adapter section when enableLora=false', () => {
+            const script = renderTemplate({
+                enableLora: false,
+                deploymentTarget: 'realtime-inference',
+                framework: 'transformers'
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script);
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(!allSource.includes('LoRA Adapter'), 'should NOT contain LoRA Adapter section');
+            assert.ok(!allSource.includes('ADAPTER_WEIGHTS_URI'), 'should NOT contain ADAPTER_WEIGHTS_URI');
+        });
+
+        it('excludes adapter section for async even when enableLora=true', () => {
+            const script = renderTemplate({
+                enableLora: true,
+                deploymentTarget: 'async-inference',
+                framework: 'transformers'
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script);
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(!allSource.includes('LoRA Adapter'), 'should NOT contain LoRA Adapter for async');
+        });
+    });
+
+    describe('tune section present when TUNE_SUPPORTED=true + realtime, absent otherwise', () => {
+        it('includes tune section when tuneSupported=true and realtime', () => {
+            const script = renderTemplate({
+                tuneSupported: true,
+                deploymentTarget: 'realtime-inference',
+                framework: 'transformers'
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script, {
+                MODEL_NAME: 'meta-llama/Llama-2-7b-hf',
+                TUNE_S3_BUCKET: 'my-tune-bucket'
+            });
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(allSource.includes('Managed Fine-Tuning'), 'should contain Fine-Tune section');
+            assert.ok(allSource.includes('ModelTrainer'), 'should contain ModelTrainer');
+            assert.ok(allSource.includes('TECHNIQUE'), 'should contain TECHNIQUE variable');
+        });
+
+        it('excludes tune section when tuneSupported=false', () => {
+            const script = renderTemplate({
+                tuneSupported: false,
+                deploymentTarget: 'realtime-inference',
+                framework: 'transformers'
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script);
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(!allSource.includes('Managed Fine-Tuning'), 'should NOT contain Fine-Tune section');
+            assert.ok(!allSource.includes('ModelTrainer'), 'should NOT contain ModelTrainer');
+        });
+
+        it('excludes tune section for batch even when tuneSupported=true', () => {
+            const script = renderTemplate({
+                tuneSupported: true,
+                deploymentTarget: 'batch-transform',
+                framework: 'transformers',
+                modelServer: 'vllm'
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script);
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(!allSource.includes('Managed Fine-Tuning'), 'should NOT contain Fine-Tune for batch');
+        });
+    });
+
+    describe('adapter section uses BaseInferenceComponentName (no ComputeResourceRequirements)', () => {
+        it('adapter IC creation uses BaseInferenceComponentName without ComputeResourceRequirements', () => {
+            const script = renderTemplate({
+                enableLora: true,
+                deploymentTarget: 'realtime-inference',
+                framework: 'transformers'
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script);
+            tmpDirs.push(tmpDir);
+
+            // Find the adapter IC creation cell
+            const codeCells = getCodeCellSources(notebook);
+            const adapterCell = codeCells.find(src =>
+                src.includes('BaseInferenceComponentName') && src.includes('adapter')
+            );
+            assert.ok(adapterCell, 'should have an adapter IC creation cell with BaseInferenceComponentName');
+            assert.ok(
+                !adapterCell.includes('ComputeResourceRequirements'),
+                'adapter IC cell must NOT contain ComputeResourceRequirements'
+            );
+            assert.ok(
+                adapterCell.includes('ArtifactUrl'),
+                'adapter IC cell must contain ArtifactUrl'
+            );
+        });
+    });
+
+    describe('tune section pre-fills ADAPTER_WEIGHTS_URI from TUNE_ADAPTER_PATH when available', () => {
+        it('pre-fills ADAPTER_WEIGHTS_URI from TUNE_ADAPTER_PATH_SFT', () => {
+            const script = renderTemplate({
+                enableLora: true,
+                tuneSupported: true,
+                deploymentTarget: 'realtime-inference',
+                framework: 'transformers'
+            });
+            const tuneOutputPath = 's3://my-bucket/output/sft-adapter/adapter.tar.gz';
+            const { notebook, tmpDir } = executeNotebookGenerator(script, {
+                TUNE_ADAPTER_PATH_SFT: tuneOutputPath,
+                MODEL_NAME: 'meta-llama/Llama-2-7b-hf',
+                TUNE_S3_BUCKET: 'my-tune-bucket'
+            });
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(
+                allSource.includes(tuneOutputPath),
+                'ADAPTER_WEIGHTS_URI should be pre-filled with TUNE_ADAPTER_PATH_SFT value'
+            );
+        });
+
+        it('pre-fills ADAPTER_WEIGHTS_URI from TUNE_ADAPTER_PATH_DPO when SFT not set', () => {
+            const script = renderTemplate({
+                enableLora: true,
+                tuneSupported: true,
+                deploymentTarget: 'realtime-inference',
+                framework: 'transformers'
+            });
+            const dpoPath = 's3://my-bucket/output/dpo-adapter/adapter.tar.gz';
+            const { notebook, tmpDir } = executeNotebookGenerator(script, {
+                TUNE_ADAPTER_PATH_DPO: dpoPath,
+                MODEL_NAME: 'meta-llama/Llama-2-7b-hf',
+                TUNE_S3_BUCKET: 'my-tune-bucket'
+            });
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(
+                allSource.includes(dpoPath),
+                'ADAPTER_WEIGHTS_URI should be pre-filled with TUNE_ADAPTER_PATH_DPO value'
+            );
+        });
+
+        it('uses placeholder when no TUNE_ADAPTER_PATH is set', () => {
+            const script = renderTemplate({
+                enableLora: true,
+                tuneSupported: true,
+                deploymentTarget: 'realtime-inference',
+                framework: 'transformers'
+            });
+            const { notebook, tmpDir } = executeNotebookGenerator(script, {
+                MODEL_NAME: 'meta-llama/Llama-2-7b-hf',
+                TUNE_S3_BUCKET: 'my-tune-bucket'
+            });
+            tmpDirs.push(tmpDir);
+
+            const allSource = getAllCellSource(notebook);
+            assert.ok(
+                allSource.includes('s3://your-bucket/adapters/my-adapter/adapter.tar.gz'),
+                'ADAPTER_WEIGHTS_URI should use placeholder when no tune path is set'
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes two deployment issues and cleans up test linting.

## Changes

### Boolean env var handling (`templates/code/serve`)
Environment variables with value `"false"` were being passed as `--flag false`
to model servers. Now `false` skips the arg entirely, and `true` emits a
flag-only arg (no value). This matches how vLLM/SGLang interpret boolean flags.

### RoutingConfig for IC endpoints (`templates/do/lib/endpoint-config.sh`)
IC-based endpoints require `RoutingConfig` in the production variant. Without it,
the IC scheduler cannot place containers and the IC stays in `Creating` with no
logs. Adds `LEAST_OUTSTANDING_REQUESTS` routing strategy.

### Test lint fixes (`test/property/notebook-export.property.test.js`)
Removes trailing commas and converts `function()` to arrow functions to satisfy
ESLint rules.

## Testing

- Existing unit tests pass
- Property tests pass with lint fixes applied
