### PR TITLE
fix: bash 3.2 compat — guard _PROFILE[] access against set -u in all do/ templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/ml-container-creator",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/ml-container-creator",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^8.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/ml-container-creator",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Build and deploy custom ML containers on AWS SageMaker with minimal configuration.",
   "main": "src/index.js",
   "bin": {

--- a/templates/do/adapter
+++ b/templates/do/adapter
@@ -21,7 +21,10 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 ADAPTER_S3_BUCKET="${ADAPTER_S3_BUCKET:-mlcc-adapters-${_PROFILE[accountId]:-unknown}-${_PROFILE[awsRegion]:-us-east-1}}"
+set -u
 
 source "${SCRIPT_DIR}/lib/wait.sh"
 

--- a/templates/do/build
+++ b/templates/do/build
@@ -12,8 +12,11 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 ECR_REPOSITORY_NAME="${ECR_REPOSITORY_NAME:-${_PROFILE[ecrRepositoryName]:-ml-container-creator}}"
 export AWS_REGION="${AWS_REGION:-${_PROFILE[awsRegion]:-us-east-1}}"
+set -u
 
 echo "🚀 Building Docker image for ${PROJECT_NAME}"
 echo "   Deployment config: ${DEPLOYMENT_CONFIG}"

--- a/templates/do/clean.d/async-inference.ejs
+++ b/templates/do/clean.d/async-inference.ejs
@@ -12,8 +12,11 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 ECR_REPOSITORY_NAME="${ECR_REPOSITORY_NAME:-${_PROFILE[ecrRepositoryName]:-ml-container-creator}}"
 export AWS_REGION="${AWS_REGION:-${_PROFILE[awsRegion]:-us-east-1}}"
+set -u
 
 # Parse arguments
 CLEANUP_TARGET=""

--- a/templates/do/clean.d/batch-transform.ejs
+++ b/templates/do/clean.d/batch-transform.ejs
@@ -12,8 +12,11 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 ECR_REPOSITORY_NAME="${ECR_REPOSITORY_NAME:-${_PROFILE[ecrRepositoryName]:-ml-container-creator}}"
 export AWS_REGION="${AWS_REGION:-${_PROFILE[awsRegion]:-us-east-1}}"
+set -u
 
 # Parse arguments
 CLEANUP_TARGET=""

--- a/templates/do/clean.d/hyperpod-eks.ejs
+++ b/templates/do/clean.d/hyperpod-eks.ejs
@@ -12,8 +12,11 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 ECR_REPOSITORY_NAME="${ECR_REPOSITORY_NAME:-${_PROFILE[ecrRepositoryName]:-ml-container-creator}}"
 export AWS_REGION="${AWS_REGION:-${_PROFILE[awsRegion]:-us-east-1}}"
+set -u
 
 # Parse arguments
 CLEANUP_TARGET=""

--- a/templates/do/clean.d/managed-inference.ejs
+++ b/templates/do/clean.d/managed-inference.ejs
@@ -12,8 +12,11 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 ECR_REPOSITORY_NAME="${ECR_REPOSITORY_NAME:-${_PROFILE[ecrRepositoryName]:-ml-container-creator}}"
 export AWS_REGION="${AWS_REGION:-${_PROFILE[awsRegion]:-us-east-1}}"
+set -u
 
 # Parse arguments
 CLEANUP_TARGET=""

--- a/templates/do/deploy.d/async-inference.ejs
+++ b/templates/do/deploy.d/async-inference.ejs
@@ -41,6 +41,8 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 ROLE_ARN="${ROLE_ARN:-${_PROFILE[roleArn]:-}}"
 ECR_REPOSITORY_NAME="${ECR_REPOSITORY_NAME:-${_PROFILE[ecrRepositoryName]:-ml-container-creator}}"
 export AWS_REGION="${AWS_REGION:-${_PROFILE[awsRegion]:-us-east-1}}"
@@ -50,6 +52,7 @@ _ASYNC_BUCKET="${_PROFILE[asyncS3Bucket]:-mlcc-async-${_PROFILE[accountId]:-unkn
 ASYNC_S3_OUTPUT_PATH="${ASYNC_S3_OUTPUT_PATH:-s3://${_ASYNC_BUCKET}/${PROJECT_NAME}/output/}"
 ASYNC_SNS_SUCCESS_TOPIC="${ASYNC_SNS_SUCCESS_TOPIC:-arn:aws:sns:${_PROFILE[awsRegion]:-us-east-1}:${_PROFILE[accountId]:-unknown}:ml-container-creator-${PROJECT_NAME}-async-success}"
 ASYNC_SNS_ERROR_TOPIC="${ASYNC_SNS_ERROR_TOPIC:-arn:aws:sns:${_PROFILE[awsRegion]:-us-east-1}:${_PROFILE[accountId]:-unknown}:ml-container-creator-${PROJECT_NAME}-async-error}"
+set -u
 
 echo "🚀 Deploying to AWS"
 echo "   Project: ${PROJECT_NAME}"

--- a/templates/do/deploy.d/batch-transform.ejs
+++ b/templates/do/deploy.d/batch-transform.ejs
@@ -41,6 +41,8 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 ROLE_ARN="${ROLE_ARN:-${_PROFILE[roleArn]:-}}"
 ECR_REPOSITORY_NAME="${ECR_REPOSITORY_NAME:-${_PROFILE[ecrRepositoryName]:-ml-container-creator}}"
 export AWS_REGION="${AWS_REGION:-${_PROFILE[awsRegion]:-us-east-1}}"
@@ -49,6 +51,7 @@ export AWS_REGION="${AWS_REGION:-${_PROFILE[awsRegion]:-us-east-1}}"
 _BATCH_BUCKET="${_PROFILE[batchS3Bucket]:-mlcc-batch-${_PROFILE[accountId]:-unknown}-${_PROFILE[awsRegion]:-us-east-1}}"
 BATCH_INPUT_PATH="${BATCH_INPUT_PATH:-s3://${_BATCH_BUCKET}/${PROJECT_NAME}/input/}"
 BATCH_OUTPUT_PATH="${BATCH_OUTPUT_PATH:-s3://${_BATCH_BUCKET}/${PROJECT_NAME}/output/}"
+set -u
 
 echo "🚀 Deploying to AWS"
 echo "   Project: ${PROJECT_NAME}"

--- a/templates/do/deploy.d/hyperpod-eks.ejs
+++ b/templates/do/deploy.d/hyperpod-eks.ejs
@@ -41,7 +41,10 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 export AWS_REGION="${AWS_REGION:-${_PROFILE[awsRegion]:-us-east-1}}"
+set -u
 
 echo "🚀 Deploying to AWS"
 echo "   Project: ${PROJECT_NAME}"

--- a/templates/do/deploy.d/managed-inference.ejs
+++ b/templates/do/deploy.d/managed-inference.ejs
@@ -214,9 +214,12 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 ROLE_ARN="${ROLE_ARN:-${_PROFILE[roleArn]:-}}"
 ECR_REPOSITORY_NAME="${ECR_REPOSITORY_NAME:-${_PROFILE[ecrRepositoryName]:-ml-container-creator}}"
 export AWS_REGION="${AWS_REGION:-${_PROFILE[awsRegion]:-us-east-1}}"
+set -u
 
 echo "🚀 Deploying to AWS"
 echo "   Project: ${PROJECT_NAME}"

--- a/templates/do/push
+++ b/templates/do/push
@@ -12,8 +12,11 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 ECR_REPOSITORY_NAME="${ECR_REPOSITORY_NAME:-${_PROFILE[ecrRepositoryName]:-ml-container-creator}}"
 export AWS_REGION="${AWS_REGION:-${_PROFILE[awsRegion]:-us-east-1}}"
+set -u
 
 echo "🚀 Pushing Docker image to Amazon ECR"
 echo "   Project: ${PROJECT_NAME}"

--- a/templates/do/register
+++ b/templates/do/register
@@ -12,8 +12,11 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 ROLE_ARN="${ROLE_ARN:-${_PROFILE[roleArn]:-}}"
 ECR_REPOSITORY_NAME="${ECR_REPOSITORY_NAME:-${_PROFILE[ecrRepositoryName]:-ml-container-creator}}"
+set -u
 
 # ============================================================
 # Register deployment to the deployment registry

--- a/templates/do/submit
+++ b/templates/do/submit
@@ -12,7 +12,10 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 ECR_REPOSITORY_NAME="${ECR_REPOSITORY_NAME:-${_PROFILE[ecrRepositoryName]:-ml-container-creator}}"
+set -u
 
 # ── Derived variables (env var > computed default) ────────────────────────────
 CODEBUILD_PROJECT_NAME="${CODEBUILD_PROJECT_NAME:-${PROJECT_NAME}-build-$(date +%Y%m%d)}"

--- a/templates/do/tune
+++ b/templates/do/tune
@@ -16,7 +16,10 @@ source "${SCRIPT_DIR}/config"
 source "${SCRIPT_DIR}/lib/profile.sh"
 
 # ── Profile-resolved variables (env var > profile > default) ──────────────────
+# Disable unbound-variable checking for associative array access (bash 3.2 compat)
+set +u
 TUNE_S3_BUCKET="${TUNE_S3_BUCKET:-mlcc-tune-${_PROFILE[accountId]:-unknown}-${_PROFILE[awsRegion]:-us-east-1}}"
+set -u
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 CATALOG_FILE="${SCRIPT_DIR}/.tune_catalog.json"


### PR DESCRIPTION
## Summary

All generated `do/` scripts crash with `ecrRepositoryName: unbound variable`
on macOS default bash (3.2) or when `~/.ml-container-creator/config.json`
is absent/incomplete. Fixed by wrapping `_PROFILE[]` access in explicit
`set +u` / `set -u` guards across 14 template files.

## What changed

- `templates/do/clean.d/{managed-inference,async-inference,batch-transform,hyperpod-eks}.ejs`
- `templates/do/deploy.d/{managed-inference,async-inference,batch-transform,hyperpod-eks}.ejs`
- `templates/do/{build,push,submit,register,tune,adapter}`

Each file's "Profile-resolved variables" block now disables `set -u`
before accessing `_PROFILE[key]` and re-enables it after.

## Root cause

`profile.sh` does `set +u` at the top, but on bash 3.2 (where
`declare -A` silently fails) or certain bash 5.x builds, the unset
check still fires when evaluating associative array subscripts in
arithmetic context. The `set +u` from profile.sh doesn't reliably
protect the caller.

## Testing

- `npm test` — 4220 passing, 0 new failures
- Manually verified on bash 3.2 (macOS /bin/bash) — no crash
